### PR TITLE
Force fresh Lua extraction in test.sh

### DIFF
--- a/cli/test.sh
+++ b/cli/test.sh
@@ -100,8 +100,12 @@ if [ "$RUN_UNIT" = true ]; then
 fi
 
 if [ "$RUN_INTEGRATION" = true ]; then
+    # Touch Lua dir so cargo detects changes (git operations can preserve mtimes)
+    touch lua/
     echo "Building release binary (required by PTY integration tests)..."
     cargo build --release
+    # Clear cached Lua so the binary re-extracts fresh embedded files
+    rm -f ~/.botster/lua/.version
     echo ""
     echo "Running integration tests..."
     cargo test --test '*' $CARGO_ARGS


### PR DESCRIPTION
## Summary
- Touch `lua/` dir before `cargo build --release` so cargo detects Lua file changes (git operations can preserve mtimes, causing cargo to skip recompilation)
- Delete `~/.botster/lua/.version` before integration tests so the binary re-extracts fresh embedded Lua files

This is the final piece fixing the `test_start_without_tty_fails_gracefully` hang — the content hash fix (#92) prevents staleness across binary runs, but the cached Lua on disk still needs to be invalidated when running tests.

## Test plan
- [x] `./test.sh` passes all 808 tests including `test_start_without_tty_fails_gracefully`

🤖 Generated with [Claude Code](https://claude.com/claude-code)