### PR TITLE
Add CI gate job as required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,3 +190,15 @@ jobs:
           rm -rf ~/.botster_hub
           # Run tests with single thread to avoid env var race conditions
           cargo test --all-targets -- --test-threads=1
+
+  ci:
+    if: always()
+    needs: [scan_ruby, scan_js, lint, test, system-test, cli-test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check CI results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "CI failed or was cancelled"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds a `ci` gate job that depends on all 6 CI jobs and fails if any failed or were cancelled
- Branch protection on `main` already configured to require the `ci` check

## Test plan
- [ ] Verify the `ci` job appears on this PR's checks
- [ ] Verify merging is blocked if any job fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)