### PR TITLE
fix(cli/web): reload model for layout overrides + quiet-idle polish

### DIFF
--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -12,6 +12,66 @@ import {
   createTransportDispatch,
 } from '../ui_contract'
 import { getHub } from '../lib/hub-bridge'
+import { useWorkspaceStore } from '../store/workspace-store'
+
+// ---------------------------------------------------------------------------
+// Tree decoration — applies browser-local ephemeral UI state (workspace
+// collapse/expand) on top of the hub-authored tree before it reaches the
+// primitive interpreter. The hub doesn't track per-client collapse state
+// (collapse is a purely visual concern owned by the browser per the
+// "browser owns ephemeral UI state" invariant), so when a user clicks a
+// workspace header:
+//
+//   1. The action dispatcher (LOCAL_ONLY) routes `botster.workspace.toggle`
+//      to `lib/actions.js`, which flips the id in
+//      `useWorkspaceStore.collapsedWorkspaceIds`.
+//   2. This subscription re-renders with the new Set.
+//   3. `applyCollapseOverrides` walks the hub tree and overrides
+//      `expanded: false` on matching tree_items.
+//   4. The interpreter renders; `renderTreeItem` honours `expanded === false`
+//      by hiding the children slot.
+//
+// Pure function keyed only on `(tree, collapsedIds)` — safe to memoise.
+// ---------------------------------------------------------------------------
+
+function applyCollapseOverrides(node, collapsedIds) {
+  if (!node || typeof node !== 'object') return node
+  // `$kind` discriminator marks a conditional wrapper
+  // (`ui.when` / `ui.hidden`). Recurse into its inner node so any
+  // descendant tree_items still get their expansion state overridden.
+  if (node.$kind === 'when' || node.$kind === 'hidden') {
+    return { ...node, node: applyCollapseOverrides(node.node, collapsedIds) }
+  }
+
+  const decorated = { ...node }
+
+  if (
+    node.type === 'tree_item' &&
+    typeof node.id === 'string' &&
+    collapsedIds.has(node.id)
+  ) {
+    decorated.props = { ...(node.props ?? {}), expanded: false }
+  }
+
+  if (Array.isArray(node.children)) {
+    decorated.children = node.children.map((c) =>
+      applyCollapseOverrides(c, collapsedIds),
+    )
+  }
+
+  if (node.slots && typeof node.slots === 'object') {
+    decorated.slots = Object.fromEntries(
+      Object.entries(node.slots).map(([name, children]) => [
+        name,
+        Array.isArray(children)
+          ? children.map((c) => applyCollapseOverrides(c, collapsedIds))
+          : children,
+      ]),
+    )
+  }
+
+  return decorated
+}
 
 // ---------------------------------------------------------------------------
 // Interceptor context
@@ -147,6 +207,25 @@ export default function UiTree({
   const [tree, setTree] = useState(initialTree)
   const [transport, setTransport] = useState(null)
 
+  // Browser-local collapse state. Re-renders this component when a user
+  // toggles a workspace; `applyCollapseOverrides` then injects
+  // `expanded: false` into matching tree_items before the interpreter
+  // walks the tree. See `applyCollapseOverrides` at top of file.
+  const collapsedIds = useWorkspaceStore((s) => s.collapsedWorkspaceIds)
+  const decoratedTree = useMemo(() => {
+    if (!tree) return tree
+    // Malformed trees (e.g. getter throws) must still reach the error
+    // boundary in `UiTreeErrorBoundary` so the user sees a graceful
+    // fallback. If decoration blows up, pass the original tree through
+    // — the interpreter will then throw from its own render, which React
+    // routes to the boundary.
+    try {
+      return applyCollapseOverrides(tree, collapsedIds)
+    } catch {
+      return tree
+    }
+  }, [tree, collapsedIds])
+
   // Reset tree + transport synchronously on hubId change. Without this, a
   // hub switch (A → B) keeps the old tree visible until B's first broadcast
   // arrives and routes the user's clicks through A's transport in the
@@ -263,10 +342,10 @@ export default function UiTree({
 
   return (
     <InterceptorContext.Provider value={interceptorValue}>
-      <UiTreeErrorBoundary tree={tree} fallback={errorFallback}>
-        {tree ? (
+      <UiTreeErrorBoundary tree={decoratedTree} fallback={errorFallback}>
+        {decoratedTree ? (
           <UiTreeBody
-            node={tree}
+            node={decoratedTree}
             dispatch={dispatch}
             capabilities={capabilities}
             hubId={hubId}

--- a/app/frontend/ui_contract/registry.tsx
+++ b/app/frontend/ui_contract/registry.tsx
@@ -310,6 +310,11 @@ const renderIcon: PrimitiveRenderer = ({ props }) => {
   const glyph = (
     <IconGlyph name={name} className={clsx('h-full w-full')} />
   )
+  // Rotate chevron-down when its closest collapsible ancestor reports
+  // `aria-expanded="false"` — mirrors the Phase 1 workspace-header chevron
+  // behaviour without leaking a collapse prop into the icon primitive.
+  // Uses Tailwind 4 arbitrary variant that targets ancestor state.
+  const isCollapsibleChevron = name === 'chevron-down'
   return (
     <span
       role="img"
@@ -319,6 +324,8 @@ const renderIcon: PrimitiveRenderer = ({ props }) => {
         'inline-flex shrink-0 items-center justify-center',
         ICON_SIZE[size],
         TEXT_TONE[tone],
+        isCollapsibleChevron &&
+          'transition-transform duration-150 [[aria-expanded=false]_&]:-rotate-90',
       )}
     >
       {glyph}

--- a/cli/lua/handlers/commands.lua
+++ b/cli/lua/handlers/commands.lua
@@ -658,6 +658,43 @@ commands.register("reload_plugin", function(client, sub_id, command)
     end
 end, { description = "Reload a plugin by name" })
 
+-- Explicit invalidation of the web layout cache + proactive rebroadcast to
+-- every subscribed browser. Matches the `reload_plugin` pattern: the hub
+-- does NOT watch layout files, so users call this after editing
+-- `.botster/layout_web.lua` (or a shared override) to push their changes.
+commands.register("reload_layout", function(client, sub_id, _command)
+    local ok_reload, err = pcall(function()
+        web_layout.reload()
+    end)
+    if not ok_reload then
+        if client then
+            client:send({
+                subscriptionId = sub_id,
+                type = "layout_reloaded",
+                success = false,
+                error = tostring(err),
+            })
+        end
+        return
+    end
+
+    -- Trigger proactive rebroadcast so subscribers render the new layout
+    -- without waiting for the next state-change tick.
+    local connections = require("handlers.connections")
+    local broadcast_ok, broadcast_err = pcall(connections.broadcast_ui_layout_trees)
+    if not broadcast_ok then
+        log.warn(string.format("reload_layout: broadcast failed: %s", tostring(broadcast_err)))
+    end
+
+    if client then
+        client:send({
+            subscriptionId = sub_id,
+            type = "layout_reloaded",
+            success = true,
+        })
+    end
+end, { description = "Reload the web UI layout overrides and rebroadcast to subscribers" })
+
 commands.register("enable_plugin", function(client, sub_id, command)
     local name = command.name or command.plugin_name
     if not name then

--- a/cli/lua/handlers/connections.lua
+++ b/cli/lua/handlers/connections.lua
@@ -608,6 +608,7 @@ local M = {
     broadcast_hub_event = broadcast_hub_event,
     broadcast_workspace_list = broadcast_workspace_list,
     broadcast_spawn_target_list = broadcast_spawn_target_list,
+    broadcast_ui_layout_trees = broadcast_ui_layout_trees,
 }
 
 -- Lifecycle hooks for hot-reload

--- a/cli/lua/hub/mcp_defaults.lua
+++ b/cli/lua/hub/mcp_defaults.lua
@@ -939,6 +939,24 @@ mcp.tool("reload_plugin", {
     end
 end)
 
+mcp.tool("reload_layout", {
+    description = "Reload the web UI layout override chain (.botster/layout_web.lua, .botster/layout.lua, etc.) after editing. The hub does not watch layout files — call this when you want changes picked up. Proactively rebroadcasts to every subscribed browser so they re-render immediately.",
+    input_schema = { type = "object", properties = {} },
+}, function(_params, _ctx)
+    local ok, err = pcall(function()
+        web_layout.reload()
+    end)
+    if not ok then
+        error(string.format("Failed to reload layout: %s", tostring(err)))
+    end
+    local connections = require("handlers.connections")
+    local ok_broadcast, broadcast_err = pcall(connections.broadcast_ui_layout_trees)
+    if not ok_broadcast then
+        return string.format("Layout reloaded, but broadcast failed: %s", tostring(broadcast_err))
+    end
+    return "Layout reloaded and rebroadcast to all subscribers."
+end)
+
 mcp.tool("enable_plugin", {
     description = "Enable a disabled plugin. Loads it immediately.",
     input_schema = {

--- a/cli/lua/ui/layout.lua
+++ b/cli/lua/ui/layout.lua
@@ -125,10 +125,10 @@ local function session_activity_icon(agent)
     return nil
   end
 
-  -- Idle/active indicator
-  if agent.is_idle then
-    spans[#spans + 1] = { text = "◌ ", style = { fg = "blue", modifier = "dim" } }
-  else
+  -- Only mark genuinely active (non-idle) agents. Idle sessions render
+  -- without a glyph to keep the list visually quiet; only a working agent
+  -- draws the eye. Mirrors the default web layout in cli/lua/web/layout.lua.
+  if not agent.is_idle then
     spans[#spans + 1] = { text = "✺ ", style = { fg = "green" } }
   end
 

--- a/cli/lua/web/layout.lua
+++ b/cli/lua/web/layout.lua
@@ -24,14 +24,13 @@ local M = {}
 -- Small helpers
 -- -------------------------------------------------------------------------
 
--- status_dot parity with composites.ts:activityDotForState.
+-- Only render a dot for genuinely active sessions. Idle / accessory /
+-- hidden all suppress it so row lists stay quiet by default and only a
+-- working agent draws the eye.
 local function activity_dot(state)
-  if state == "idle" then
-    return { ui.status_dot{ state = "idle", label = "Idle" } }
-  elseif state == "active" then
+  if state == "active" then
     return { ui.status_dot{ state = "active", label = "Active" } }
   end
-  -- "accessory" and "hidden" suppress the dot
   return nil
 end
 

--- a/cli/src/lua/primitives/web_layout.rs
+++ b/cli/src/lua/primitives/web_layout.rs
@@ -202,14 +202,110 @@ struct CachedOverride {
 ///   reused verbatim (zero stats, cached content re-loaded into `lua`);
 /// - otherwise, each candidate is stat-ed to check for mtime drift. A cached
 ///   winning override whose mtime is unchanged short-circuits the read.
+///
+/// `package.loaded[EMBEDDED_LAYOUT_MODULE]` is cleared at the top so both
+/// the override path and the embedded-fallback path evaluate against a
+/// fresh copy of the embedded module. Without this, a previous override
+/// that monkey-patched `base.workspace_surface` (a common-looking
+/// wrap-the-embedded pattern) would pollute the VM singleton forever and
+/// stack wrapper layers on every re-evaluation.
 fn resolve_layout_table(lua: &Lua) -> Result<Table> {
+    reset_embedded_module(lua)?;
+
     if let Some(cached) = cache_hit() {
         match cached.winning {
-            Some(entry) => return load_override_from_str(lua, &entry.path, &entry.content),
+            Some(entry) => return load_override_cached(lua, &entry.path, &entry.content),
             None => return load_embedded(lua),
         }
     }
     scan_and_load(lua)
+}
+
+/// Clear `package.loaded[EMBEDDED_LAYOUT_MODULE]` so the next
+/// `require("web.layout")` call — whether from inside an override or from
+/// `load_embedded` — re-evaluates the embedded source and returns a fresh
+/// table. This is the defense against overrides that mutate the cached
+/// embedded module.
+fn reset_embedded_module(lua: &Lua) -> Result<()> {
+    let package: Table = lua
+        .globals()
+        .get("package")
+        .map_err(|e| anyhow!("cannot find `package` global: {e}"))?;
+    let loaded: Table = package
+        .get("loaded")
+        .map_err(|e| anyhow!("`package.loaded` missing: {e}"))?;
+    loaded
+        .set(EMBEDDED_LAYOUT_MODULE, Value::Nil)
+        .map_err(|e| anyhow!("failed to clear package.loaded[`{EMBEDDED_LAYOUT_MODULE}`]: {e}"))?;
+    Ok(())
+}
+
+/// Cache key for the Lua-side compiled-override Table. Hashed by content so
+/// re-evaluation happens at most once per content change, not once per
+/// render.
+const LUA_OVERRIDE_RESULT_KEY: &str = "__botster_web_layout_override_module";
+const LUA_OVERRIDE_HASH_KEY: &str = "__botster_web_layout_override_hash";
+
+/// Hash of the override source content, formatted as a hex string to dodge
+/// any number-representation subtleties on the Lua side. Non-cryptographic;
+/// just a collision-resistant identity for cache lookup.
+fn content_hash(content: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Attempt to load a compiled-override table from a Lua-side cache keyed by
+/// content hash. Returns `Ok(None)` if no cached entry exists for this
+/// content; evaluation proceeds normally in that case.
+fn load_override_from_cache(lua: &Lua, content: &str) -> Result<Option<Table>> {
+    let globals = lua.globals();
+    let stored_hash: Option<String> = globals
+        .get::<Option<String>>(LUA_OVERRIDE_HASH_KEY)
+        .map_err(|e| anyhow!("failed to read override-hash cache: {e}"))?;
+    if stored_hash.as_deref() != Some(content_hash(content).as_str()) {
+        return Ok(None);
+    }
+    let table: Option<Table> = globals
+        .get::<Option<Table>>(LUA_OVERRIDE_RESULT_KEY)
+        .map_err(|e| anyhow!("failed to read override-result cache: {e}"))?;
+    Ok(table)
+}
+
+/// Store a newly compiled override table in the Lua-side cache keyed by its
+/// content hash. Subsequent calls with the same content reuse this exact
+/// table instead of re-evaluating the chunk.
+fn store_override_cache(lua: &Lua, table: &Table, content: &str) -> Result<()> {
+    let globals = lua.globals();
+    globals
+        .set(LUA_OVERRIDE_HASH_KEY, content_hash(content))
+        .map_err(|e| anyhow!("failed to write override-hash cache: {e}"))?;
+    globals
+        .set(LUA_OVERRIDE_RESULT_KEY, table.clone())
+        .map_err(|e| anyhow!("failed to write override-result cache: {e}"))?;
+    Ok(())
+}
+
+/// Clear the Lua-side override-module cache. Tests use this between runs so
+/// an earlier override's compiled table doesn't leak into a fresh test.
+#[cfg(test)]
+pub fn _clear_lua_override_cache_for_tests(lua: &Lua) {
+    let globals = lua.globals();
+    let _ = globals.set(LUA_OVERRIDE_HASH_KEY, Value::Nil);
+    let _ = globals.set(LUA_OVERRIDE_RESULT_KEY, Value::Nil);
+}
+
+/// Resolve an override to a compiled Lua Table. If a previous evaluation's
+/// result is still cached for this exact content, reuse it; otherwise
+/// evaluate the chunk and cache the result.
+fn load_override_cached(lua: &Lua, path: &Path, content: &str) -> Result<Table> {
+    if let Some(cached) = load_override_from_cache(lua, content)? {
+        return Ok(cached);
+    }
+    let table = load_override_from_str(lua, path, content)?;
+    store_override_cache(lua, &table, content)?;
+    Ok(table)
 }
 
 /// Return the cached entry if it is still within its TTL window. Expiry is
@@ -255,7 +351,7 @@ fn scan_and_load(lua: &Lua) -> Result<Table> {
                         }
                     }
                 };
-                let table = load_override_from_str(lua, &entry.path, &entry.content)?;
+                let table = load_override_cached(lua, &entry.path, &entry.content)?;
                 store_cache(Some(entry));
                 return Ok(table);
             }

--- a/cli/src/lua/primitives/web_layout.rs
+++ b/cli/src/lua/primitives/web_layout.rs
@@ -36,9 +36,7 @@
 // Rust guideline compliant 2026-04-18
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
-use std::time::{Duration, Instant, SystemTime};
 
 use anyhow::{anyhow, Result};
 use mlua::{Function, Lua, LuaSerdeExt, Table, Value};
@@ -69,18 +67,8 @@ const LAYOUT_WEB_FILE: &str = "layout_web.lua";
 /// for web; Phase 2b or later may let the TUI consume the same file.
 const LAYOUT_SHARED_FILE: &str = "layout.lua";
 
-/// Default TTL (milliseconds) for the successful override-chain scan cache.
-///
-/// Phase 2a flagged that `web_layout.render` stats four candidates on every
-/// call. Phase 2b broadcasts trigger that path on every state change, so a
-/// per-render TTL collapses bursts of renders into at most one stat set per
-/// window. 500 ms balances staleness on edits vs. re-stat chatter.
-///
-/// Override at runtime via [`set_override_cache_ttl_millis`]; tests use a 0
-/// TTL so sequential file writes are observed immediately.
-const DEFAULT_OVERRIDE_CACHE_TTL_MILLIS: u64 = 500;
-
-/// Install `web_layout` as a global Lua table with one method: `render`.
+/// Install `web_layout` as a global Lua table with two methods: `render` and
+/// `reload`.
 ///
 /// ```lua
 /// local json = web_layout.render("workspace_surface", {
@@ -124,11 +112,54 @@ pub fn register(lua: &Lua) -> Result<()> {
         .set("render", render_fn)
         .map_err(|e| anyhow!("Failed to set web_layout.render: {e}"))?;
 
+    // `web_layout.reload()` — explicit invalidation of all caches. Matches
+    // the `reload_plugin` pattern: callers explicitly opt in so editor fs
+    // chatter doesn't trigger spurious reloads mid-edit. The hub does not
+    // watch files.
+    let reload_fn = lua
+        .create_function(|lua, (): ()| {
+            reload(lua).map_err(|e| mlua::Error::external(format!("{e:#}")))?;
+            Ok(())
+        })
+        .map_err(|e| anyhow!("Failed to create web_layout.reload: {e}"))?;
+
+    table
+        .set("reload", reload_fn)
+        .map_err(|e| anyhow!("Failed to set web_layout.reload: {e}"))?;
+
     lua.globals()
         .set("web_layout", table)
         .map_err(|e| anyhow!("Failed to register web_layout global: {e}"))?;
 
     log::debug!("Registered web_layout primitive");
+    Ok(())
+}
+
+/// Invalidate every layer of caching so the next `render()` re-reads the
+/// override file from disk, re-evaluates it, and refreshes the embedded
+/// module. Safe to call from Lua (`web_layout.reload()`) and from Rust.
+///
+/// Does NOT itself broadcast — callers (e.g. the `reload_layout` command
+/// handler) are responsible for triggering `broadcast_ui_layout_trees` after
+/// invalidation so subscribers re-render.
+pub fn reload(lua: &Lua) -> Result<()> {
+    // Rust-side override cache (path/mtime/content)
+    if let Ok(mut guard) = OVERRIDE_CACHE.lock() {
+        *guard = None;
+    }
+    // Lua-side compiled override table (content-hash cache)
+    let globals = lua.globals();
+    globals
+        .set(LUA_OVERRIDE_HASH_KEY, Value::Nil)
+        .map_err(|e| anyhow!("reload: clear override-hash cache: {e}"))?;
+    globals
+        .set(LUA_OVERRIDE_RESULT_KEY, Value::Nil)
+        .map_err(|e| anyhow!("reload: clear override-result cache: {e}"))?;
+    // Embedded `require("web.layout")` cache — dropped so a fresh require()
+    // re-runs the shipped Lua source. Defense against overrides that may have
+    // mutated the singleton during their lifetime.
+    reset_embedded_module(lua)?;
+    log::info!("web_layout.reload: all caches invalidated");
     Ok(())
 }
 
@@ -155,63 +186,45 @@ fn render_surface(lua: &Lua, surface_name: &str, state: Value) -> Result<String>
 
 /// Process-wide cache of the last successful override-chain scan.
 ///
-/// Phase 2a's render path stats four candidate files unconditionally; Phase
-/// 2b broadcasts trigger that path on every state change, which can fire many
-/// times per second. The cache bounds the common case to at most one scan per
-/// TTL window while still picking up edits promptly.
+/// Held for the lifetime of the hub process. Only explicit `reload()` calls
+/// invalidate it — there is no TTL and no filesystem watcher. This matches
+/// the `reload_plugin` pattern for plugins: editor fs chatter mid-edit
+/// shouldn't trigger spurious hub activity; users explicitly opt in to
+/// re-reading when they finish editing.
 static OVERRIDE_CACHE: Mutex<Option<OverrideCache>> = Mutex::new(None);
-
-/// Current TTL for the cache, in milliseconds. Adjustable at runtime via
-/// [`set_override_cache_ttl_millis`] for tests that need to observe
-/// sequential file writes without waiting 500 ms between them.
-static OVERRIDE_CACHE_TTL_MILLIS: AtomicU64 = AtomicU64::new(DEFAULT_OVERRIDE_CACHE_TTL_MILLIS);
-
-fn override_cache_ttl() -> Duration {
-    Duration::from_millis(OVERRIDE_CACHE_TTL_MILLIS.load(Ordering::Relaxed))
-}
 
 /// Snapshot of the override-chain resolution, guarded by `OVERRIDE_CACHE`.
 ///
-/// `valid_until` is the wall-clock deadline after which the cache MUST be
-/// refreshed; `winning` records which candidate (if any) won and the mtime it
-/// had at scan time. A matching mtime on refresh lets us skip the disk read
-/// and reuse the cached `content`. A mismatch (or a newly-present higher-
-/// priority override) invalidates the entry.
+/// `winning` records which candidate (if any) won the scan. `None` means the
+/// embedded default took over. The cache is only cleared by [`reload`]; once
+/// populated, `resolve_layout_table` never re-stats the four candidate paths.
 #[derive(Clone)]
 struct OverrideCache {
-    valid_until: Instant,
     winning: Option<CachedOverride>,
 }
 
-/// Cached payload for one override file: source text plus the mtime observed
-/// when the text was read. Stored as `String` (not `Table`) because Lua tables
-/// can't outlive their parent `Lua`; re-evaluating a cached string on the
-/// caller's Lua VM is cheap compared to a fresh disk read.
+/// Cached payload for one override file: source text observed at scan time.
+/// Stored as `String` (not `Table`) because Lua tables can't outlive their
+/// parent `Lua`; the Lua-side content-hash cache in
+/// [`load_override_from_cache`] handles Table reuse across renders.
 #[derive(Clone)]
 struct CachedOverride {
     path: PathBuf,
-    mtime: SystemTime,
     content: String,
 }
 
 /// Walk the resolution chain and return the first layout table that loads
 /// successfully. Falls back to the embedded default via `require`.
 ///
-/// Hot path:
-/// - within `OVERRIDE_CACHE_TTL` of the last successful scan, the cache is
-///   reused verbatim (zero stats, cached content re-loaded into `lua`);
-/// - otherwise, each candidate is stat-ed to check for mtime drift. A cached
-///   winning override whose mtime is unchanged short-circuits the read.
+/// Hot path after the first call is entirely zero-I/O:
+/// - `OVERRIDE_CACHE` holds the winning override's path + content (or
+///   `None` meaning embedded wins);
+/// - `load_override_cached` looks up the compiled Table from the Lua-side
+///   content-hash cache and returns it directly.
 ///
-/// `package.loaded[EMBEDDED_LAYOUT_MODULE]` is cleared at the top so both
-/// the override path and the embedded-fallback path evaluate against a
-/// fresh copy of the embedded module. Without this, a previous override
-/// that monkey-patched `base.workspace_surface` (a common-looking
-/// wrap-the-embedded pattern) would pollute the VM singleton forever and
-/// stack wrapper layers on every re-evaluation.
+/// The only way to re-stat the filesystem or re-evaluate a chunk is to call
+/// [`reload`]. See the module docstring for rationale.
 fn resolve_layout_table(lua: &Lua) -> Result<Table> {
-    reset_embedded_module(lua)?;
-
     if let Some(cached) = cache_hit() {
         match cached.winning {
             Some(entry) => return load_override_cached(lua, &entry.path, &entry.content),
@@ -224,8 +237,8 @@ fn resolve_layout_table(lua: &Lua) -> Result<Table> {
 /// Clear `package.loaded[EMBEDDED_LAYOUT_MODULE]` so the next
 /// `require("web.layout")` call — whether from inside an override or from
 /// `load_embedded` — re-evaluates the embedded source and returns a fresh
-/// table. This is the defense against overrides that mutate the cached
-/// embedded module.
+/// table. Called only from [`reload`]; the Lua-side content-hash cache
+/// means per-render resets are unnecessary in the steady state.
 fn reset_embedded_module(lua: &Lua) -> Result<()> {
     let package: Table = lua
         .globals()
@@ -308,114 +321,55 @@ fn load_override_cached(lua: &Lua, path: &Path, content: &str) -> Result<Table> 
     Ok(table)
 }
 
-/// Return the cached entry if it is still within its TTL window. Expiry is
-/// resolved eagerly: the returned value is an owned snapshot so the lock is
-/// released before we touch Lua.
+/// Return the cached entry if one exists. The cache is held for the
+/// lifetime of the hub and only cleared by [`reload`].
 fn cache_hit() -> Option<OverrideCache> {
     let guard = OVERRIDE_CACHE.lock().ok()?;
-    let cached = guard.as_ref()?;
-    if Instant::now() >= cached.valid_until {
-        return None;
-    }
-    Some(cached.clone())
+    guard.as_ref().cloned()
 }
 
-/// Perform a full override-chain scan, update the cache, and load the winning
-/// candidate (or the embedded default) into `lua`.
+/// Perform a full override-chain scan (one-time, on a cold cache) and load
+/// the winning candidate (or the embedded default) into `lua`. After this
+/// runs once, subsequent renders skip disk I/O entirely until `reload()` is
+/// called.
 fn scan_and_load(lua: &Lua) -> Result<Table> {
     let candidates = override_candidates();
-
-    // Seed the fresh scan with whatever we have cached for each candidate
-    // path. If a candidate's mtime still matches the cache we skip re-reading
-    // its content; otherwise we pull fresh bytes off disk.
-    let prior_by_path = prior_cache_by_path();
-
     for candidate in candidates {
-        match candidate_mtime(&candidate) {
-            None => continue, // not a file — skip.
-            Some(mtime) => {
-                let entry = match prior_by_path.get(&candidate) {
-                    Some(prev) if prev.mtime == mtime => CachedOverride {
-                        path: candidate.clone(),
-                        mtime,
-                        content: prev.content.clone(),
-                    },
-                    _ => {
-                        let content = std::fs::read_to_string(&candidate).map_err(|e| {
-                            anyhow!("failed to read {}: {e}", candidate.display())
-                        })?;
-                        CachedOverride {
-                            path: candidate.clone(),
-                            mtime,
-                            content,
-                        }
-                    }
-                };
-                let table = load_override_cached(lua, &entry.path, &entry.content)?;
-                store_cache(Some(entry));
-                return Ok(table);
-            }
+        if !candidate.is_file() {
+            continue;
         }
+        let content = std::fs::read_to_string(&candidate)
+            .map_err(|e| anyhow!("failed to read {}: {e}", candidate.display()))?;
+        let entry = CachedOverride {
+            path: candidate,
+            content,
+        };
+        let table = load_override_cached(lua, &entry.path, &entry.content)?;
+        store_cache(Some(entry));
+        return Ok(table);
     }
 
-    // No override won — cache the negative result so subsequent renders in
-    // this TTL window skip stat-ing the same four paths.
+    // No override won — record the negative result so we don't re-scan on
+    // every render. Cleared by `reload()` if the user adds an override file
+    // later.
     store_cache(None);
     load_embedded(lua)
 }
 
-/// Build a fast lookup of the prior cache keyed by path. Used so a partial
-/// rescan (e.g. a newly-added higher-priority override) can still reuse
-/// already-read bytes for unchanged lower-priority files.
-fn prior_cache_by_path() -> std::collections::HashMap<PathBuf, CachedOverride> {
-    let guard = match OVERRIDE_CACHE.lock() {
-        Ok(g) => g,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let mut out = std::collections::HashMap::new();
-    if let Some(cache) = guard.as_ref() {
-        if let Some(entry) = &cache.winning {
-            out.insert(entry.path.clone(), entry.clone());
-        }
-    }
-    out
-}
-
-/// Persist the resolution snapshot and set the next TTL deadline.
+/// Persist the resolution snapshot. No expiry; `reload()` is the only path
+/// that clears it.
 fn store_cache(winning: Option<CachedOverride>) {
-    let new_cache = OverrideCache {
-        valid_until: Instant::now() + override_cache_ttl(),
-        winning,
-    };
+    let new_cache = OverrideCache { winning };
     match OVERRIDE_CACHE.lock() {
         Ok(mut guard) => *guard = Some(new_cache),
         Err(poisoned) => *poisoned.into_inner() = Some(new_cache),
     }
 }
 
-/// Adjust the override-chain cache TTL. Tests that exercise sequential file
-/// edits set this to 0 so each render re-scans the filesystem; production
-/// code never needs to call it. Returns the previous value so test harnesses
-/// can restore it after use.
-#[doc(hidden)]
-pub fn set_override_cache_ttl_millis(ttl_millis: u64) -> u64 {
-    OVERRIDE_CACHE_TTL_MILLIS.swap(ttl_millis, Ordering::Relaxed)
-}
-
-/// Stat helper — returns `Some(mtime)` iff `path` is a regular file. Any I/O
-/// error (including "not found") yields `None` so the caller can skip.
-fn candidate_mtime(path: &Path) -> Option<SystemTime> {
-    let meta = std::fs::metadata(path).ok()?;
-    if !meta.is_file() {
-        return None;
-    }
-    meta.modified().ok()
-}
-
-/// Invalidate the process-wide override cache. Tests use this between runs;
-/// production never needs it because each render's TTL window expires on its
-/// own. Exposed `pub` only because `tests/` and integration test binaries
-/// live outside the crate root.
+/// Invalidate the process-wide override cache. Tests use this between runs
+/// to simulate a `reload()` from the Rust side without needing a live Lua
+/// VM. Production callers use [`reload`] which also clears the Lua-side
+/// caches.
 #[doc(hidden)]
 pub fn _clear_override_cache_for_tests() {
     match OVERRIDE_CACHE.lock() {

--- a/cli/src/tui/layout_lua.rs
+++ b/cli/src/tui/layout_lua.rs
@@ -2144,7 +2144,7 @@ mod tests {
     }
 
     #[test]
-    fn test_layout_renders_idle_icon_for_idle_agent() {
+    fn test_layout_suppresses_activity_icon_for_idle_agent() {
         let lua = make_full_lua_with_events();
 
         lua.exec(
@@ -2168,9 +2168,12 @@ mod tests {
         let items = extract_sidebar_items(&tree);
 
         assert_eq!(items.len(), 1, "Should have exactly 1 agent item");
+        // Quiet-idle contract: idle agents render no activity glyph; the row
+        // starts directly with the display name. Active rows still start with
+        // "✺ " (see test_layout_renders_active_icon_for_running_agent).
         assert!(
-            items[0].starts_with("◌ "),
-            "Idle agent row should render idle glyph, got: {}",
+            !items[0].starts_with("◌ ") && !items[0].starts_with("✺ "),
+            "Idle agent row must not render any activity glyph, got: {}",
             items[0]
         );
     }

--- a/cli/tests/fixtures/ui_contract_web_layout/mixed_activity.golden.json
+++ b/cli/tests/fixtures/ui_contract_web_layout/mixed_activity.golden.json
@@ -129,15 +129,6 @@
                       "type": "inline"
                     }
                   ],
-                  "start": [
-                    {
-                      "props": {
-                        "label": "Idle",
-                        "state": "idle"
-                      },
-                      "type": "status_dot"
-                    }
-                  ],
                   "subtitle": [
                     {
                       "props": {

--- a/cli/tests/fixtures/ui_contract_web_layout/preview_error.golden.json
+++ b/cli/tests/fixtures/ui_contract_web_layout/preview_error.golden.json
@@ -62,15 +62,6 @@
                       "type": "inline"
                     }
                   ],
-                  "start": [
-                    {
-                      "props": {
-                        "label": "Idle",
-                        "state": "idle"
-                      },
-                      "type": "status_dot"
-                    }
-                  ],
                   "subtitle": [
                     {
                       "props": {

--- a/cli/tests/fixtures/ui_contract_web_layout/ungrouped_with_empty_workspace.golden.json
+++ b/cli/tests/fixtures/ui_contract_web_layout/ungrouped_with_empty_workspace.golden.json
@@ -54,15 +54,6 @@
                       "type": "inline"
                     }
                   ],
-                  "start": [
-                    {
-                      "props": {
-                        "label": "Idle",
-                        "state": "idle"
-                      },
-                      "type": "status_dot"
-                    }
-                  ],
                   "subtitle": [
                     {
                       "props": {

--- a/cli/tests/ui_contract_web_layout_test.rs
+++ b/cli/tests/ui_contract_web_layout_test.rs
@@ -437,17 +437,18 @@ fn every_session_row_includes_menu_open_placeholder() {
 }
 
 #[test]
-fn accessory_session_suppresses_activity_dot() {
+fn only_active_sessions_render_activity_dot() {
     let _lock = lock_render_env();
     let lua = new_web_layout_lua();
     let tree = render_via_lua(&lua, FIXTURE_MIXED_ACTIVITY);
     let json = tree.to_string();
-    // The accessory session (session_type="accessory") must NOT contribute a
-    // status_dot; active/idle sessions must. Count is 2, not 3.
+    // Only active sessions contribute a status_dot. Accessory and idle
+    // sessions are quiet — no dot at all. Mixed-activity fixture has one
+    // active session, so exactly one dot.
     let dots = json.matches("\"type\":\"status_dot\"").count();
     assert_eq!(
-        dots, 2,
-        "accessory must skip status_dot — expected 2 dots (active+idle), got {dots}: {json}"
+        dots, 1,
+        "only active sessions render status_dot — expected 1 dot (active only), got {dots}: {json}"
     );
 }
 

--- a/cli/tests/ui_contract_web_layout_test.rs
+++ b/cli/tests/ui_contract_web_layout_test.rs
@@ -1041,3 +1041,189 @@ fn modtime_cache_reuses_unchanged_content_without_rereading() {
     );
     let _ = touch_future; // silence warn in the common case where 2-stage touch is unused
 }
+
+// -----------------------------------------------------------------------------
+// Regression tests for the override-evaluation lifecycle.
+//
+// Phase 2a's loader re-evaluated the override chunk on every render (even on
+// cache HIT — the string content was re-loaded into Lua each call) AND
+// `require("web.layout")` inside the override returned the VM singleton from
+// `package.loaded`. Overrides that monkey-patched `base.workspace_surface`
+// therefore stacked wrapper layers on every re-evaluation, producing N
+// banners after N renders.
+//
+// These tests lock in the post-fix behavior:
+// 1. Override that mutates `base.workspace_surface` does NOT accumulate
+//    wrappers across renders — exactly one banner shows regardless of how
+//    many times render is called.
+// 2. Override is evaluated at most once per content hash — a counter
+//    incremented at eval time advances exactly once even over N renders.
+// 3. Deleting the override restores the embedded default to an unpolluted
+//    state (no residual wrappers leaking from the prior override's session).
+// -----------------------------------------------------------------------------
+
+#[test]
+fn override_monkey_patching_does_not_stack_wrappers_across_renders() {
+    let _lock = lock_render_env();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_dir = tmp.path().join("repo").join(".botster");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    let _env_repo = EnvGuard::set(
+        "BOTSTER_WEB_LAYOUT_REPO_DIR",
+        repo_dir.to_str().expect("utf-8 repo path"),
+    );
+
+    // Classic "wrap the embedded function" override shape — exactly what a
+    // user writing `.botster/layout_web.lua` would naïvely try. Pre-fix this
+    // pattern accumulated one wrapper per render; the test renders five times
+    // and asserts exactly ONE banner exists in the final output.
+    let override_path = repo_dir.join("layout_web.lua");
+    std::fs::write(
+        &override_path,
+        r#"
+            local base = require("web.layout")
+            local original = base.workspace_surface
+            function base.workspace_surface(state)
+                local inner = original(state)
+                return {
+                    type = "stack",
+                    props = { direction = "vertical", gap = "3" },
+                    children = {
+                        { type = "panel", props = { title = "WRAPPED", tone = "muted" } },
+                        inner,
+                    },
+                }
+            end
+            return base
+        "#,
+    )
+    .unwrap();
+
+    let lua = new_web_layout_lua();
+    let mut last: JsonValue = JsonValue::Null;
+    for _ in 0..5 {
+        last = render_via_lua(&lua, FIXTURE_EMPTY);
+    }
+    let json = last.to_string();
+    let banner_count = json.matches("\"title\":\"WRAPPED\"").count();
+    assert_eq!(
+        banner_count, 1,
+        "override that wraps base.workspace_surface must NOT stack wrappers \
+         across renders; got {banner_count} banners in: {json}"
+    );
+}
+
+#[test]
+fn override_module_evaluated_at_most_once_per_content_hash() {
+    let _lock = lock_render_env();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_dir = tmp.path().join("repo").join(".botster");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    let _env_repo = EnvGuard::set(
+        "BOTSTER_WEB_LAYOUT_REPO_DIR",
+        repo_dir.to_str().expect("utf-8 repo path"),
+    );
+
+    // The override increments a global counter on every module-evaluation.
+    // If the loader evaluates the chunk once per render (pre-fix), the
+    // counter will equal the render count. If the loader caches the
+    // evaluated module by content hash (post-fix), the counter stays at 1
+    // regardless of render count.
+    let override_path = repo_dir.join("layout_web.lua");
+    std::fs::write(
+        &override_path,
+        r#"
+            _G._botster_override_eval_count = (_G._botster_override_eval_count or 0) + 1
+            return {
+                workspace_surface = function(_state)
+                    return {
+                        type = "panel",
+                        props = { title = "COUNTER-TEST", tone = "muted" },
+                    }
+                end,
+            }
+        "#,
+    )
+    .unwrap();
+
+    let lua = new_web_layout_lua();
+    lua.globals().set("_botster_override_eval_count", 0i64).unwrap();
+
+    for _ in 0..4 {
+        let _ = render_via_lua(&lua, FIXTURE_EMPTY);
+    }
+
+    let count: i64 = lua.globals().get("_botster_override_eval_count").unwrap();
+    assert_eq!(
+        count, 1,
+        "override module must be evaluated at most once per unchanged content, \
+         got {count} evaluations across 4 renders"
+    );
+}
+
+#[test]
+fn override_deletion_restores_unpolluted_embedded_module() {
+    let _lock = lock_render_env();
+
+    let tmp = tempfile::tempdir().unwrap();
+    let repo_dir = tmp.path().join("repo").join(".botster");
+    std::fs::create_dir_all(&repo_dir).unwrap();
+    let _env_repo = EnvGuard::set(
+        "BOTSTER_WEB_LAYOUT_REPO_DIR",
+        repo_dir.to_str().expect("utf-8 repo path"),
+    );
+
+    // Phase 1: a mutating override that poisons `package.loaded["web.layout"]`.
+    let override_path = repo_dir.join("layout_web.lua");
+    std::fs::write(
+        &override_path,
+        r#"
+            local base = require("web.layout")
+            local original = base.workspace_surface
+            function base.workspace_surface(state)
+                local inner = original(state)
+                return {
+                    type = "stack",
+                    props = { direction = "vertical", gap = "3" },
+                    children = {
+                        { type = "panel", props = { title = "POISON", tone = "muted" } },
+                        inner,
+                    },
+                }
+            end
+            return base
+        "#,
+    )
+    .unwrap();
+
+    let lua = new_web_layout_lua();
+    let poisoned = render_via_lua(&lua, FIXTURE_EMPTY);
+    assert!(
+        poisoned.to_string().contains("\"title\":\"POISON\""),
+        "first render should see the poison banner as a sanity check: {poisoned}"
+    );
+
+    // Phase 2: delete the override. Clearing the scan cache simulates the
+    // TTL expiry production would see naturally. The next render falls back
+    // to the embedded default — and its output MUST NOT contain any residual
+    // wrapping from the poisoned module singleton.
+    std::fs::remove_file(&override_path).unwrap();
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
+
+    let restored = render_via_lua(&lua, FIXTURE_EMPTY);
+    let json = restored.to_string();
+    assert!(
+        !json.contains("\"title\":\"POISON\""),
+        "after override deletion the embedded default must NOT carry residual \
+         wrappers from the prior override: {json}"
+    );
+    // And the embedded empty-state shape is what we expect.
+    assert_eq!(
+        restored.get("type").and_then(|v| v.as_str()),
+        Some("stack"),
+        "deleted-override fallback must return the embedded empty-state stack: {restored}"
+    );
+}
+

--- a/cli/tests/ui_contract_web_layout_test.rs
+++ b/cli/tests/ui_contract_web_layout_test.rs
@@ -83,9 +83,10 @@ fn golden_dir() -> PathBuf {
 /// lock — the guard drops before the lock is released so subsequent tests
 /// see the known-empty baseline.
 ///
-/// Also resets the Phase-2b override cache TTL to zero so sequential file
-/// writes inside a single test are picked up without waiting for the 500 ms
-/// window to expire. Production runs leave the default TTL in place.
+/// Also clears the Rust-side override cache so one test's cached winner
+/// doesn't leak into the next. In production the cache is only cleared by
+/// an explicit `web_layout.reload()` call; tests simulate that from the
+/// Rust side via `_clear_override_cache_for_tests`.
 fn lock_render_env() -> MutexGuard<'static, ()> {
     let guard = RENDER_LOCK
         .lock()
@@ -97,11 +98,6 @@ fn lock_render_env() -> MutexGuard<'static, ()> {
         std::env::set_var("BOTSTER_CONFIG_DIR", EMPTY_SENTINEL_PATH);
         std::env::remove_var("BOTSTER_DEV");
     }
-    // Drop TTL to 0 and clear the cache — together they make sequential
-    // file edits deterministic. `_clear_override_cache_for_tests()` is safe
-    // to call without any corresponding "restore" step because production
-    // bootstrap paths never observe the test TTL.
-    botster::lua::primitives::web_layout::set_override_cache_ttl_millis(0);
     botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     guard
 }
@@ -674,6 +670,12 @@ fn override_chain_and_error_fallback() {
         EnvGuard::set(DEVICE_DIR_OVERRIDE_ENV, device_dir.to_string_lossy().as_ref());
     let _dev_guard = EnvGuard::set(DEV_MODE_ENV, "");
 
+    // Tests explicitly invalidate the Rust-side override cache between
+    // filesystem mutations. In production the user would call
+    // `web_layout.reload()`; from Rust tests we hit the same invalidation
+    // via `_clear_override_cache_for_tests` to avoid needing a shared Lua
+    // VM across the test steps.
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let embedded = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -695,6 +697,7 @@ fn override_chain_and_error_fallback() {
     )
     .unwrap();
 
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let device_tree = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -718,6 +721,7 @@ fn override_chain_and_error_fallback() {
     )
     .unwrap();
 
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let repo_tree = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -745,6 +749,7 @@ fn override_chain_and_error_fallback() {
         }"#,
     )
     .unwrap();
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let device_shared_tree = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -766,6 +771,7 @@ fn override_chain_and_error_fallback() {
         }"#,
     )
     .unwrap();
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let repo_shared_tree = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -780,6 +786,7 @@ fn override_chain_and_error_fallback() {
     // A broken override (Lua syntax error) must not crash the hub; the
     // primitive wraps the failure in a fallback `ui.panel{}` tree.
     std::fs::write(&repo_shared, "this is not valid lua }{").unwrap();
+    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
     let lua = new_web_layout_lua();
     let fallback = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
@@ -803,28 +810,13 @@ fn override_chain_and_error_fallback() {
 // mtime changes and preserve override priority on invalidation.
 // -------------------------------------------------------------------------
 
-/// Helper: bump a file's mtime forward by ~2 seconds so the next
-/// `candidate_mtime` call observes a different value even on filesystems
-/// with coarse (1s) mtime granularity.
-fn touch_future(path: &std::path::Path) {
-    // Read-then-write bumps mtime on every filesystem. Add a distinct byte
-    // so the content hash would also change if we ever key on content.
-    let prev = std::fs::read_to_string(path).unwrap_or_default();
-    let bumped = format!("{prev}\n-- touched");
-    std::fs::write(path, bumped).unwrap();
-    // Also force mtime forward explicitly in case the filesystem clamps
-    // subsecond resolution.
-    let now = std::time::SystemTime::now();
-    let future = now + std::time::Duration::from_secs(2);
-    let _ = filetime::set_file_mtime(path, filetime::FileTime::from_system_time(future));
-}
-
 #[test]
-fn modtime_cache_invalidates_on_file_edit_and_restores_embedded_when_removed() {
+fn cache_invalidates_on_reload_and_restores_embedded_when_removed() {
+    // New semantics (plugin-reload-parity): the override cache is held
+    // indefinitely and only cleared by an explicit reload. File edits are
+    // NOT auto-detected — the user invokes `web_layout.reload()` when they
+    // want their changes picked up.
     let _lock = lock_render_env();
-    // `lock_render_env` already sets TTL=0 and clears the cache; those are
-    // the right defaults for sequential file edits inside a single test.
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
 
     let tmp = tempfile::tempdir().unwrap();
     let repo_dir = tmp.path().join("repo").join(".botster");
@@ -844,108 +836,94 @@ fn modtime_cache_invalidates_on_file_edit_and_restores_embedded_when_removed() {
         "embedded default renders the empty-state stack: {base}"
     );
 
-    // 2. Add a repo override. Because the previous render cached
-    // "no override won" with a 500 ms TTL, the next render WITHIN that
-    // window must still pick up the new file — so we explicitly clear
-    // the cache the same way a cache-miss past TTL would.
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
+    // 2. Add a repo override. Because the previous render cached "no
+    // override won", the new file is NOT picked up until we reload.
     let override_path = repo_dir.join("layout_web.lua");
     std::fs::write(
         &override_path,
         r#"return {
             workspace_surface = function(_state)
-                return ui.panel{ title = "MODTIME-v1", tone = "muted" }
+                return ui.panel{ title = "OVERRIDE-v1", tone = "muted" }
             end,
         }"#,
     )
     .unwrap();
-    let lua = new_web_layout_lua();
+    let pre_reload = render_via_lua(&lua, FIXTURE_EMPTY);
+    assert_eq!(
+        pre_reload.get("type").and_then(|v| v.as_str()),
+        Some("stack"),
+        "without reload the cached 'no override' result still serves: {pre_reload}"
+    );
+
+    // 3. Explicit reload picks up the new file.
+    botster::lua::primitives::web_layout::reload(&lua).expect("reload");
     let v1 = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
         v1.get("props")
             .and_then(|p| p.get("title"))
             .and_then(|t| t.as_str()),
-        Some("MODTIME-v1"),
-        "override picked up after cache clear: {v1}"
+        Some("OVERRIDE-v1"),
+        "override picked up after explicit reload: {v1}"
     );
 
-    // 3. Second render within TTL reuses the cached content — still v1.
+    // 4. Subsequent renders without another reload reuse the cached v1.
     let v1_again = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
         v1_again
             .get("props")
             .and_then(|p| p.get("title"))
             .and_then(|t| t.as_str()),
-        Some("MODTIME-v1"),
-        "within-TTL render reuses cached override: {v1_again}"
+        Some("OVERRIDE-v1"),
+        "steady-state render reuses cached override without re-reading: {v1_again}"
     );
 
-    // 4. Rewrite the file with a new payload and bump mtime. Clearing the
-    // cache here stands in for "TTL elapsed" — the production behavior is
-    // identical past 500 ms.
+    // 5. Rewrite the override on disk — still ignored until we reload.
     std::fs::write(
         &override_path,
         r#"return {
             workspace_surface = function(_state)
-                return ui.panel{ title = "MODTIME-v2", tone = "muted" }
+                return ui.panel{ title = "OVERRIDE-v2", tone = "muted" }
             end,
         }"#,
     )
     .unwrap();
-    let now = std::time::SystemTime::now();
-    let future = now + std::time::Duration::from_secs(2);
-    let _ = filetime::set_file_mtime(
-        &override_path,
-        filetime::FileTime::from_system_time(future),
+    let still_v1 = render_via_lua(&lua, FIXTURE_EMPTY);
+    assert_eq!(
+        still_v1
+            .get("props")
+            .and_then(|p| p.get("title"))
+            .and_then(|t| t.as_str()),
+        Some("OVERRIDE-v1"),
+        "edit without reload must NOT take effect: {still_v1}"
     );
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
+
+    // 6. Reload picks up the edit.
+    botster::lua::primitives::web_layout::reload(&lua).expect("reload after edit");
     let v2 = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
         v2.get("props")
             .and_then(|p| p.get("title"))
             .and_then(|t| t.as_str()),
-        Some("MODTIME-v2"),
-        "mtime drift invalidates the cached content: {v2}"
+        Some("OVERRIDE-v2"),
+        "reload after edit picks up the new content: {v2}"
     );
 
-    // 5. Remove the override entirely. Past the TTL (or after an explicit
-    // clear) the chain must fall back to embedded again — the previous
-    // "winning override" entry must not be served once the file is gone.
+    // 7. Delete the override, reload, and fall back to embedded.
     std::fs::remove_file(&override_path).unwrap();
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
+    botster::lua::primitives::web_layout::reload(&lua).expect("reload after deletion");
     let after_delete = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
         after_delete.get("type").and_then(|v| v.as_str()),
         Some("stack"),
-        "removing the override must restore embedded default: {after_delete}"
+        "reload after deletion restores embedded default: {after_delete}"
     );
 }
 
 #[test]
-fn modtime_cache_reuses_unchanged_content_without_rereading() {
-    // If the cached mtime matches the filesystem's mtime, the cache must
-    // reuse the stored content. We prove this by swapping the file's
-    // content to something that WOULD raise a Lua error on evaluation,
-    // while pinning mtime to the original value. A successful render with
-    // the original title proves the cache served the old bytes.
-    //
-    // This test temporarily restores the production TTL (500 ms) so the
-    // within-TTL cache-hit branch is exercised at all — `lock_render_env`
-    // drops TTL to 0 for deterministic sequential edits.
+fn reload_is_callable_from_lua_and_clears_caches() {
+    // `web_layout.reload()` is the Lua-visible entry point that matches the
+    // `reload_plugin` pattern — users/callers explicitly opt in.
     let _lock = lock_render_env();
-    botster::lua::primitives::web_layout::set_override_cache_ttl_millis(500);
-    // Clear between TTL changes so the first `render` in this test seeds a
-    // cache with the new TTL rather than serving a zero-TTL entry.
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
-    // Restore test default at scope exit so later tests aren't surprised.
-    struct TtlRestore;
-    impl Drop for TtlRestore {
-        fn drop(&mut self) {
-            botster::lua::primitives::web_layout::set_override_cache_ttl_millis(0);
-            botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
-        }
-    }
-    let _ttl_restore = TtlRestore;
 
     let tmp = tempfile::tempdir().unwrap();
     let repo_dir = tmp.path().join("repo").join(".botster");
@@ -955,91 +933,34 @@ fn modtime_cache_reuses_unchanged_content_without_rereading() {
         repo_dir.to_str().expect("utf-8 repo path"),
     );
 
+    let lua = new_web_layout_lua();
+    // Seed the cache with "no override wins".
+    let _ = render_via_lua(&lua, FIXTURE_EMPTY);
+
+    // Add an override AFTER the first render seeded the cache.
     let override_path = repo_dir.join("layout_web.lua");
     std::fs::write(
         &override_path,
         r#"return {
             workspace_surface = function(_state)
-                return ui.panel{ title = "CACHED-CONTENT", tone = "muted" }
+                return ui.panel{ title = "LUA-RELOAD", tone = "muted" }
             end,
         }"#,
     )
     .unwrap();
-    let original_mtime =
-        filetime::FileTime::from_last_modification_time(&std::fs::metadata(&override_path).unwrap());
 
-    // First render: populates the cache with the good content.
-    let lua = new_web_layout_lua();
-    let first = render_via_lua(&lua, FIXTURE_EMPTY);
-    assert_eq!(
-        first
-            .get("props")
-            .and_then(|p| p.get("title"))
-            .and_then(|t| t.as_str()),
-        Some("CACHED-CONTENT"),
-    );
+    // Call `web_layout.reload()` from Lua — same entrypoint users hit.
+    lua.load("web_layout.reload()").exec().expect("lua reload");
 
-    // Swap content to something that would raise on evaluation, but pin
-    // mtime back to the original so the cache considers the file
-    // unchanged and reuses the cached bytes.
-    std::fs::write(&override_path, "THIS WOULD RAISE IF RE-READ").unwrap();
-    filetime::set_file_mtime(&override_path, original_mtime).unwrap();
-
-    // Second render within TTL: reuse cache directly (zero disk reads).
-    let second = render_via_lua(&lua, FIXTURE_EMPTY);
-    assert_eq!(
-        second
-            .get("props")
-            .and_then(|p| p.get("title"))
-            .and_then(|t| t.as_str()),
-        Some("CACHED-CONTENT"),
-        "within-TTL render should reuse cached content without re-reading"
-    );
-
-    // Force a cache miss: mtime-pinned content must STILL be reused
-    // because the stat-then-content-diff path short-circuits on mtime
-    // equality.
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
-    // Repopulate cache with good content by rewriting, then pin mtime back.
-    std::fs::write(
-        &override_path,
-        r#"return {
-            workspace_surface = function(_state)
-                return ui.panel{ title = "CACHED-CONTENT", tone = "muted" }
-            end,
-        }"#,
-    )
-    .unwrap();
-    filetime::set_file_mtime(&override_path, original_mtime).unwrap();
-    let lua = new_web_layout_lua();
-    let _prime = render_via_lua(&lua, FIXTURE_EMPTY);
-    // Now the cache holds the good content at `original_mtime`.
-    // Swap to broken content WITHOUT bumping mtime:
-    std::fs::write(&override_path, "still broken").unwrap();
-    filetime::set_file_mtime(&override_path, original_mtime).unwrap();
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
-    // After clear, scan_and_load() re-stats. Mtime equals the cached mtime
-    // only if we can re-seed the cache — but _clear_override_cache_for_tests
-    // wipes it. This branch therefore EXERCISES the re-read path; it must
-    // now fail to a fallback (not crash). Regression guard: the primitive
-    // must never propagate the I/O/parse error as a Rust panic.
-    let lua = new_web_layout_lua();
     let after = render_via_lua(&lua, FIXTURE_EMPTY);
     assert_eq!(
-        after.get("type").and_then(|v| v.as_str()),
-        Some("panel"),
-        "broken re-read must land on the error fallback tree: {after}"
+        after
+            .get("props")
+            .and_then(|p| p.get("title"))
+            .and_then(|t| t.as_str()),
+        Some("LUA-RELOAD"),
+        "lua-driven reload must pick up the new override: {after}"
     );
-    let title = after
-        .get("props")
-        .and_then(|p| p.get("title"))
-        .and_then(|t| t.as_str())
-        .unwrap_or_default();
-    assert!(
-        title.contains("Layout error"),
-        "fallback title must announce the failure, got {title}"
-    );
-    let _ = touch_future; // silence warn in the common case where 2-stage touch is unused
 }
 
 // -----------------------------------------------------------------------------
@@ -1205,12 +1126,13 @@ fn override_deletion_restores_unpolluted_embedded_module() {
         "first render should see the poison banner as a sanity check: {poisoned}"
     );
 
-    // Phase 2: delete the override. Clearing the scan cache simulates the
-    // TTL expiry production would see naturally. The next render falls back
-    // to the embedded default — and its output MUST NOT contain any residual
-    // wrapping from the poisoned module singleton.
+    // Phase 2: delete the override. An explicit reload (matching the
+    // plugin-reload pattern) invalidates ALL caches including
+    // `package.loaded["web.layout"]`, so the next render falls back to the
+    // embedded default from a fresh copy — zero residual wrapping from the
+    // poisoned singleton.
     std::fs::remove_file(&override_path).unwrap();
-    botster::lua::primitives::web_layout::_clear_override_cache_for_tests();
+    botster::lua::primitives::web_layout::reload(&lua).expect("reload after delete");
 
     let restored = render_via_lua(&lua, FIXTURE_EMPTY);
     let json = restored.to_string();


### PR DESCRIPTION
## Summary

Three commits, all audited by codex (verdict: **APPROVED**):

1. **`45e2274f` — Cache compiled override table per content hash + reset embedded module on reload.** Fixes wrapper-stacking bug where `require("web.layout")` returned the VM singleton and repeated overrides accumulated. Content-hash cache (hex `u64`) ensures the Lua chunk is re-evaluated only when source changes.

2. **`aac56d98` — Replace TTL polling with explicit `web_layout.reload()`.** Mirrors the plugin-reload pattern: no more ambient background polling / "override live" banner spam, plugins and layouts both reload on an explicit hub call. Removes the Rust `OVERRIDE_CACHE` TTL path.

3. **`db114c1d` — Quiet-idle polish + client-side collapse decoration.**
   - `layout.lua` + `web/layout.lua`: only active sessions render an activity glyph/dot. Idle and accessory sessions are quiet (no dot, no `◌`).
   - `UiTree.jsx`: `applyCollapseOverrides` walks the hub tree and injects `expanded: false` on tree_items whose id is in `useWorkspaceStore.collapsedWorkspaceIds` (per-client ephemeral UI state, browser-owned).
   - Chevron rotation moved from custom CSS to Tailwind arbitrary variant `[[aria-expanded=false]_&]:-rotate-90`.

4. **`3bb84733` — Follow-up test alignment** (per codex BLOCKING findings on the original branch tip):
   - `cli/tests/ui_contract_web_layout_test.rs`: renamed `accessory_session_suppresses_activity_dot` → `only_active_sessions_render_activity_dot`, asserts 1 dot.
   - Regenerated 3 goldens: `mixed_activity`, `preview_error`, `ungrouped_with_empty_workspace` — each drops the old idle `status_dot` node.
   - `cli/src/tui/layout_lua.rs`: renamed `test_layout_renders_idle_icon_for_idle_agent` → `test_layout_suppresses_activity_icon_for_idle_agent`; active-glyph test untouched.

## Test plan

- [x] `./test.sh` — full CLI test suite: 1308 unit + all integration pass
- [x] `npx vitest --run` — 16 files, 115 tests pass
- [x] Codex re-audit after fix commit → APPROVED, no findings
- [ ] Live-test reload after merge: edit `~/.botster/layout_web.lua`, trigger `web_layout.reload()`, confirm override swaps without banner spam
- [ ] Confirm chevron rotates on workspace collapse in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)