### PR TITLE
feat(cli+web): surface registry + dynamic plugin pages (Phase 4a)

### DIFF
--- a/app/frontend/components/AppShell.jsx
+++ b/app/frontend/components/AppShell.jsx
@@ -38,6 +38,7 @@ const HubDashboard = React.lazy(() => import('./pages/HubDashboard'))
 const HubShow = React.lazy(() => import('./pages/HubShow'))
 const SettingsRoute = React.lazy(() => import('./pages/SettingsRoute'))
 const PairingRoute = React.lazy(() => import('./pages/PairingRoute'))
+const DynamicSurfaceRoute = React.lazy(() => import('./pages/DynamicSurface'))
 
 function SuspenseFallback() {
   return (
@@ -316,6 +317,12 @@ export function AppRoutes() {
           <Route path="sessions/:sessionUuid" element={null} />
           <Route path="settings" element={<SettingsRoute />} />
           <Route path="pairing" element={<PairingRoute />} />
+          {/* Phase 4a: catch-all for hub-authored surfaces. React Router
+              v6 prefers static segments over splats, so the enumerated
+              legacy routes above still win for their paths; any other
+              hub-scoped URL falls through here and resolves against the
+              `ui_route_registry_v1` broadcast. */}
+          <Route path="*" element={<DynamicSurfaceRoute />} />
         </Route>
       </Route>
     </Routes>

--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -6,6 +6,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
 } from 'react'
 import {
   UiTreeBody,
@@ -71,6 +72,114 @@ function applyCollapseOverrides(node, collapsedIds) {
   }
 
   return decorated
+}
+
+// ---------------------------------------------------------------------------
+// Nav-selection decorator — applies browser-local "which nav entry is the
+// current page" state on top of the hub-authored tree before it reaches the
+// primitive interpreter.
+//
+// Phase 4a registered-surface nav entries use a shared action shape:
+//
+//     ui.action("botster.nav.open", { path = "/plugins/hello" })
+//
+// The hub doesn't track per-client URL state — that's a browser-ephemeral
+// concern (parallel to the workspace collapse invariant). So we decorate
+// here: if a tree_item's action targets `botster.nav.open` with a `path`
+// that matches the current hub-scoped URL, set `selected: true` on it.
+// Pure function keyed only on `(tree, hubId, pathname)` — safe to memoise.
+// ---------------------------------------------------------------------------
+
+/** Subscribe `useSyncExternalStore` to browser history updates. Triggers
+ *  a re-render of any UiTree instance whose nav-entry highlight depends
+ *  on the current URL. Cross-component because multiple UiTrees can be
+ *  mounted (sidebar + panel) simultaneously. */
+function subscribeToPathname(onChange) {
+  if (typeof window === 'undefined') return () => {}
+  window.addEventListener('popstate', onChange)
+  return () => window.removeEventListener('popstate', onChange)
+}
+
+function getPathnameSnapshot() {
+  return typeof window !== 'undefined' ? window.location.pathname : ''
+}
+
+function getServerPathnameSnapshot() {
+  // SSR-safe placeholder. The project doesn't SSR this island but keeping
+  // a distinct value avoids hydration mismatches if that ever changes.
+  return ''
+}
+
+/** React hook wrapping the store-contract listener. */
+function useCurrentPathname() {
+  return useSyncExternalStore(
+    subscribeToPathname,
+    getPathnameSnapshot,
+    getServerPathnameSnapshot,
+  )
+}
+
+/** Is `treeItemNode`'s action a `botster.nav.open` whose hub-relative
+ *  `path` field, combined with `hubId`, matches `pathname`? Tolerant of
+ *  leading-slash discrepancies — the hub's Lua code emits a
+ *  leading-slash path ("/plugins/hello"), but users editing overrides
+ *  may omit it. */
+function navEntryMatchesPathname(actionProp, hubId, pathname) {
+  if (!actionProp || typeof actionProp !== 'object') return false
+  if (actionProp.id !== 'botster.nav.open') return false
+  const path =
+    actionProp.payload && typeof actionProp.payload.path === 'string'
+      ? actionProp.payload.path
+      : null
+  if (path == null || typeof hubId !== 'string' || hubId.length === 0) return false
+
+  const trimmed = path.startsWith('/') ? path : '/' + path
+  // Root path "/" collapses to "/hubs/<hubId>" (not "/hubs/<hubId>/") so a
+  // deep-linked `/hubs/:id` lands on the hub-root nav entry.
+  const expected = trimmed === '/' ? `/hubs/${hubId}` : `/hubs/${hubId}${trimmed}`
+  if (pathname === expected) return true
+  // Also match trailing-slash variants so either is considered "current".
+  if (expected === `/hubs/${hubId}` && pathname === `/hubs/${hubId}/`) return true
+  if (pathname === expected + '/') return true
+  return false
+}
+
+function applyNavSelectionOverrides(node, hubId, pathname) {
+  if (!node || typeof node !== 'object') return node
+
+  const decorated = { ...node }
+
+  if (node.type === 'tree_item') {
+    const action = node.props?.action
+    if (navEntryMatchesPathname(action, hubId, pathname)) {
+      decorated.props = { ...(node.props ?? {}), selected: true }
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    decorated.children = node.children.map((c) =>
+      applyNavSelectionOverrides(c, hubId, pathname),
+    )
+  }
+
+  if (node.slots && typeof node.slots === 'object') {
+    decorated.slots = Object.fromEntries(
+      Object.entries(node.slots).map(([name, children]) => [
+        name,
+        Array.isArray(children)
+          ? children.map((c) => applyNavSelectionOverrides(c, hubId, pathname))
+          : children,
+      ]),
+    )
+  }
+
+  return decorated
+}
+
+// Exported for vitest coverage without round-tripping through React.
+export {
+  applyNavSelectionOverrides as _applyNavSelectionOverridesForTests,
+  navEntryMatchesPathname as _navEntryMatchesPathnameForTests,
 }
 
 // ---------------------------------------------------------------------------
@@ -207,24 +316,33 @@ export default function UiTree({
   const [tree, setTree] = useState(initialTree)
   const [transport, setTransport] = useState(null)
 
-  // Browser-local collapse state. Re-renders this component when a user
-  // toggles a workspace; `applyCollapseOverrides` then injects
-  // `expanded: false` into matching tree_items before the interpreter
-  // walks the tree. See `applyCollapseOverrides` at top of file.
+  // Browser-local ephemeral UI state — two independent decorators stack
+  // on top of the hub-authored tree before it reaches the interpreter:
+  //
+  //   1. `applyCollapseOverrides` — workspace collapse/expand state owned
+  //      by `useWorkspaceStore.collapsedWorkspaceIds`. Triggered by the
+  //      LOCAL_ONLY `botster.workspace.toggle` action.
+  //   2. `applyNavSelectionOverrides` — Phase 4a nav highlight for the
+  //      current URL, subscribed via `useSyncExternalStore` on popstate
+  //      so `botster.nav.open` pushState updates re-render automatically.
+  //
+  // Both are pure functions; order is fixed (collapse first, then
+  // selection) because selection walks the same node shape collapse
+  // produces and never depends on collapse state. Malformed trees must
+  // still reach `UiTreeErrorBoundary` — if decoration blows up, pass the
+  // original tree through and let the interpreter's render routes React
+  // to the error boundary.
   const collapsedIds = useWorkspaceStore((s) => s.collapsedWorkspaceIds)
+  const currentPathname = useCurrentPathname()
   const decoratedTree = useMemo(() => {
     if (!tree) return tree
-    // Malformed trees (e.g. getter throws) must still reach the error
-    // boundary in `UiTreeErrorBoundary` so the user sees a graceful
-    // fallback. If decoration blows up, pass the original tree through
-    // — the interpreter will then throw from its own render, which React
-    // routes to the boundary.
     try {
-      return applyCollapseOverrides(tree, collapsedIds)
+      const collapsed = applyCollapseOverrides(tree, collapsedIds)
+      return applyNavSelectionOverrides(collapsed, hubId ?? '', currentPathname)
     } catch {
       return tree
     }
-  }, [tree, collapsedIds])
+  }, [tree, collapsedIds, hubId, currentPathname])
 
   // Reset tree + transport synchronously on hubId change. Without this, a
   // hub switch (A → B) keeps the old tree visible until B's first broadcast

--- a/app/frontend/components/pages/DynamicSurface.jsx
+++ b/app/frontend/components/pages/DynamicSurface.jsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import UiTree from '../UiTree'
+import SessionActionsMenu from '../workspace/SessionActionsMenu'
+import {
+  useRouteRegistryStore,
+  selectRoutesForHub,
+  selectHasRouteRegistrySnapshot,
+} from '../../store/route-registry-store'
+
+/**
+ * Phase 4a: dynamic hub-authored surface route.
+ *
+ * Matches `useParams()`'s splat (`*`) against the hub's
+ * `ui_route_registry_v1` entries and mounts `<UiTree>` for the matching
+ * surface. A plugin that registers `surfaces.register("hello", { path =
+ * "/plugins/hello", ... })` becomes reachable at
+ * `/hubs/:hubId/plugins/hello` with zero Rails changes — the Rails
+ * catch-all routes every `/hubs/:hubId/*` URL to `spa#hub`, React Router
+ * routes it here, and this component subscribes the hub to the surface's
+ * tree frames.
+ *
+ * Three resolution states for the current URL:
+ *   1. Registry hasn't shipped its first snapshot yet for this hub
+ *      (cold deep-link, hub still connecting) → loading state.
+ *   2. Snapshot received, path matches a registered surface → mount
+ *      `<UiTree>` for that surface.
+ *   3. Snapshot received, no match → true 404.
+ *
+ * Distinguishing (1) from (3) avoids the "flash of 404" that would
+ * otherwise show whenever a user types / bookmarks a plugin URL and
+ * hits it before the hub broadcasts the registry.
+ */
+export default function DynamicSurfaceRoute() {
+  const { hubId, '*': splat } = useParams()
+  const routes = useRouteRegistryStore((s) => selectRoutesForHub(s, hubId))
+  const hasSnapshot = useRouteRegistryStore((s) =>
+    selectHasRouteRegistrySnapshot(s, hubId),
+  )
+
+  // Belt-and-suspenders: `/sessions/*` is handled by `AppShell`'s
+  // `TerminalCache` branch, NOT by a registered surface. React Router
+  // matches specific routes before the wildcard in Router v6, so this
+  // check only fires on rare misroutes (e.g. a session-like URL that
+  // isn't actually a real session). Defer to the legacy fallback by
+  // rendering nothing; AppShell's own detection takes over.
+  if (typeof splat === 'string' && splat.startsWith('sessions/')) {
+    return null
+  }
+
+  // The routes registry is keyed on paths that are hub-scoped (e.g. "/",
+  // "/plugins/hello"). React Router's splat gives us the path WITHOUT a
+  // leading slash for nested routes. Normalise before comparing.
+  const requestedPath = '/' + (splat ?? '')
+
+  // Unresolved: registry frame hasn't arrived yet. Render a loading
+  // placeholder (visually distinct from the 404 state) instead of
+  // flashing "Not found" while the hub is still connecting.
+  if (!hasSnapshot) {
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <div className="text-sm text-zinc-500">Loading…</div>
+      </div>
+    )
+  }
+
+  const match = routes.find((r) => r.path === requestedPath)
+
+  if (!match) {
+    // Unknown path — render a minimal local 404. Phase 4a intentionally
+    // skips hub-authored 404 surfaces (the orchestrator flagged that as
+    // optional); a plugin can still register one at path "/404" if it
+    // wants consistent chrome.
+    return (
+      <div className="h-full flex items-center justify-center p-4">
+        <div className="max-w-md text-center">
+          <h1 className="text-lg font-semibold text-zinc-200">
+            Not found
+          </h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            No surface is registered for{' '}
+            <code className="rounded bg-zinc-800 px-1 py-0.5 font-mono text-xs text-zinc-300">
+              {requestedPath}
+            </code>
+            .
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-full overflow-y-auto p-4 lg:p-6">
+      <UiTree hubId={hubId} targetSurface={match.surface}>
+        <SessionActionsMenu />
+      </UiTree>
+    </div>
+  )
+}

--- a/app/frontend/lib/actions.js
+++ b/app/frontend/lib/actions.js
@@ -11,6 +11,11 @@ const ACTION = {
   PREVIEW_OPEN: 'botster.session.preview.open',
   SESSION_MOVE: 'botster.session.move.request',
   SESSION_DELETE: 'botster.session.delete.request',
+  // Phase 4a: router-level navigation fired from Lua-authored trees (e.g.
+  // sidebar nav entries for plugin-registered surfaces). Payload expected:
+  // { path, hubId? }. When `hubId` is present the path is prefixed with
+  // `/hubs/<id>`; callers that emit pre-qualified absolute paths can omit.
+  NAV_OPEN: 'botster.nav.open',
 }
 
 // Validate that a URL uses a safe protocol (http/https only)
@@ -103,6 +108,25 @@ const handlers = {
         },
       })
     )
+  },
+
+  [ACTION.NAV_OPEN](payload) {
+    // Phase 4a: router-level nav. Accept either a pre-qualified absolute
+    // path (`/hubs/:id/plugins/hello`) or a hub-relative one (`/plugins/hello`)
+    // alongside the hubId enriched by createTransportDispatch. Relative
+    // paths are the common case — the sidebar Lua emits the surface's own
+    // `path` field directly, which is hub-relative.
+    let target = typeof payload.path === 'string' ? payload.path : null
+    if (!target || typeof window === 'undefined' || !window.history?.pushState) {
+      return
+    }
+    if (!target.startsWith('/hubs/') && typeof payload.hubId === 'string' && payload.hubId.length > 0) {
+      const trimmed = target.startsWith('/') ? target : '/' + target
+      target = `/hubs/${payload.hubId}${trimmed === '/' ? '' : trimmed}`
+    }
+    if (window.location.pathname === target) return
+    window.history.pushState({}, '', target)
+    window.dispatchEvent(new PopStateEvent('popstate'))
   },
 }
 

--- a/app/frontend/lib/connections/hub_connection.js
+++ b/app/frontend/lib/connections/hub_connection.js
@@ -40,12 +40,29 @@ export class HubTransport extends HubRoute {
     this._openWorkspaces = [];
     this._spawnTargets = [];
     this._hubRecoveryState = null;
+    this._uiRouteRegistry = [];
 
     this._hasAgentListSnapshot = false;
     this._hasHubWorkspaceListSnapshot = false;
     this._hasOpenWorkspaceListSnapshot = false;
     this._hasSpawnTargetListSnapshot = false;
     this._hasHubRecoveryStateSnapshot = false;
+    this._hasUiRouteRegistrySnapshot = false;
+  }
+
+  // ========== Public snapshot accessors ==========
+
+  /**
+   * Current Phase-4a route registry (array of { path, surface, label, icon,
+   * hide_from_nav }). Empty until the hub ships the first
+   * `ui_route_registry_v1` frame.
+   */
+  uiRouteRegistry() {
+    return this._uiRouteRegistry;
+  }
+
+  hasUiRouteRegistrySnapshot() {
+    return this._hasUiRouteRegistrySnapshot;
   }
 
   // ========== Connection overrides ==========
@@ -148,6 +165,16 @@ export class HubTransport extends HubRoute {
         this._hasHubRecoveryStateSnapshot = true;
         this.emit("hubRecoveryState", message);
         if (message.state === "ready") this.emit("hubReady", message);
+        break;
+
+      case "ui_route_registry_v1":
+        // Phase 4a: hub-authored registry of routable browser surfaces.
+        // Cached so a subscriber acquiring the hub after the initial frame
+        // still sees the registry without a re-broadcast. Replaces wholesale
+        // on each frame — the hub is the source of truth.
+        this._uiRouteRegistry = Array.isArray(message.routes) ? message.routes : [];
+        this._hasUiRouteRegistrySnapshot = true;
+        this.emit("uiRouteRegistry", this._uiRouteRegistry);
         break;
 
       case "hub_ready":

--- a/app/frontend/lib/hub-bridge.js
+++ b/app/frontend/lib/hub-bridge.js
@@ -1,5 +1,6 @@
 import { HubManager } from 'connections'
 import { useWorkspaceStore } from '../store/workspace-store'
+import { useRouteRegistryStore } from '../store/route-registry-store'
 
 // Per-hub shared state
 const hubState = new Map()  // hubId → { hub, unsubscribers, callerIds: Set }
@@ -83,6 +84,30 @@ async function doConnect(hubId, callerId) {
     })
   )
 
+  // Phase 4a: seed + follow the hub-authored route registry. The hub sends
+  // `ui_route_registry_v1` on hub-channel subscribe (so the first frame
+  // arrives shortly after acquire) and on every `surfaces_changed` hook
+  // firing. `hub.transport` is the HubTransport; `uiRouteRegistry` is both
+  // an event name and a snapshot accessor.
+  const seedRoutes = () => {
+    const transport = hub.transport
+    if (transport && typeof transport.uiRouteRegistry === 'function') {
+      const initial = transport.uiRouteRegistry()
+      if (Array.isArray(initial) && initial.length > 0) {
+        useRouteRegistryStore.getState().setRoutes(hubId, initial)
+      }
+    }
+  }
+  seedRoutes()
+  if (hub.transport && typeof hub.transport.on === 'function') {
+    const off = hub.transport.on('uiRouteRegistry', (routes) => {
+      useRouteRegistryStore.getState().setRoutes(hubId, routes)
+    })
+    if (typeof off === 'function') {
+      unsubscribers.push(off)
+    }
+  }
+
   syncSelectionFromUrl(hub)
 
   state = { hub, unsubscribers, callerIds: new Set([callerId]) }
@@ -119,6 +144,7 @@ function doDisconnect(hubId, callerId) {
   hubState.delete(hubId)
   chains.delete(hubId)
   getStoreActions().setConnected(false)
+  useRouteRegistryStore.getState().clearRoutes(hubId)
 }
 
 export function getHub(hubId) {

--- a/app/frontend/store/route-registry-store.js
+++ b/app/frontend/store/route-registry-store.js
@@ -1,0 +1,79 @@
+import { create } from 'zustand'
+
+// Phase 4a: per-hub registry of routable browser surfaces. Populated from
+// the `ui_route_registry_v1` broadcast (see `lib/connections/hub_connection.js`
+// and the bridge in `lib/hub-bridge.js`). Components subscribe via the
+// `useRouteRegistryStore` hook; `DynamicSurfaceRoute` matches the current
+// URL splat against an entry's `path` to decide which hub-authored surface
+// to mount.
+//
+// Shape:
+//   routesByHubId: { [hubId]: Array<{ path, surface, label, icon, hide_from_nav? }> }
+//   snapshotReceivedAtByHubId: { [hubId]: number }
+//
+// Routes are replaced wholesale per frame so the hub always owns the
+// source of truth; local mutation is never correct. `snapshotReceivedAt`
+// distinguishes "first broadcast hasn't arrived yet" (undefined) from
+// "registry says this path is not routable" (timestamp present, path
+// absent from the array). `DynamicSurfaceRoute` renders a loading state
+// before the first snapshot and a true 404 after.
+
+export const useRouteRegistryStore = create((set) => ({
+  routesByHubId: {},
+  snapshotReceivedAtByHubId: {},
+
+  setRoutes(hubId, routes) {
+    if (!hubId) return
+    const next = Array.isArray(routes) ? routes : []
+    set((s) => ({
+      routesByHubId: { ...s.routesByHubId, [String(hubId)]: next },
+      snapshotReceivedAtByHubId: {
+        ...s.snapshotReceivedAtByHubId,
+        [String(hubId)]: Date.now(),
+      },
+    }))
+  },
+
+  clearRoutes(hubId) {
+    if (!hubId) return
+    set((s) => {
+      const routesCopy = { ...s.routesByHubId }
+      const snapshotCopy = { ...s.snapshotReceivedAtByHubId }
+      let changed = false
+      if (String(hubId) in routesCopy) {
+        delete routesCopy[String(hubId)]
+        changed = true
+      }
+      if (String(hubId) in snapshotCopy) {
+        delete snapshotCopy[String(hubId)]
+        changed = true
+      }
+      if (!changed) return s
+      return {
+        routesByHubId: routesCopy,
+        snapshotReceivedAtByHubId: snapshotCopy,
+      }
+    })
+  },
+}))
+
+// Stable empty-array singleton. Zustand subscribes components via
+// `Object.is` comparison; returning a fresh `[]` per selector call would
+// look like a new value every render and trigger React's update-depth
+// protection. A frozen module-level constant is safe here because the
+// selector never mutates.
+const EMPTY_ROUTES = Object.freeze([])
+
+/** Selector: return the routes for a given hub id, or an empty array. */
+export function selectRoutesForHub(state, hubId) {
+  if (!hubId) return EMPTY_ROUTES
+  return state.routesByHubId[String(hubId)] ?? EMPTY_ROUTES
+}
+
+/** Selector: has this hub shipped its first `ui_route_registry_v1` frame?
+ *  Consumers should render a loading state while this is false and fall
+ *  back to the 404 / no-match branch only after it turns true. */
+export function selectHasRouteRegistrySnapshot(state, hubId) {
+  if (!hubId) return false
+  return state.snapshotReceivedAtByHubId[String(hubId)] !== undefined
+}

--- a/app/frontend/test/dynamic-surface-route.test.jsx
+++ b/app/frontend/test/dynamic-surface-route.test.jsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { useRouteRegistryStore } from '../store/route-registry-store'
+
+// UiTree is the hub-subscribing mount. For this unit test we don't want to
+// exercise real subscription / transport code — we just want to assert that
+// DynamicSurfaceRoute passes the right `targetSurface` through.
+vi.mock('../components/UiTree', () => ({
+  default: ({ hubId, targetSurface, children }) => (
+    <div data-testid="ui-tree">
+      <span>{`hubId=${hubId}`}</span>
+      <span>{`targetSurface=${targetSurface}`}</span>
+      {children}
+    </div>
+  ),
+}))
+
+vi.mock('../components/workspace/SessionActionsMenu', () => ({
+  default: () => <div data-testid="session-actions-menu" />,
+}))
+
+// eslint-disable-next-line import/first
+import DynamicSurfaceRoute from '../components/pages/DynamicSurface'
+
+function renderDynamic(path) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/hubs/:hubId/*" element={<DynamicSurfaceRoute />} />
+      </Routes>
+    </MemoryRouter>
+  )
+}
+
+describe('DynamicSurfaceRoute', () => {
+  beforeEach(() => {
+    // Reset registry store between tests so each test owns its routes.
+    useRouteRegistryStore.setState({
+      routesByHubId: {},
+      snapshotReceivedAtByHubId: {},
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    useRouteRegistryStore.setState({
+      routesByHubId: {},
+      snapshotReceivedAtByHubId: {},
+    })
+  })
+
+  it('mounts UiTree with the surface matching the requested path', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello', label: 'Hello' },
+    ])
+    renderDynamic('/hubs/h1/plugins/hello')
+
+    const tree = screen.getByTestId('ui-tree')
+    expect(tree).toHaveTextContent('hubId=h1')
+    expect(tree).toHaveTextContent('targetSurface=hello')
+  })
+
+  it('renders a 404 fallback when the path is not in the registry', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello', label: 'Hello' },
+    ])
+    renderDynamic('/hubs/h1/plugins/missing')
+
+    expect(screen.getByText(/Not found/i)).toBeInTheDocument()
+    expect(screen.queryByTestId('ui-tree')).toBeNull()
+  })
+
+  it('defers to the legacy session route by rendering nothing for sessions/*', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/', surface: 'workspace_panel', label: 'Hub' },
+    ])
+    const { container } = renderDynamic('/hubs/h1/sessions/some-session-uuid')
+
+    // The component returns null so the splat branch leaves no UiTree and
+    // no 404 in its subtree. The MemoryRouter wrapper still exists — the
+    // component's *own* output should be empty.
+    expect(screen.queryByTestId('ui-tree')).toBeNull()
+    expect(screen.queryByText(/Not found/i)).toBeNull()
+    expect(container.textContent?.trim() ?? '').toBe('')
+  })
+
+  it('matches the root path for the workspace_panel surface', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/', surface: 'workspace_panel', label: 'Hub' },
+    ])
+    renderDynamic('/hubs/h1/')
+
+    expect(screen.getByTestId('ui-tree')).toHaveTextContent(
+      'targetSurface=workspace_panel'
+    )
+  })
+
+  // F4: distinguish "registry hasn't arrived yet" from "true 404".
+  it('renders the loading state while the registry snapshot is unresolved', () => {
+    // Deliberately do NOT call setRoutes — the hub is still connecting
+    // and the first ui_route_registry_v1 frame hasn't arrived.
+    renderDynamic('/hubs/brand-new-hub/plugins/hello')
+
+    // Loading placeholder, NOT 404.
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Not found/i)).toBeNull()
+    expect(screen.queryByTestId('ui-tree')).toBeNull()
+  })
+
+  it('transitions from loading to matched surface when the snapshot arrives', () => {
+    const { rerender } = renderDynamic('/hubs/h1/plugins/hello')
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+
+    // First frame arrives.
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello', label: 'Hello' },
+    ])
+    rerender(
+      <MemoryRouter initialEntries={['/hubs/h1/plugins/hello']}>
+        <Routes>
+          <Route path="/hubs/:hubId/*" element={<DynamicSurfaceRoute />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('ui-tree')).toHaveTextContent('targetSurface=hello')
+  })
+
+  it('transitions from loading to 404 when the snapshot confirms no such path', () => {
+    const { rerender } = renderDynamic('/hubs/h1/plugins/nope')
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument()
+
+    // First frame arrives — but `/plugins/nope` isn't in it.
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello', label: 'Hello' },
+    ])
+    rerender(
+      <MemoryRouter initialEntries={['/hubs/h1/plugins/nope']}>
+        <Routes>
+          <Route path="/hubs/:hubId/*" element={<DynamicSurfaceRoute />} />
+        </Routes>
+      </MemoryRouter>
+    )
+    expect(screen.getByText(/Not found/i)).toBeInTheDocument()
+  })
+
+  it('treats an explicit empty-array snapshot as resolved (true 404, not loading)', () => {
+    // The hub may ship an empty routes array (no routable surfaces yet);
+    // that's still a "snapshot received" event and should 404, not loop
+    // forever on "loading".
+    useRouteRegistryStore.getState().setRoutes('h1', [])
+    renderDynamic('/hubs/h1/anywhere')
+
+    expect(screen.getByText(/Not found/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Loading/i)).toBeNull()
+  })
+})

--- a/app/frontend/test/ui-tree-nav-selection.test.jsx
+++ b/app/frontend/test/ui-tree-nav-selection.test.jsx
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest'
+import {
+  _applyNavSelectionOverridesForTests as applyNavSelectionOverrides,
+  _navEntryMatchesPathnameForTests as navEntryMatchesPathname,
+} from '../components/UiTree'
+
+// Phase 4a F3: browser-local decorator that marks `botster.nav.open`
+// tree_items as `selected` when their hub-scoped path matches
+// `window.location.pathname`. Tested at the pure-function level so the
+// store/router dependencies don't have to be spun up for each variant.
+
+function navItem(path, overrides = {}) {
+  return {
+    type: 'tree_item',
+    props: {
+      action: {
+        id: 'botster.nav.open',
+        payload: { path },
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('navEntryMatchesPathname', () => {
+  it('matches an exact hub-scoped path', () => {
+    const action = { id: 'botster.nav.open', payload: { path: '/plugins/hello' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1/plugins/hello')).toBe(true)
+  })
+
+  it('tolerates a missing leading slash on the payload path', () => {
+    const action = { id: 'botster.nav.open', payload: { path: 'plugins/hello' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1/plugins/hello')).toBe(true)
+  })
+
+  it('matches the root path to /hubs/<hubId>', () => {
+    const action = { id: 'botster.nav.open', payload: { path: '/' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1')).toBe(true)
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1/')).toBe(true)
+  })
+
+  it('tolerates trailing-slash variants', () => {
+    const action = { id: 'botster.nav.open', payload: { path: '/plugins/hello' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1/plugins/hello/')).toBe(true)
+  })
+
+  it('does not match unrelated actions', () => {
+    const action = { id: 'botster.session.select', payload: { path: '/plugins/hello' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h1/plugins/hello')).toBe(false)
+  })
+
+  it('does not match when hub ids differ', () => {
+    const action = { id: 'botster.nav.open', payload: { path: '/plugins/hello' } }
+    expect(navEntryMatchesPathname(action, 'h1', '/hubs/h2/plugins/hello')).toBe(false)
+  })
+
+  it('returns false when hubId is empty', () => {
+    const action = { id: 'botster.nav.open', payload: { path: '/plugins/hello' } }
+    expect(navEntryMatchesPathname(action, '', '/hubs/h1/plugins/hello')).toBe(false)
+  })
+})
+
+describe('applyNavSelectionOverrides', () => {
+  it('marks only the matching tree_item as selected', () => {
+    const tree = {
+      type: 'tree',
+      children: [
+        navItem('/plugins/hello'),
+        navItem('/plugins/other'),
+      ],
+    }
+
+    const result = applyNavSelectionOverrides(tree, 'h1', '/hubs/h1/plugins/hello')
+    expect(result.children[0].props.selected).toBe(true)
+    expect(result.children[1].props.selected).toBeUndefined()
+  })
+
+  it('does not mutate the input tree', () => {
+    const tree = {
+      type: 'tree',
+      children: [navItem('/plugins/hello')],
+    }
+    const snapshot = JSON.parse(JSON.stringify(tree))
+    applyNavSelectionOverrides(tree, 'h1', '/hubs/h1/plugins/hello')
+    expect(tree).toEqual(snapshot)
+  })
+
+  it('recurses into children and slots', () => {
+    const tree = {
+      type: 'tree',
+      children: [
+        {
+          type: 'tree_item',
+          props: { id: 'wrapper' },
+          slots: {
+            children: [navItem('/plugins/hello')],
+          },
+        },
+      ],
+    }
+    const result = applyNavSelectionOverrides(tree, 'h1', '/hubs/h1/plugins/hello')
+    expect(result.children[0].slots.children[0].props.selected).toBe(true)
+  })
+
+  it('does not mark selection when hubId is missing', () => {
+    const tree = { type: 'tree', children: [navItem('/plugins/hello')] }
+    const result = applyNavSelectionOverrides(tree, '', '/hubs/h1/plugins/hello')
+    expect(result.children[0].props.selected).toBeUndefined()
+  })
+
+  it('preserves the existing tree_item.selected = false when nothing matches', () => {
+    const tree = {
+      type: 'tree',
+      children: [{
+        type: 'tree_item',
+        props: {
+          selected: false,  // authored-as-false; decorator must not flip to true
+          action: { id: 'botster.nav.open', payload: { path: '/plugins/other' } },
+        },
+      }],
+    }
+    const result = applyNavSelectionOverrides(tree, 'h1', '/hubs/h1/plugins/hello')
+    // Not a match → selected prop stays whatever was authored (false here).
+    expect(result.children[0].props.selected).toBe(false)
+  })
+})

--- a/app/frontend/ui_contract/dispatch.ts
+++ b/app/frontend/ui_contract/dispatch.ts
@@ -45,6 +45,10 @@ const LOCAL_ONLY_ACTIONS = new Set<string>([
   'botster.session.preview.open',
   'botster.session.move.request',
   'botster.session.delete.request',
+  // Phase 4a: router-level nav triggered from a Lua-authored tree (e.g.
+  // the sidebar's nav entries for plugin-registered surfaces). Hub has no
+  // server-side meaning for this action — it's pure browser navigation.
+  'botster.nav.open',
 ])
 
 /**

--- a/cli/lua/handlers/connections.lua
+++ b/cli/lua/handlers/connections.lua
@@ -193,6 +193,32 @@ local function broadcast_ui_layout_trees()
     end
 end
 
+--- Broadcast the `ui_route_registry_v1` frame to every hub-channel
+--- subscriber. Called on `surfaces_changed` so a plugin that registers a
+--- new surface mid-session reaches existing browsers without requiring
+--- them to reconnect. Subscribers receive the full registry; the frontend
+--- replaces its copy wholesale on each frame.
+local function broadcast_ui_route_registry()
+    local sub_count = 0
+    for _, client in pairs(clients) do
+        for sub_id, sub in pairs(client.subscriptions or {}) do
+            if sub.channel == "hub" then
+                sub_count = sub_count + 1
+                local ok, err = pcall(client.send_ui_route_registry, client, sub_id)
+                if not ok then
+                    log.warn(string.format(
+                        "broadcast_ui_route_registry: %s -> %s failed: %s",
+                        client.peer_id:sub(1, 8), sub_id:sub(1, 16), tostring(err)))
+                end
+            end
+        end
+    end
+    if sub_count > 0 then
+        log.debug(string.format(
+            "Broadcast ui_route_registry_v1 to %d subscription(s)", sub_count))
+    end
+end
+
 local function broadcast_workspace_list()
     local Hub = require("lib.hub")
     local ok, workspaces = pcall(function()
@@ -228,6 +254,21 @@ end
 -- ============================================================================
 -- Hook Observers (Lua → Lua)
 -- ============================================================================
+
+-- Phase 4a: re-broadcast the route registry whenever a surface is
+-- registered/unregistered. Debounced so a plugin that registers many
+-- surfaces in a tight loop coalesces into a single emission.
+local ROUTE_REGISTRY_DEBOUNCE_SECS = 0.05
+
+hooks.on("surfaces_changed", "broadcast_ui_route_registry", function(_info)
+    timer.after_idle("ui_route_registry_broadcast", ROUTE_REGISTRY_DEBOUNCE_SECS, function()
+        broadcast_ui_route_registry()
+        -- When a surface appears/disappears, the set of layout trees
+        -- available to subscribers changes too — force a layout rebroadcast
+        -- so the new surface's initial tree reaches existing browsers.
+        broadcast_ui_layout_trees()
+    end)
+end)
 
 hooks.on("agent_created", "broadcast_agent_created", function(info)
     if Session.is_system_session(info) then
@@ -609,6 +650,7 @@ local M = {
     broadcast_workspace_list = broadcast_workspace_list,
     broadcast_spawn_target_list = broadcast_spawn_target_list,
     broadcast_ui_layout_trees = broadcast_ui_layout_trees,
+    broadcast_ui_route_registry = broadcast_ui_route_registry,
 }
 
 -- Lifecycle hooks for hot-reload
@@ -630,6 +672,8 @@ function M._before_reload()
     hooks.off("pty_prompt", "update_agent_prompt")
     hooks.off("pty_cursor_visibility", "update_agent_cursor")
     hooks.off("client_disconnected", "unfocus_on_disconnect")
+    hooks.off("surfaces_changed", "broadcast_ui_route_registry")
+    timer.cancel("ui_route_registry_broadcast")
     _set_pty_focused = nil
     _on_pty_input = nil
     _clear_session_notification = nil

--- a/cli/lua/hub/builtin_surfaces.lua
+++ b/cli/lua/hub/builtin_surfaces.lua
@@ -1,0 +1,73 @@
+-- Bootstrap registrations for the built-in workspace surfaces.
+--
+-- Prior to Phase 4a, `workspace_sidebar` and `workspace_panel` were hardcoded
+-- in `lib.layout_broadcast` (the two-density SURFACE_TARGETS table) and
+-- rendered directly by `web_layout.render("workspace_surface", state)`. The
+-- surface registry (`lib.surfaces`) is now the single source of truth for
+-- browser surfaces, so both densities are registered here as first-class
+-- surfaces whose render function delegates to the existing embedded
+-- `workspace_surface` layout. This preserves the override-file chain — a user
+-- layout_web.lua that defines `workspace_surface` still wins — and keeps the
+-- Lua-authored tree identical to Phase 2 output.
+
+local surfaces = require("lib.surfaces")
+
+-- Shallow-copy `base` and set `surface` to the density the embedded
+-- `workspace_surface` layout expects. `web.layout:workspace_surface` branches
+-- on this field to pick sidebar-vs-panel sizing.
+local function with_density(base, density)
+    local out = {}
+    if type(base) == "table" then
+        for k, v in pairs(base) do out[k] = v end
+    end
+    out.surface = density
+    return out
+end
+
+-- Both surfaces share the same embedded layout function; the only difference
+-- is the `surface` density hint injected into the state. The wrapper calls
+-- the Rust `web_layout.render` primitive (not `surfaces.render_node`) so
+-- override files for `workspace_surface` take effect for free.
+local function workspace_renderer(density)
+    return function(render_state)
+        local state_with_density = with_density(render_state, density)
+        local tree_json = web_layout.render("workspace_surface", state_with_density)
+        if type(tree_json) ~= "string" then
+            error(string.format(
+                "workspace_renderer(%s): web_layout.render returned %s, expected string",
+                density, type(tree_json)))
+        end
+        local tree, decode_err = json.decode(tree_json)
+        if type(tree) ~= "table" then
+            error(string.format(
+                "workspace_renderer(%s): failed to decode layout JSON: %s",
+                density, tostring(decode_err)))
+        end
+        return tree
+    end
+end
+
+-- Ordering rationale:
+--   * workspace_panel is the hub landing page ("/"); `order = 0` pins it to
+--     the top of the nav, ahead of any plugin-registered surfaces (which
+--     default to `order = nil` == math.huge).
+--   * workspace_sidebar is the sidebar-only surface — no path, no nav entry;
+--     `order` is irrelevant but keeping it with the panel at 0 keeps debug
+--     output grouped.
+surfaces.register("workspace_sidebar", {
+    render = workspace_renderer("sidebar"),
+    order = 0,
+    source = "builtin",
+    -- no path: sidebar is not a routable page
+})
+
+surfaces.register("workspace_panel", {
+    path = "/",
+    label = "Hub",
+    icon = "home",
+    render = workspace_renderer("panel"),
+    order = 0,
+    source = "builtin",
+})
+
+return true

--- a/cli/lua/hub/init.lua
+++ b/cli/lua/hub/init.lua
@@ -56,7 +56,37 @@ _G.mcp = safe_require("lib.mcp")
 -- globals keeps plugin authoring ergonomic (no boilerplate require).
 _G.action = safe_require("lib.action")
 safe_require("lib.layout_input")
+
+-- Phase 4a: surface registry. Must load BEFORE `lib.layout_broadcast` so the
+-- broadcast module can see the registry, and BEFORE `handlers.connections`
+-- so the `surfaces_changed` hook subscription lands on the real table. The
+-- surfaces global lets plugin authors call `surfaces.register(name, opts)`
+-- without boilerplate. `hub.builtin_surfaces` registers workspace_sidebar /
+-- workspace_panel so the workspace isn't special-cased anywhere else.
+_G.surfaces = safe_require("lib.surfaces")
+safe_require("hub.builtin_surfaces")
+
 safe_require("lib.layout_broadcast")
+
+-- Phase 4a demo plugin. The real plugin loader (ConfigResolver below) walks
+-- the device root and admitted spawn target repos; it does NOT scan
+-- cli/lua/plugins/. That's deliberate — shipped demo plugins load here so
+-- the substrate is always exercised, without putting user plugins on the
+-- Lua `package.path`. A plugin author follows the same `surfaces.register`
+-- contract regardless of where their `plugin.lua` lives.
+--
+-- Gated so production hubs don't ship the `/plugins/hello` route to real
+-- users. Dev hubs (BOTSTER_DEV=1) and test hubs (BOTSTER_ENV=test) still
+-- register the demo so the substrate is exercisable end-to-end in those
+-- environments. Matches the DEV_ENV_VAR convention used by
+-- `cli/src/lua/primitives/web_layout.rs` for override directory selection.
+local demo_env = os.getenv("BOTSTER_DEV") == "1"
+    or os.getenv("BOTSTER_ENV") == "test"
+if demo_env then
+    safe_require("plugins.hello_surface.plugin")
+else
+    log.debug("plugins/hello_surface skipped (BOTSTER_DEV!=1 and BOTSTER_ENV!=test)")
+end
 
 -- Register built-in default MCP prompts. Loaded here so they are available
 -- before user.init runs, allowing users to override them by re-registering

--- a/cli/lua/lib/client.lua
+++ b/cli/lua/lib/client.lua
@@ -252,6 +252,17 @@ function Client:handle_subscribe(msg)
         self:send_workspace_list(sub_id)
         self:send_spawn_target_list(sub_id)
         self:send_hub_recovery_state(sub_id)
+        -- Phase 4a: prime the route registry BEFORE the layout trees so a
+        -- fresh browser knows which surfaces it can route to before it
+        -- receives their trees. The browser store replaces the registry
+        -- wholesale on each frame, so ordering matters only for the first
+        -- render; subsequent mutations flow via hooks.
+        local reg_ok, reg_err = pcall(self.send_ui_route_registry, self, sub_id)
+        if not reg_ok then
+            log.warn(string.format(
+                "send_ui_route_registry failed for %s: %s",
+                self.peer_id:sub(1, 8), tostring(reg_err)))
+        end
         -- Prime Phase 2b layout trees so a fresh subscriber renders
         -- immediately without waiting for the next session_updated.
         -- `force=true` bypasses dedup; this is the only call that does so
@@ -363,9 +374,17 @@ function Client:send_ui_layout_trees(sub_id, opts)
     opts = opts or {}
     local force = opts.force == true
 
+    -- Phase 4a: layout_broadcast iterates `lib.surfaces` and asks each
+    -- surface for its own input via its `input_builder`. We still precompute
+    -- the canonical workspace input here so layout_broadcast can fall back
+    -- to it for the built-in workspace surfaces (which don't declare their
+    -- own input_builder — Phase 2b kept the builder inlined). Passing
+    -- `client = self` additionally lets surfaces that DO declare an
+    -- input_builder thread the per-subscription identity through.
     local input = LayoutInput.build_for_subscription(self, sub_id)
     local frames = LayoutBroadcast.build_frames(input, {
         subscription_key = sub_id,
+        client = self,
         force = force,
     })
     if #frames == 0 then
@@ -377,6 +396,29 @@ function Client:send_ui_layout_trees(sub_id, opts)
     end
     LayoutBroadcast.mark_sent(frames, { subscription_key = sub_id })
     return #frames
+end
+
+--- Send the `ui_route_registry_v1` frame for a HubChannel subscription.
+--
+-- The payload enumerates every registered surface that declares a `path`,
+-- giving the browser's React Router everything it needs to render the
+-- correct surface for an arbitrary hub-scoped URL (e.g. /hubs/:id/plugins/X)
+-- WITHOUT a Rails route edit. Re-broadcast on every `surfaces_changed`
+-- hook firing so a hot-reloaded plugin registering a new surface is
+-- discoverable within the same session.
+-- @param sub_id The subscription ID to send to
+function Client:send_ui_route_registry(sub_id)
+    local ok_surfaces, surfaces_mod = pcall(require, "lib.surfaces")
+    if not ok_surfaces or type(surfaces_mod) ~= "table" then
+        log.warn(string.format(
+            "send_ui_route_registry: surfaces module unavailable: %s",
+            tostring(surfaces_mod)))
+        return
+    end
+    local hub_id = (type(hub) == "table") and hub.server_id and hub.server_id() or nil
+    local payload = surfaces_mod.build_route_registry_payload(hub_id)
+    payload.subscriptionId = sub_id
+    self:send(payload)
 end
 
 --- Send workspace list to a HubChannel subscription.

--- a/cli/lua/lib/layout_broadcast.lua
+++ b/cli/lua/lib/layout_broadcast.lua
@@ -1,18 +1,21 @@
--- Web layout broadcast helper (Phase 2b).
+-- Web layout broadcast helper (Phase 2b + Phase 4a).
 --
--- Wraps `web_layout.render(...)` (Phase 2a) with:
---   1. Two-density expansion — the web has a sidebar and a main panel
---      consuming the same state; this module renders both and returns one
---      frame per target surface.
+-- Wraps `web_layout.render(...)` with:
+--   1. Registry-driven surface expansion — iterates
+--      `lib.surfaces.list()` so every registered surface (workspace_sidebar,
+--      workspace_panel, plugin-authored surfaces) fans out automatically.
+--      Pre-Phase-4a this was a hardcoded two-entry table for the workspace
+--      densities; plugins dropping `surfaces.register(...)` now slot in
+--      without changes here.
 --   2. Version hashing — a pure-Lua fingerprint over the resulting tree JSON
 --      so downstream dedup can skip rebroadcasts when the tree is unchanged.
 --   3. Dedup snapshot — `build_frames` only emits frames whose `version`
 --      differs from the last-sent version for that target surface.
 --
--- Known perf tradeoff (ack'd by orchestrator): two densities broadcast per
--- update. If hub CPU becomes hot with large session lists, we can add
--- per-subscription density selection. For now the hub is viewport-agnostic
--- and the browser picks the matching tree.
+-- Known perf tradeoff (ack'd by orchestrator): every registered surface
+-- is re-rendered per broadcast. Surfaces that don't depend on the session
+-- list can short-circuit in their own render fn; dedup will suppress
+-- unchanged bytes downstream.
 --
 -- The module is pure: no `client:send`. Callers (handlers/connections.lua
 -- and lib/client.lua:send_hub_layout_trees) iterate the returned frames and
@@ -21,19 +24,6 @@
 local state = require("hub.state")
 
 local M = {}
-
--- Maps the logical surface name on the wire -> the state.surface density
--- hint consumed by `web/layout.lua:workspace_surface`. Keeping the map here
--- (rather than in connections.lua) lets tests reason about exactly which
--- frames will fire for a given state.
-local SURFACE_TARGETS = {
-    { target_surface = "workspace_sidebar", density = "sidebar" },
-    { target_surface = "workspace_panel",   density = "panel" },
-}
-
--- Surface name to feed `web_layout.render(...)` — currently a single shared
--- function that switches on `state.surface` for density variation.
-local LAYOUT_SURFACE_NAME = "workspace_surface"
 
 -- Last-sent version per `{subscription_key, target_surface}`. Selection is
 -- per-browser (a click on client A must not flip the selected row on
@@ -104,37 +94,30 @@ end
 -- Frame construction
 -- -------------------------------------------------------------------------
 
---- Build a shallow copy of `state` with `surface` set to the requested
---- density. The Phase-2a layout also looks at other fields
---- (agents/open_workspaces/selected_session_uuid/hub_id) unchanged.
-local function state_with_density(base_state, density)
-    local out = {}
-    for k, v in pairs(base_state) do out[k] = v end
-    out.surface = density
-    return out
-end
-
---- Render one frame for one target surface. Returns a table
---- `{ type, target_surface, tree, version, hub_id }` ready to ship via
---- `client:send(frame)`.
-local function render_one(base_state, entry)
-    local density_state = state_with_density(base_state, entry.density)
-    local tree_json, err = pcall(function()
-        return web_layout.render(LAYOUT_SURFACE_NAME, density_state)
+--- Render one frame for `surface_name` using `surface_state` as input.
+--- Returns a table `{ type, target_surface, tree, version, hub_id }` ready
+--- to ship via `client:send(frame)`, or nil if rendering / decoding failed.
+---
+--- Uses `web_layout.render(surface_name, state)` uniformly so:
+---   * override files (`.botster/layout_web.lua`) keep their precedence
+---   * the embedded `web.layout` module still handles `workspace_surface`
+---     when the workspace wrappers delegate to it
+---   * plugin-registered surfaces fall through to
+---     `_G.surfaces.render_node(...)` via the Rust fallback (Phase 4a).
+local function render_one(surface_name, surface_state)
+    local ok, result_json = pcall(function()
+        return web_layout.render(surface_name, surface_state)
     end)
-    -- pcall with a closure returns (ok, result); remap.
-    local ok = tree_json
-    local result_json = err
     if not ok then
         log.warn(string.format(
             "layout_broadcast: web_layout.render failed for %s: %s",
-            entry.target_surface, tostring(result_json)))
+            surface_name, tostring(result_json)))
         return nil
     end
     if type(result_json) ~= "string" then
         log.warn(string.format(
             "layout_broadcast: render returned %s for %s",
-            type(result_json), entry.target_surface))
+            type(result_json), surface_name))
         return nil
     end
 
@@ -142,7 +125,7 @@ local function render_one(base_state, entry)
     if type(tree) ~= "table" then
         log.warn(string.format(
             "layout_broadcast: tree decode failed for %s: %s",
-            entry.target_surface, tostring(decode_err)))
+            surface_name, tostring(decode_err)))
         return nil
     end
 
@@ -153,10 +136,10 @@ local function render_one(base_state, entry)
 
     return {
         type = "ui_layout_tree_v1",
-        target_surface = entry.target_surface,
+        target_surface = surface_name,
         tree = tree,
         version = version,
-        hub_id = base_state.hub_id,
+        hub_id = (type(surface_state) == "table") and surface_state.hub_id or nil,
     }
 end
 
@@ -179,20 +162,38 @@ local function versions_for(key)
     return bucket
 end
 
---- Build the frame list for a given `AgentWorkspaceSurfaceInputV1`-shaped
---- state. Returns an array of frames that differ from the last-sent version
---- for the given subscription + target surface.
+--- Build the frame list for a hub-channel subscription.
 ---
---- When `opts.force` is true, always emit every frame regardless of dedup.
---- Used for priming new subscribers.
--- @param base_state table Input state (agents, open_workspaces, hub_id, selected_session_uuid, etc.)
--- @param opts table? { force = bool, subscription_key = string }
+--- Iterates every registered surface in `lib.surfaces` and emits one frame
+--- per surface whose rendered tree differs from the last-sent version for
+--- this `(subscription_key, target_surface)` pair.
+---
+--- Input resolution (per surface, in order):
+---   1. If the surface declares an `input_builder(client, sub_id)`, call it.
+---   2. Otherwise, if `opts.client` is set, fall back to
+---      `LayoutInput.build_for_subscription(opts.client, opts.subscription_key)`
+---      — the Phase 2b default for the workspace surfaces.
+---   3. Otherwise (tests / diagnostics), use `base_state` as-is. This is the
+---      path the old two-density test helpers exercise.
+---
+--- When `opts.force` is true, emit every frame regardless of dedup. Used for
+--- priming new subscribers.
+---
+-- @param base_state table Input state (agents, open_workspaces, hub_id, etc.).
+--                         May be nil when opts.client is provided — each
+--                         surface builds its own input in that case.
+-- @param opts table? { force = bool, subscription_key = string, client = any }
 -- @return table array of frames
 function M.build_frames(base_state, opts)
+    if opts == true then
+        -- Legacy API: `build_frames(state, true)` used by older callers /
+        -- tests to force a full emission. Normalise to the modern shape.
+        opts = { force = true }
+    end
     opts = opts or {}
-    local force = opts == true or opts.force == true
+    local force = opts.force == true
 
-    if type(base_state) ~= "table" then
+    if base_state ~= nil and type(base_state) ~= "table" then
         log.warn("layout_broadcast.build_frames: non-table state")
         return {}
     end
@@ -200,12 +201,46 @@ function M.build_frames(base_state, opts)
     local key = resolve_key(opts)
     local bucket = versions_for(key)
 
+    -- Defer the `lib.surfaces` require to call time. Loading it at module
+    -- load would create a circular dependency (surfaces → state → layout,
+    -- layout → surfaces) whenever hot-reload re-evaluates either module.
+    local ok_surfaces, surfaces_mod = pcall(require, "lib.surfaces")
+    if not ok_surfaces or type(surfaces_mod) ~= "table" then
+        log.warn(string.format(
+            "layout_broadcast.build_frames: surfaces module unavailable: %s",
+            tostring(surfaces_mod)))
+        return {}
+    end
+
     local frames = {}
-    for _, entry in ipairs(SURFACE_TARGETS) do
-        local frame = render_one(base_state, entry)
-        if frame then
-            if force or bucket[entry.target_surface] ~= frame.version then
-                frames[#frames + 1] = frame
+    for _, summary in ipairs(surfaces_mod.list()) do
+        local surface_name = summary.name
+        local entry = surfaces_mod.get(surface_name)
+        if entry then
+            local surface_state
+            if entry.input_builder then
+                local ok, built = pcall(entry.input_builder, opts.client, opts.subscription_key)
+                if ok then
+                    surface_state = built
+                else
+                    log.warn(string.format(
+                        "layout_broadcast: input_builder for %s threw: %s",
+                        surface_name, tostring(built)))
+                end
+            elseif opts.client then
+                local LayoutInput = require("lib.layout_input")
+                surface_state = LayoutInput.build_for_subscription(opts.client, opts.subscription_key)
+            else
+                surface_state = base_state
+            end
+
+            if type(surface_state) == "table" then
+                local frame = render_one(surface_name, surface_state)
+                if frame then
+                    if force or bucket[surface_name] ~= frame.version then
+                        frames[#frames + 1] = frame
+                    end
+                end
             end
         end
     end
@@ -249,6 +284,32 @@ function M.forget(subscription_key)
     state.set("layout_broadcast.versions_by_key", versions_by_key)
 end
 
+--- Drop the dedup baselines for `surface_name` across EVERY subscription.
+---
+--- Called when a surface is unregistered so its per-sub version entries
+--- don't accumulate forever. Also guards against the "re-register same
+--- name" footgun: without this, a freshly-registered surface with the
+--- same name would inherit the old surface's cached version hash for
+--- every subscription that ever saw the old tree, and — if the new
+--- tree's hash happened to collide — dedup would silently swallow the
+--- first emission.
+-- @param surface_name string
+-- @return number count of subscription buckets that had an entry removed
+function M.forget_surface(surface_name)
+    if type(surface_name) ~= "string" or surface_name == "" then return 0 end
+    local removed = 0
+    for _, bucket in pairs(versions_by_key) do
+        if bucket[surface_name] ~= nil then
+            bucket[surface_name] = nil
+            removed = removed + 1
+        end
+    end
+    if removed > 0 then
+        state.set("layout_broadcast.versions_by_key", versions_by_key)
+    end
+    return removed
+end
+
 --- Drop the entire dedup cache so the next `build_frames` emits both
 --- densities for every subscription. Used when the input shape changes in a
 --- way the hash cannot detect (e.g. a surface added) or by tests.
@@ -257,12 +318,16 @@ function M.invalidate()
     state.set("layout_broadcast.versions_by_key", versions_by_key)
 end
 
---- Expose the configured target set for introspection (tests).
--- @return table copy of SURFACE_TARGETS
+--- Expose the set of currently registered target surfaces (tests).
+--- Returns a deterministic array `{ target_surface = ... }` mirroring the
+--- ordering produced by `lib.surfaces.list()`.
+-- @return table
 function M.surface_targets()
+    local ok, surfaces_mod = pcall(require, "lib.surfaces")
+    if not ok or type(surfaces_mod) ~= "table" then return {} end
     local out = {}
-    for _, e in ipairs(SURFACE_TARGETS) do
-        out[#out + 1] = { target_surface = e.target_surface, density = e.density }
+    for _, entry in ipairs(surfaces_mod.list()) do
+        out[#out + 1] = { target_surface = entry.name }
     end
     return out
 end

--- a/cli/lua/lib/surfaces.lua
+++ b/cli/lua/lib/surfaces.lua
@@ -1,0 +1,252 @@
+-- Surface registry (Phase 4a) — the Lua-side source of truth for browser
+-- surfaces. A "surface" is the unit the hub composes and ships to browsers:
+--   * it has a stable `name` (the `target_surface` on the wire)
+--   * a `render(state)` function returning a UiNodeV1 table
+--   * optional `path` making it a routable browser page
+--   * optional `input_builder(client, sub_id)` for per-subscription state
+--
+-- Plugins call `surfaces.register(...)` from their own Lua init and the
+-- registration flows through three places automatically:
+--
+--   1. `web_layout.render(name, state)` (Rust primitive) falls back to
+--      `_G.surfaces.render_node(name, state)` when `layout_table[name]` is not
+--      a function — so override files (.botster/layout_web.lua) still win
+--      when they define the same name, but otherwise the Lua registry wins.
+--   2. `lib.layout_broadcast` iterates `surfaces.list()` when building
+--      per-subscription frame lists — every registered surface fans out.
+--   3. `handlers.connections` broadcasts `ui_route_registry_v1` on every
+--      `surfaces_changed` hook firing, so browsers can discover new routes
+--      without a Rails change.
+--
+-- Storage lives in `hub.state` so hot-reload (Lua module reload, `plugin:reload`)
+-- preserves the registry across the reload cycle; the module body is
+-- re-evaluated but the underlying table identity is reused.
+
+local state = require("hub.state")
+
+local M = {}
+
+-- Storage shape:
+--   registry.by_name[name] = {
+--       name, path, label, icon, render, input_builder,
+--       hide_from_nav, order, source,
+--   }
+--   registry.seq — monotonically increasing insertion counter for stable
+--     secondary sort when two surfaces share an `order`.
+local registry = state.get("surfaces.registry", { by_name = {}, seq = 0 })
+if registry.by_name == nil then registry.by_name = {} end
+if registry.seq == nil then registry.seq = 0 end
+
+-- -------------------------------------------------------------------------
+-- Internal helpers
+-- -------------------------------------------------------------------------
+
+local function is_nonempty_string(v)
+    return type(v) == "string" and v ~= ""
+end
+
+local function notify_changed()
+    if type(hooks) == "table" and type(hooks.notify) == "function" then
+        pcall(hooks.notify, "surfaces_changed", { registry = M })
+    end
+end
+
+-- -------------------------------------------------------------------------
+-- Public API
+-- -------------------------------------------------------------------------
+
+--- Register (or replace) a surface.
+--
+-- Replacing an existing registration is intentional — plugin reloads re-call
+-- `register(...)` on the same name, and the registry must end up with the
+-- fresh closure rather than a stale one captured before the reload.
+--
+-- @param name string — wire `target_surface` identifier.
+-- @param opts table — see module doc.
+-- @return the stored entry table (for chaining / tests).
+function M.register(name, opts)
+    assert(is_nonempty_string(name), "surfaces.register: name must be non-empty string")
+    assert(type(opts) == "table", "surfaces.register: opts must be a table")
+    assert(type(opts.render) == "function", "surfaces.register: opts.render must be a function")
+
+    local existing = registry.by_name[name]
+    local seq = existing and existing.seq or (registry.seq + 1)
+    if not existing then registry.seq = seq end
+
+    local entry = {
+        name = name,
+        path = is_nonempty_string(opts.path) and opts.path or nil,
+        label = is_nonempty_string(opts.label) and opts.label or name,
+        icon = is_nonempty_string(opts.icon) and opts.icon or nil,
+        render = opts.render,
+        input_builder = type(opts.input_builder) == "function" and opts.input_builder or nil,
+        hide_from_nav = opts.hide_from_nav == true,
+        order = type(opts.order) == "number" and opts.order or nil,
+        source = is_nonempty_string(opts.source) and opts.source or nil,
+        seq = seq,
+    }
+    registry.by_name[name] = entry
+
+    if log and log.debug then
+        log.debug(string.format(
+            "surfaces.register: name=%s path=%s label=%s",
+            name, tostring(entry.path), tostring(entry.label)))
+    end
+    notify_changed()
+    return entry
+end
+
+--- Remove a previously registered surface.
+-- @param name string
+-- @return true if the entry existed and was removed, false otherwise.
+function M.unregister(name)
+    if not is_nonempty_string(name) then return false end
+    if registry.by_name[name] == nil then return false end
+    registry.by_name[name] = nil
+    if log and log.debug then
+        log.debug(string.format("surfaces.unregister: name=%s", name))
+    end
+    -- Purge the broadcast module's per-subscription dedup baselines for
+    -- this surface. Without this, versions_by_key[sub_id][name] would
+    -- accumulate forever (one entry per subscription that ever saw the
+    -- old tree), AND a re-registration of the same name could be
+    -- silently swallowed by dedup if the new tree's hash matched the
+    -- stale one. Synchronous so the next render in this tick already
+    -- sees a clean baseline. pcall in case lib.layout_broadcast isn't
+    -- loaded (test harnesses that only import surfaces.lua).
+    local ok_broadcast, broadcast = pcall(require, "lib.layout_broadcast")
+    if ok_broadcast and type(broadcast) == "table"
+        and type(broadcast.forget_surface) == "function"
+    then
+        pcall(broadcast.forget_surface, name)
+    end
+    notify_changed()
+    return true
+end
+
+--- Look up a registered surface.
+-- @return the entry table (render fn included) or nil.
+function M.get(name)
+    if not is_nonempty_string(name) then return nil end
+    return registry.by_name[name]
+end
+
+--- Resolve a surface name to its declared path.
+-- @return string path, or nil when the surface is non-routable (no `path`).
+function M.path(name)
+    local entry = M.get(name)
+    return entry and entry.path or nil
+end
+
+--- Return a deterministic array view of the registry.
+--
+-- Sort key: (order asc, seq asc, name asc) — surfaces with an explicit
+-- `order` sort first (lower wins), then registration order, then name. This
+-- keeps the sidebar nav stable across reloads.
+--
+-- Each returned entry is a shallow copy EXCLUDING the render/input_builder
+-- closures — consumers that need those call `surfaces.get(name)` directly.
+-- Stripping closures from `list()` keeps it JSON-safe for the route
+-- registry broadcast path and prevents accidental serialisation of Lua
+-- functions (which `json.encode` would reject).
+function M.list()
+    local out = {}
+    for name, entry in pairs(registry.by_name) do
+        out[#out + 1] = {
+            name = name,
+            path = entry.path,
+            label = entry.label,
+            icon = entry.icon,
+            hide_from_nav = entry.hide_from_nav,
+            order = entry.order,
+            seq = entry.seq,
+            source = entry.source,
+        }
+    end
+    table.sort(out, function(a, b)
+        local ao = a.order or math.huge
+        local bo = b.order or math.huge
+        if ao ~= bo then return ao < bo end
+        if a.seq ~= b.seq then return a.seq < b.seq end
+        return a.name < b.name
+    end)
+    return out
+end
+
+--- Build the `ui_route_registry_v1` payload from the registry.
+--
+-- Only surfaces with a `path` are included — that's the definition of a
+-- routable page. `hide_from_nav` is passed through so the sidebar renderer
+-- can filter at display time; we still ship it in the registry because
+-- React Router needs to know about hidden paths in order to route to them.
+-- @param hub_id string|nil
+-- @return table
+function M.build_route_registry_payload(hub_id)
+    local routes = {}
+    for _, entry in ipairs(M.list()) do
+        if entry.path then
+            routes[#routes + 1] = {
+                path = entry.path,
+                surface = entry.name,
+                label = entry.label,
+                icon = entry.icon,
+                hide_from_nav = entry.hide_from_nav or nil,
+            }
+        end
+    end
+    return {
+        type = "ui_route_registry_v1",
+        hub_id = hub_id,
+        routes = routes,
+    }
+end
+
+--- Rust-facing entry point — called by `web_layout.render(name, state)` when
+--- no override-chain layout table supplies `name`. Returns a UiNodeV1 table
+--- or nil when the surface is not registered.
+---
+--- Errors raised by `render(state)` propagate up so the Rust fallback
+--- wrapper sees them; `web_layout.render` already converts errors to the
+--- error-fallback tree so a broken surface cannot crash the hub.
+function M.render_node(name, render_state)
+    local entry = M.get(name)
+    if not entry then return nil end
+    return entry.render(render_state)
+end
+
+--- Build per-subscription input state for `surface_name`. Uses the
+--- surface's own `input_builder` when provided; otherwise delegates to the
+--- default `LayoutInput.build_for_subscription`. Callers that want the
+--- workspace-shaped `AgentWorkspaceSurfaceInputV1` get it for free; plugin
+--- surfaces that need less can provide a tiny builder.
+--- @param name string
+--- @param client any Client instance (passed to input_builder)
+--- @param sub_id string|nil
+--- @return table input state (ready to hand to render())
+function M.build_input(name, client, sub_id)
+    local entry = M.get(name)
+    if not entry then return nil end
+    if entry.input_builder then
+        return entry.input_builder(client, sub_id)
+    end
+    local LayoutInput = require("lib.layout_input")
+    return LayoutInput.build_for_subscription(client, sub_id)
+end
+
+--- Test-only reset. Production never calls this — hot-reload preserves
+--- state by design.
+function M._reset_for_tests()
+    for k in pairs(registry.by_name) do registry.by_name[k] = nil end
+    registry.seq = 0
+end
+
+-- Hot-reload lifecycle
+function M._before_reload()
+    if log and log.info then log.info("surfaces.lua reloading") end
+end
+
+function M._after_reload()
+    if log and log.info then log.info("surfaces.lua reloaded") end
+end
+
+return M

--- a/cli/lua/plugins/hello_surface/plugin.lua
+++ b/cli/lua/plugins/hello_surface/plugin.lua
@@ -1,0 +1,83 @@
+-- Phase 4a demo plugin — registers a hub-authored surface at
+-- `/plugins/hello` so the end-to-end substrate (surface registry +
+-- ui_route_registry_v1 broadcast + DynamicSurfaceRoute) can be exercised
+-- without any Rails route changes or hand-crafted React components.
+--
+-- ENV GATE (important): this file is only loaded by `hub/init.lua` when
+-- `BOTSTER_DEV=1` OR `BOTSTER_ENV=test`. Production hubs skip it so real
+-- users don't see the demo in their sidebar. If you're writing a real
+-- plugin, do NOT copy this gating pattern — user plugins live under the
+-- device root or a spawn target's repo and are picked up by the
+-- ConfigResolver plugin loader. This file ships as part of the CLI so
+-- dev/test hubs always exercise the substrate; that's the only reason it
+-- sits under `cli/lua/plugins/`.
+--
+-- The spawn-target plugin loader does NOT scan `cli/lua/plugins/` — the
+-- goal here is to ship the demo as part of the CLI itself. A real plugin
+-- author follows the same `surfaces.register(...)` contract regardless of
+-- where their `plugin.lua` lives.
+
+local function build_tree(_state)
+    return ui.stack{
+        direction = "vertical",
+        gap = "3",
+        padding = "4",
+        children = {
+            ui.panel{
+                tone = "default",
+                border = true,
+                children = {
+                    ui.stack{
+                        direction = "vertical",
+                        gap = "2",
+                        children = {
+                            ui.text{
+                                text = "Hello from a plugin-registered surface",
+                                size = "md",
+                                weight = "semibold",
+                            },
+                            ui.text{
+                                text = "This page is rendered by cli/lua/plugins/hello_surface/plugin.lua. "
+                                    .. "It was reachable at /hubs/:hub_id/plugins/hello without a "
+                                    .. "single Rails route, React component, or controller change — "
+                                    .. "the hub broadcasts ui_route_registry_v1 and ui_layout_tree_v1, "
+                                    .. "and the browser mounts a UiTree bound to this surface.",
+                                size = "sm",
+                                tone = "muted",
+                            },
+                            ui.text{
+                                text = "Phase 4a: substrate proven.",
+                                size = "xs",
+                                tone = "accent",
+                                monospace = true,
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+end
+
+-- Surfaces with a simple `input_builder` decouple themselves from the
+-- workspace payload — they don't need `AgentWorkspaceSurfaceInputV1`.
+local function minimal_input(_client, _sub_id)
+    local hub_id = (type(hub) == "table") and hub.server_id and hub.server_id() or nil
+    return { hub_id = hub_id }
+end
+
+local entry = surfaces.register("hello", {
+    path = "/plugins/hello",
+    label = "Hello",
+    icon = "sparkle",
+    order = 1000,
+    source = "plugin:hello_surface",
+    render = build_tree,
+    input_builder = minimal_input,
+})
+
+log.info(string.format(
+    "plugins/hello_surface: registered surface `%s` at %s",
+    entry.name, entry.path))
+
+return true

--- a/cli/lua/web/layout.lua
+++ b/cli/lua/web/layout.lua
@@ -296,15 +296,75 @@ local function session_children(sessions, vm_state)
   return out
 end
 
+-- Phase 4a: compile a list of hub-authored routable surfaces into sidebar
+-- tree_items. Only shown in the sidebar density — the panel surface is the
+-- "current page" body, not a nav host. Entries skip themselves so a surface
+-- doesn't link to itself, and skip `hide_from_nav = true` so plugins can
+-- register routable-but-invisible surfaces (e.g. future `/404`).
+local function nav_tree_items(current_surface_name)
+  local entries = {}
+  local ok, surfaces_mod = pcall(require, "lib.surfaces")
+  if not ok or type(surfaces_mod) ~= "table" then return entries end
+  for _, entry in ipairs(surfaces_mod.list()) do
+    if entry.path and not entry.hide_from_nav and entry.name ~= current_surface_name then
+      local title_nodes = {
+        ui.text{
+          text = entry.label or entry.name,
+          size = "xs",
+          tone = "muted",
+          weight = "medium",
+          truncate = true,
+        },
+      }
+      local start_nodes = nil
+      if entry.icon then
+        start_nodes = {
+          ui.icon{ name = entry.icon, size = "xs", tone = "muted" },
+        }
+      end
+      local item_args = {
+        id = "nav:" .. entry.name,
+        action = ui.action("botster.nav.open", { path = entry.path }),
+        title = title_nodes,
+      }
+      if start_nodes then item_args.start = start_nodes end
+      entries[#entries + 1] = ui.tree_item(item_args)
+    end
+  end
+  return entries
+end
+
+-- Build the sidebar body; separating this lets the empty-state path still
+-- append nav entries so a fresh hub with no sessions still exposes plugin
+-- surfaces. Returns a UiNodeV1 or nil when there's nothing to render.
+local function sidebar_nav_section(current_surface_name)
+  local items = nav_tree_items(current_surface_name)
+  if #items == 0 then return nil end
+  return ui.tree{ children = items }
+end
+
 -- -------------------------------------------------------------------------
 -- Surface entry points
 -- -------------------------------------------------------------------------
 
 function M.workspace_surface(state)
   local vm_state = vm.build(state)
+  local is_sidebar = vm_state.density == "sidebar"
+  -- The density `"sidebar"` matches the workspace_sidebar registered
+  -- surface; the workspace_panel uses `"panel"` and should not show nav.
+  local current_name = is_sidebar and "workspace_sidebar" or "workspace_panel"
+  local nav_section = is_sidebar and sidebar_nav_section(current_name) or nil
 
   if vm_state.empty then
-    return empty_state_tree(vm_state.density)
+    local body = empty_state_tree(vm_state.density)
+    if nav_section then
+      return ui.stack{
+        direction = "vertical",
+        gap = "2",
+        children = { body, nav_section },
+      }
+    end
+    return body
   end
 
   local tree_children = {}
@@ -330,14 +390,20 @@ function M.workspace_surface(state)
 
   -- WorkspaceList.jsx wraps the groups/rows in a flat div and appends the
   -- NewSession button as a sibling. We mirror that with a vertical stack
-  -- containing the tree and the button.
+  -- containing the tree and the button. Phase 4a: in the sidebar density
+  -- we additionally append a nav section listing every routable surface
+  -- registered via `lib.surfaces` (plugin-authored + workspace_panel).
+  local children = {
+    ui.tree{ children = tree_children },
+    new_session_button(),
+  }
+  if nav_section then
+    children[#children + 1] = nav_section
+  end
   return ui.stack{
     direction = "vertical",
-    gap = vm_state.density == "sidebar" and "0" or "2",
-    children = {
-      ui.tree{ children = tree_children },
-      new_session_button(),
-    },
+    gap = is_sidebar and "0" or "2",
+    children = children,
   }
 end
 

--- a/cli/src/lua/primitives/web_layout.rs
+++ b/cli/src/lua/primitives/web_layout.rs
@@ -165,16 +165,31 @@ pub fn reload(lua: &Lua) -> Result<()> {
 
 /// Core render pipeline: resolve the layout table, look up the surface
 /// function, call it with the state, and serialise the resulting node.
+///
+/// Resolution order:
+///   1. Override/embedded layout table (existing Phase 2a behaviour). Any
+///      file that defines `layout_table[surface_name]` as a function wins.
+///   2. Phase 4a: `_G.surfaces.render_node(surface_name, state)`. This is
+///      the hook plugins use to ship new surfaces without touching the
+///      override-file chain. When `surfaces` is not registered or does not
+///      know the surface, this returns nil and we fall through to the
+///      error path.
+///
+/// The fall-through from (1) to (2) happens whenever the layout table
+/// lookup yields a non-function (including nil); override files that want
+/// to shadow a plugin-registered surface just define the name, even if the
+/// function they define is a thin wrapper around `surfaces.render_node`.
 fn render_surface(lua: &Lua, surface_name: &str, state: Value) -> Result<String> {
     let layout_table = resolve_layout_table(lua)?;
 
-    let surface_fn: Function = layout_table
-        .get(surface_name)
-        .map_err(|e| anyhow!("layout table has no surface `{surface_name}`: {e}"))?;
+    let returned = call_layout_table_surface(&layout_table, surface_name, state.clone())?
+        .or_else(|| call_surfaces_registry_fallback(lua, surface_name, state));
 
-    let returned: Value = surface_fn
-        .call(state)
-        .map_err(|e| anyhow!("surface `{surface_name}` raised: {e}"))?;
+    let Some(returned) = returned else {
+        return Err(anyhow!(
+            "no layout surface registered for `{surface_name}` (checked layout table + surfaces registry)"
+        ));
+    };
 
     let node: UiNodeV1 = lua
         .from_value(returned)
@@ -182,6 +197,58 @@ fn render_surface(lua: &Lua, surface_name: &str, state: Value) -> Result<String>
 
     serde_json::to_string(&node)
         .map_err(|e| anyhow!("failed to serialise UiNodeV1 for `{surface_name}`: {e}"))
+}
+
+/// Look up `surface_name` in the resolved layout table and call it with the
+/// given state when the lookup yields a function. Returns `Ok(None)` when
+/// the layout table has no such entry (or the entry is not callable) — the
+/// caller then consults the surfaces registry.
+fn call_layout_table_surface(
+    layout_table: &Table,
+    surface_name: &str,
+    state: Value,
+) -> Result<Option<Value>> {
+    let candidate: Value = layout_table
+        .get(surface_name)
+        .map_err(|e| anyhow!("layout table lookup for `{surface_name}` failed: {e}"))?;
+    match candidate {
+        Value::Function(f) => {
+            let returned = f
+                .call(state)
+                .map_err(|e| anyhow!("surface `{surface_name}` raised: {e}"))?;
+            Ok(Some(returned))
+        }
+        _ => Ok(None),
+    }
+}
+
+/// Fallback to the Phase-4a Lua-side surface registry (`_G.surfaces`). Any
+/// failure (no surfaces global, no `render_node`, registry has no such
+/// surface, or the registered render function raised) is logged and
+/// resolves to `None` so the caller emits the error fallback tree.
+fn call_surfaces_registry_fallback(
+    lua: &Lua,
+    surface_name: &str,
+    state: Value,
+) -> Option<Value> {
+    let surfaces: Table = match lua.globals().get("surfaces") {
+        Ok(Value::Table(t)) => t,
+        _ => return None,
+    };
+    let render_node: Function = match surfaces.get("render_node") {
+        Ok(Value::Function(f)) => f,
+        _ => return None,
+    };
+    match render_node.call::<Value>((surface_name.to_string(), state)) {
+        Ok(Value::Nil) => None,
+        Ok(v) => Some(v),
+        Err(err) => {
+            log::warn!(
+                "web_layout.render: surfaces.render_node for `{surface_name}` raised: {err}"
+            );
+            None
+        }
+    }
 }
 
 /// Process-wide cache of the last successful override-chain scan.

--- a/cli/tests/ui_layout_transport_test.rs
+++ b/cli/tests/ui_layout_transport_test.rs
@@ -133,6 +133,10 @@ fn install_lua_stubs(lua: &Lua) {
 /// - `package.path` pointing at `cli/lua/` so `require("lib.*")` finds the
 ///   shipped modules
 /// - stubs for runtime globals the shipped code expects to find pre-installed
+/// - the Phase 4a surface registry with the two workspace surfaces wired in
+///   via `hub.builtin_surfaces`, matching the production bootstrap in
+///   `hub/init.lua`. Tests that assert two-density behavior rely on these
+///   registrations; dropping them would break the Phase-2b dedup semantics.
 fn new_test_lua() -> Lua {
     let lua = Lua::new();
     register_ui_contract(&lua).expect("register ui_contract");
@@ -151,6 +155,20 @@ fn new_test_lua() -> Lua {
 
     // Reset per-test global caches.
     web_layout::_clear_override_cache_for_tests();
+
+    // Phase 4a: load the surface registry and register the workspace
+    // surfaces so `lib.layout_broadcast` has something to iterate over.
+    // Matches `cli/lua/hub/init.lua` lines that install `_G.surfaces` and
+    // require `hub.builtin_surfaces`.
+    lua.load(
+        r#"
+        _G.surfaces = require("lib.surfaces")
+        _G.surfaces._reset_for_tests()
+        require("hub.builtin_surfaces")
+        "#,
+    )
+    .exec()
+    .expect("install surfaces + builtin_surfaces");
 
     lua
 }

--- a/cli/tests/ui_surface_registry_test.rs
+++ b/cli/tests/ui_surface_registry_test.rs
@@ -1,0 +1,785 @@
+//! Phase 4a — `lib.surfaces` registry tests + multi-surface broadcast
+//! integration tests.
+//!
+//! Covers:
+//!   1. `surfaces.register/unregister/list/get/path` Lua API.
+//!   2. `web_layout.render(surface_name, state)` falling back to
+//!      `surfaces.render_node` when the layout table has no entry.
+//!   3. `lib.layout_broadcast.build_frames` iterating the registry and
+//!      producing one frame per registered surface, deduped per
+//!      `(subscription_key, surface_name)`.
+//!   4. `surfaces.build_route_registry_payload` shape assertions.
+//!
+//! Run with: `./test.sh -- ui_surface_registry` from `cli/`.
+//
+// Rust guideline compliant 2026-04-20
+
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::missing_docs_in_private_items,
+    clippy::needless_raw_string_hashes,
+    clippy::match_single_binding,
+    clippy::ignored_unit_patterns,
+    clippy::redundant_closure_for_method_calls,
+    reason = "test-code brevity"
+)]
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use botster::lua::primitives::web_layout;
+use botster::ui_contract::lua::register as register_ui_contract;
+use mlua::{Lua, Table, Value};
+
+/// Global lock to serialise tests that mutate process env (the `web_layout`
+/// primitive reads `BOTSTER_CONFIG_DIR` / `BOTSTER_WEB_LAYOUT_REPO_DIR`).
+static RENDER_LOCK: Mutex<()> = Mutex::new(());
+
+fn cli_manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+fn lua_src_dir() -> PathBuf {
+    cli_manifest_dir().join("lua")
+}
+
+fn install_lua_stubs(lua: &Lua) {
+    let globals = lua.globals();
+
+    let log_tbl = lua.create_table().unwrap();
+    for name in ["debug", "info", "warn", "error"] {
+        let f = lua.create_function(|_, _: Value| Ok(())).unwrap();
+        log_tbl.set(name, f).unwrap();
+    }
+    globals.set("log", log_tbl).unwrap();
+
+    let hub_tbl = lua.create_table().unwrap();
+    let server_id = lua.create_function(|_, _: ()| Ok("hub-test")).unwrap();
+    hub_tbl.set("server_id", server_id).unwrap();
+    globals.set("hub", hub_tbl).unwrap();
+
+    // Simple in-memory hooks stub: `hooks.notify` is a no-op so surfaces.lua
+    // doesn't need a live hub event bus for these tests; the bus itself is
+    // covered by the layout_transport tests. We keep a counter visible
+    // through a global so tests can assert `surfaces_changed` fired.
+    let hooks_tbl: Table = lua
+        .load(
+            r#"
+            local h = { notify_count = {}, fired = {} }
+            function h.call(_event, payload) return payload end
+            function h.notify(event, payload)
+                h.notify_count[event] = (h.notify_count[event] or 0) + 1
+                h.fired[#h.fired + 1] = { event = event, payload = payload }
+            end
+            function h.on(_event, _name, _fn) end
+            function h.off(_event, _name) end
+            return h
+            "#,
+        )
+        .eval()
+        .unwrap();
+    globals.set("hooks", hooks_tbl).unwrap();
+
+    let state_tbl: Table = lua
+        .load(
+            r#"
+            local M = {}
+            local store = {}
+            function M.get(key, default)
+                if store[key] == nil then store[key] = default end
+                return store[key]
+            end
+            function M.set(key, value) store[key] = value end
+            function M.class(_name) return {} end
+            function M.clear(key) store[key] = nil end
+            return M
+            "#,
+        )
+        .eval()
+        .unwrap();
+    globals.set("state", state_tbl).unwrap();
+}
+
+fn new_test_lua() -> Lua {
+    let lua = Lua::new();
+    register_ui_contract(&lua).expect("register ui_contract");
+    web_layout::register(&lua).expect("register web_layout");
+    botster::lua::primitives::json::register(&lua).expect("register json");
+
+    install_lua_stubs(&lua);
+
+    let dir = lua_src_dir();
+    let code = format!(
+        "package.path = \"{dir}/?.lua;{dir}/?/init.lua;\" .. package.path",
+        dir = dir.display()
+    );
+    lua.load(&code).exec().expect("update package.path");
+
+    web_layout::_clear_override_cache_for_tests();
+
+    // Load the registry module and expose it as _G.surfaces so the Rust
+    // fallback in web_layout.rs finds it. Matches the production wiring in
+    // hub/init.lua where `_G.surfaces = safe_require("lib.surfaces")`.
+    lua.load(
+        r#"
+        _G.surfaces = require("lib.surfaces")
+        _G.surfaces._reset_for_tests()
+        "#,
+    )
+    .exec()
+    .expect("install _G.surfaces");
+
+    lua
+}
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    let guard = RENDER_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    // SAFETY: Rust 2024 requires `unsafe` for env mutation; serialised by
+    // RENDER_LOCK so parallel tests cannot observe a half-set state.
+    unsafe {
+        std::env::set_var(
+            "BOTSTER_WEB_LAYOUT_REPO_DIR",
+            "/tmp/botster-nonexistent-ui-surface-registry",
+        );
+        std::env::set_var(
+            "BOTSTER_CONFIG_DIR",
+            "/tmp/botster-nonexistent-ui-surface-registry",
+        );
+        std::env::remove_var("BOTSTER_DEV");
+    }
+    guard
+}
+
+// -------------------------------------------------------------------------
+// surfaces.lua API
+// -------------------------------------------------------------------------
+
+#[test]
+fn surfaces_register_stores_entry_and_list_returns_it() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (name, path, label, icon, list_len): (String, String, String, String, i64) = lua
+        .load(
+            r#"
+            surfaces.register("hello", {
+                path = "/plugins/hello",
+                label = "Hello",
+                icon = "sparkle",
+                render = function(_state) return { type = "panel", props = { title = "hi" } } end,
+            })
+            local all = surfaces.list()
+            local entry = all[1]
+            return entry.name, entry.path, entry.label, entry.icon, #all
+            "#,
+        )
+        .eval()
+        .expect("register + list");
+
+    assert_eq!(name, "hello");
+    assert_eq!(path, "/plugins/hello");
+    assert_eq!(label, "Hello");
+    assert_eq!(icon, "sparkle");
+    assert_eq!(list_len, 1);
+}
+
+#[test]
+fn surfaces_list_is_deterministically_ordered() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let ordered: Vec<String> = lua
+        .load(
+            r#"
+            -- mix ordered and unordered entries, out of alphabetical order
+            surfaces.register("zeta", {
+                render = function() return {type="panel", props={}} end,
+                order = 10,
+            })
+            surfaces.register("alpha", {
+                render = function() return {type="panel", props={}} end,
+                order = 10,  -- same order as zeta, should fall back to seq
+            })
+            surfaces.register("middle", {
+                render = function() return {type="panel", props={}} end,
+                order = 5,
+            })
+            surfaces.register("last", {
+                render = function() return {type="panel", props={}} end,
+                -- no order = math.huge
+            })
+            local out = {}
+            for _, e in ipairs(surfaces.list()) do
+                out[#out + 1] = e.name
+            end
+            return out
+            "#,
+        )
+        .eval()
+        .expect("list order");
+
+    // Expected: order=5 (middle) < order=10 (zeta seq=1, alpha seq=2) < no-order (last).
+    assert_eq!(ordered, vec!["middle", "zeta", "alpha", "last"]);
+}
+
+#[test]
+fn surfaces_unregister_removes_entry() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (before, after, get_after): (i64, i64, Value) = lua
+        .load(
+            r#"
+            surfaces.register("tmp", {
+                render = function() return {type="panel", props={}} end,
+            })
+            local b = #surfaces.list()
+            local removed = surfaces.unregister("tmp")
+            assert(removed == true, "unregister should return true for existing")
+            local a = #surfaces.list()
+            return b, a, surfaces.get("tmp")
+            "#,
+        )
+        .eval()
+        .expect("unregister");
+
+    assert_eq!(before, 1);
+    assert_eq!(after, 0);
+    assert!(matches!(get_after, Value::Nil));
+}
+
+#[test]
+fn surfaces_path_resolves_registered_path() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let path: String = lua
+        .load(
+            r#"
+            surfaces.register("routed", {
+                path = "/foo/bar",
+                render = function() return {type="panel", props={}} end,
+            })
+            return surfaces.path("routed")
+            "#,
+        )
+        .eval()
+        .expect("path");
+
+    assert_eq!(path, "/foo/bar");
+}
+
+#[test]
+fn surfaces_changed_hook_fires_on_register_and_unregister() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (after_register, after_unregister): (i64, i64) = lua
+        .load(
+            r#"
+            surfaces.register("a", {
+                render = function() return {type="panel", props={}} end,
+            })
+            local after_register = hooks.notify_count["surfaces_changed"] or 0
+            surfaces.unregister("a")
+            local after_unregister = hooks.notify_count["surfaces_changed"] or 0
+            return after_register, after_unregister
+            "#,
+        )
+        .eval()
+        .expect("hooks.notify fires");
+
+    assert_eq!(after_register, 1, "register should fire surfaces_changed once");
+    assert_eq!(
+        after_unregister, 2,
+        "unregister should fire surfaces_changed once more"
+    );
+}
+
+// -------------------------------------------------------------------------
+// web_layout.render falls back to surfaces.render_node
+// -------------------------------------------------------------------------
+
+#[test]
+fn web_layout_render_falls_back_to_surfaces_registry() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // The embedded `web.layout` has no "custom" entry, and we're using the
+    // empty override directory — so the only path to a tree is the Phase
+    // 4a fallback into _G.surfaces.render_node.
+    let json: String = lua
+        .load(
+            r#"
+            surfaces.register("custom_demo", {
+                render = function(state)
+                    return {
+                        type = "panel",
+                        props = { title = "demo", customValue = state.echo or "missing" },
+                    }
+                end,
+            })
+            return web_layout.render("custom_demo", { echo = "from-state" })
+            "#,
+        )
+        .eval()
+        .expect("render custom surface");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+    let ty = parsed.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(ty, "panel", "fallback should render the registered tree");
+    let title = parsed
+        .pointer("/props/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert_eq!(title, "demo");
+    let custom = parsed
+        .pointer("/props/customValue")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert_eq!(
+        custom, "from-state",
+        "state should flow through the registered render fn"
+    );
+}
+
+#[test]
+fn web_layout_render_missing_surface_returns_error_fallback() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let json: String = lua
+        .load(r#"return web_layout.render("nope_not_registered", {})"#)
+        .eval()
+        .expect("render missing surface");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+    let title = parsed
+        .pointer("/props/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        title.contains("Layout error"),
+        "missing surface must yield the error-fallback tree; got title={title}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Multi-surface broadcast: layout_broadcast iterates the registry
+// -------------------------------------------------------------------------
+
+#[test]
+fn layout_broadcast_emits_one_frame_per_registered_surface() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let names: Vec<String> = lua
+        .load(
+            r#"
+            -- Only register lightweight non-workspace surfaces so we don't
+            -- need the full AgentWorkspaceSurfaceInputV1 fixture here. Each
+            -- supplies its own input_builder that returns a trivial state.
+            surfaces.register("alpha", {
+                path = "/alpha",
+                render = function(s) return {type="panel", props={title="alpha", h=s.hub_id or "?"}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+                order = 1,
+            })
+            surfaces.register("beta", {
+                path = "/beta",
+                render = function(s) return {type="panel", props={title="beta", h=s.hub_id or "?"}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+                order = 2,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+            local frames = LayoutBroadcast.build_frames(nil, {
+                force = true,
+                subscription_key = "sub-alpha",
+            })
+            local out = {}
+            for _, f in ipairs(frames) do out[#out + 1] = f.target_surface end
+            return out
+            "#,
+        )
+        .eval()
+        .expect("build frames");
+
+    assert_eq!(names, vec!["alpha", "beta"]);
+}
+
+#[test]
+fn layout_broadcast_dedups_per_subscription_per_surface() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (first_len, second_len): (i64, i64) = lua
+        .load(
+            r#"
+            surfaces.register("alpha", {
+                render = function(s) return {type="panel", props={title="alpha", hub=s.hub_id or "?"}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+            })
+            surfaces.register("beta", {
+                render = function(s) return {type="panel", props={title="beta", hub=s.hub_id or "?"}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+
+            local f1 = LayoutBroadcast.build_frames(nil, { subscription_key = "s1" })
+            LayoutBroadcast.mark_sent(f1, { subscription_key = "s1" })
+            local f2 = LayoutBroadcast.build_frames(nil, { subscription_key = "s1" })
+            return #f1, #f2
+            "#,
+        )
+        .eval()
+        .expect("dedup");
+
+    assert_eq!(first_len, 2, "first emission must emit both surfaces");
+    assert_eq!(
+        second_len, 0,
+        "identical second emission must dedup to zero"
+    );
+}
+
+#[test]
+fn unregister_purges_per_subscription_dedup_baselines() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (before_removed, after_removed, stale_present_after_reregister): (i64, i64, bool) = lua
+        .load(
+            r#"
+            surfaces.register("alpha", {
+                render = function() return {type="panel", props={title="alpha-v1"}} end,
+                input_builder = function() return { hub_id = "hub-test" } end,
+            })
+            surfaces.register("beta", {
+                render = function() return {type="panel", props={title="beta-v1"}} end,
+                input_builder = function() return { hub_id = "hub-test" } end,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+
+            -- Seed dedup baselines for TWO subscriptions so we exercise the
+            -- "across every subscription" contract on forget_surface.
+            local f_a = LayoutBroadcast.build_frames(nil, { subscription_key = "sub-A" })
+            LayoutBroadcast.mark_sent(f_a, { subscription_key = "sub-A" })
+            local f_b = LayoutBroadcast.build_frames(nil, { subscription_key = "sub-B" })
+            LayoutBroadcast.mark_sent(f_b, { subscription_key = "sub-B" })
+
+            -- Sanity: both subs now have a baseline for "alpha".
+            assert(LayoutBroadcast.last_version("alpha", { subscription_key = "sub-A" }) ~= nil)
+            assert(LayoutBroadcast.last_version("alpha", { subscription_key = "sub-B" }) ~= nil)
+
+            -- Unregister "alpha". surfaces.unregister should delegate to
+            -- layout_broadcast.forget_surface, purging both subs' entries.
+            surfaces.unregister("alpha")
+
+            local alpha_a_gone = LayoutBroadcast.last_version("alpha", { subscription_key = "sub-A" }) == nil
+            local alpha_b_gone = LayoutBroadcast.last_version("alpha", { subscription_key = "sub-B" }) == nil
+            -- Beta should be untouched (unregister only purges the named surface).
+            local beta_still_cached = LayoutBroadcast.last_version("beta", { subscription_key = "sub-A" }) ~= nil
+            assert(beta_still_cached, "beta's baseline must survive alpha's unregister")
+
+            local before_removed = (alpha_a_gone and alpha_b_gone) and 2 or 0
+
+            -- Re-register "alpha" with a deliberately identical tree to
+            -- reproduce the "stale hash collision" footgun: if forget_surface
+            -- didn't run, this render's hash would match the stale baseline
+            -- and dedup would swallow the frame.
+            surfaces.register("alpha", {
+                render = function() return {type="panel", props={title="alpha-v1"}} end,
+                input_builder = function() return { hub_id = "hub-test" } end,
+            })
+            local f2 = LayoutBroadcast.build_frames(nil, { subscription_key = "sub-A" })
+
+            local saw_alpha = false
+            for _, frame in ipairs(f2) do
+                if frame.target_surface == "alpha" then saw_alpha = true end
+            end
+            -- Key assertion: re-register + identical tree must re-emit
+            -- because the forget_surface call zeroed the baseline.
+            return before_removed, 0, not saw_alpha
+            "#,
+        )
+        .eval()
+        .expect("unregister purges dedup");
+
+    assert_eq!(
+        before_removed, 2,
+        "alpha's dedup baseline must be cleared from both subscription buckets"
+    );
+    assert_eq!(after_removed, 0, "trivially zero (keeps return shape 3-tuple)");
+    assert!(
+        !stale_present_after_reregister,
+        "re-registering alpha with an identical tree must re-emit; stale baseline was not purged"
+    );
+}
+
+#[test]
+fn layout_broadcast_reemits_when_one_surface_changes() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (first_len, second_surfaces): (i64, Vec<String>) = lua
+        .load(
+            r#"
+            local tick = 0
+            surfaces.register("stable", {
+                render = function() return {type="panel", props={title="stable"}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+            })
+            surfaces.register("changing", {
+                render = function() return {type="panel", props={title="changing-" .. tostring(tick)}} end,
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+
+            local f1 = LayoutBroadcast.build_frames(nil, { subscription_key = "s1" })
+            LayoutBroadcast.mark_sent(f1, { subscription_key = "s1" })
+            tick = 1  -- changing render now produces a different tree
+            local f2 = LayoutBroadcast.build_frames(nil, { subscription_key = "s1" })
+
+            local names = {}
+            for _, f in ipairs(f2) do names[#names + 1] = f.target_surface end
+            return #f1, names
+            "#,
+        )
+        .eval()
+        .expect("partial re-emit");
+
+    assert_eq!(first_len, 2, "first emission must emit both surfaces");
+    assert_eq!(
+        second_surfaces,
+        vec!["changing"],
+        "only the changed surface should re-emit; stable must dedup"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Route registry payload
+// -------------------------------------------------------------------------
+
+#[test]
+fn route_registry_payload_includes_routable_surfaces_and_excludes_pathless() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let json: String = lua
+        .load(
+            r#"
+            surfaces.register("workspace_sidebar", {
+                render = function() return {type="panel", props={}} end,
+                -- no path: internal/non-routed surface
+            })
+            surfaces.register("workspace_panel", {
+                path = "/",
+                label = "Hub",
+                icon = "home",
+                render = function() return {type="panel", props={}} end,
+                order = 0,
+            })
+            surfaces.register("hello", {
+                path = "/plugins/hello",
+                label = "Hello",
+                icon = "sparkle",
+                render = function() return {type="panel", props={}} end,
+                order = 1000,
+            })
+            local payload = surfaces.build_route_registry_payload("hub-test")
+            return json.encode(payload)
+            "#,
+        )
+        .eval()
+        .expect("build route registry payload");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse JSON");
+    assert_eq!(parsed.get("type").and_then(|v| v.as_str()), Some("ui_route_registry_v1"));
+    assert_eq!(parsed.get("hub_id").and_then(|v| v.as_str()), Some("hub-test"));
+    let routes = parsed.get("routes").and_then(|v| v.as_array()).expect("routes array");
+    let paths: Vec<&str> = routes
+        .iter()
+        .filter_map(|r| r.get("path").and_then(|v| v.as_str()))
+        .collect();
+    assert_eq!(paths, vec!["/", "/plugins/hello"]);
+
+    // workspace_sidebar had no path, so it must NOT appear.
+    let surfaces: Vec<&str> = routes
+        .iter()
+        .filter_map(|r| r.get("surface").and_then(|v| v.as_str()))
+        .collect();
+    assert!(!surfaces.contains(&"workspace_sidebar"));
+}
+
+// -------------------------------------------------------------------------
+// F1: demo plugin env gate
+// -------------------------------------------------------------------------
+//
+// The `plugins/hello_surface/plugin.lua` file is loaded by `hub/init.lua`
+// only when BOTSTER_DEV=1 OR BOTSTER_ENV=test. These tests exercise both
+// legs of the gate by evaluating the same Lua predicate + safe_require
+// block that init.lua uses, then asserting on the resulting registry.
+
+/// Run `body` with `BOTSTER_DEV` and `BOTSTER_ENV` set to the given
+/// values (or removed when `None`). Restores the previous values on drop.
+fn with_demo_env<F: FnOnce()>(dev: Option<&str>, env: Option<&str>, body: F) {
+    let prev_dev = std::env::var("BOTSTER_DEV").ok();
+    let prev_env = std::env::var("BOTSTER_ENV").ok();
+    // SAFETY: env-var mutation is serialised by RENDER_LOCK (held by the
+    // caller via lock_env()) so no other thread can observe a half-set
+    // state. Single-thread visibility is sufficient for Rust 2024's
+    // set_var/remove_var invariant.
+    unsafe {
+        match dev {
+            Some(v) => std::env::set_var("BOTSTER_DEV", v),
+            None => std::env::remove_var("BOTSTER_DEV"),
+        }
+        match env {
+            Some(v) => std::env::set_var("BOTSTER_ENV", v),
+            None => std::env::remove_var("BOTSTER_ENV"),
+        }
+    }
+    body();
+    // SAFETY: same as the block above — still inside the RENDER_LOCK
+    // held by the caller, so the restore is single-threaded.
+    unsafe {
+        match prev_dev {
+            Some(v) => std::env::set_var("BOTSTER_DEV", v),
+            None => std::env::remove_var("BOTSTER_DEV"),
+        }
+        match prev_env {
+            Some(v) => std::env::set_var("BOTSTER_ENV", v),
+            None => std::env::remove_var("BOTSTER_ENV"),
+        }
+    }
+}
+
+/// Emulate `hub/init.lua`'s demo-plugin gate + safe_require. Returns true
+/// iff the surface ended up registered.
+const DEMO_GATE_LUA: &str = r#"
+    local demo_env = os.getenv("BOTSTER_DEV") == "1"
+        or os.getenv("BOTSTER_ENV") == "test"
+    if demo_env then
+        require("plugins.hello_surface.plugin")
+    end
+    return surfaces.get("hello") ~= nil
+"#;
+
+#[test]
+fn demo_plugin_registered_when_botster_dev_set() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(Some("1"), None, || {
+        let registered: bool = lua
+            .load(DEMO_GATE_LUA)
+            .eval()
+            .expect("demo gate with BOTSTER_DEV=1");
+        assert!(
+            registered,
+            "BOTSTER_DEV=1 must load the demo and register `hello`"
+        );
+    });
+}
+
+#[test]
+fn demo_plugin_registered_when_botster_env_test() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let registered: bool = lua
+            .load(DEMO_GATE_LUA)
+            .eval()
+            .expect("demo gate with BOTSTER_ENV=test");
+        assert!(
+            registered,
+            "BOTSTER_ENV=test must load the demo and register `hello`"
+        );
+    });
+}
+
+#[test]
+fn demo_plugin_skipped_when_neither_env_var_set() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, None, || {
+        let registered: bool = lua
+            .load(DEMO_GATE_LUA)
+            .eval()
+            .expect("demo gate with no env vars");
+        assert!(
+            !registered,
+            "without BOTSTER_DEV / BOTSTER_ENV=test the demo must NOT register"
+        );
+    });
+}
+
+#[test]
+fn demo_plugin_skipped_when_production_like_env_vars_set() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Hostile production-like values — neither matches the gate.
+    with_demo_env(Some("0"), Some("production"), || {
+        let registered: bool = lua
+            .load(DEMO_GATE_LUA)
+            .eval()
+            .expect("demo gate with production-like env");
+        assert!(
+            !registered,
+            "BOTSTER_DEV=0, BOTSTER_ENV=production must NOT register the demo"
+        );
+    });
+}
+
+#[test]
+fn route_registry_includes_hide_from_nav_entries_with_flag() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let payload_json: String = lua
+        .load(
+            r#"
+            surfaces.register("visible", {
+                path = "/visible",
+                render = function() return {type="panel", props={}} end,
+            })
+            surfaces.register("hidden", {
+                path = "/hidden",
+                hide_from_nav = true,
+                render = function() return {type="panel", props={}} end,
+            })
+            return json.encode(surfaces.build_route_registry_payload("hub-test"))
+            "#,
+        )
+        .eval()
+        .expect("route registry with hide_from_nav");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&payload_json).expect("parse registry JSON");
+    let routes = parsed.get("routes").and_then(|v| v.as_array()).unwrap();
+    // Both present; filter happens at sidebar render time, not here — the
+    // registry is the authoritative list of routable paths.
+    assert_eq!(routes.len(), 2);
+    let pairs: Vec<(String, bool)> = routes
+        .iter()
+        .map(|r| {
+            let name = r.get("surface").and_then(|v| v.as_str()).unwrap_or("").to_string();
+            let hidden = r
+                .get("hide_from_nav")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            (name, hidden)
+        })
+        .collect();
+    assert!(pairs.contains(&("visible".to_string(), false)));
+    assert!(pairs.contains(&("hidden".to_string(), true)));
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,11 +65,13 @@ Rails.application.routes.draw do
   # SPA frontend routes — React Router handles navigation
   root to: "spa#home"
 
-  # SPA catch-all for frontend paths that React Router manages.
+  # SPA catch-all for frontend paths that React Router manages. React
+  # Router decides whether the path corresponds to a hub-authored surface
+  # (via the ui_route_registry_v1 broadcast) or a static Rails-hosted page;
+  # Rails only has to serve the SPA shell for any `/hubs/:hub_id/...` URL,
+  # so plugins can ship new browser routes without editing this file.
   # Must be after all API/auth routes to avoid intercepting them.
-  get "/hubs/:hub_id/sessions/*path", to: "spa#hub", as: nil
-  get "/hubs/:hub_id/settings", to: "spa#hub", as: nil
-  get "/hubs/:hub_id/pairing", to: "spa#hub", as: nil
+  get "/hubs/:hub_id/*path", to: "spa#hub", as: :spa_hub
 
   # PWA
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest

--- a/test/controllers/spa_controller_test.rb
+++ b/test/controllers/spa_controller_test.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Phase 4a: the /hubs/:hub_id/... routing collapsed from three enumerated
+# Rails routes (sessions/settings/pairing) to a single wildcard that lets
+# React Router decide which hub-authored surface to mount. These tests lock
+# the collapse: arbitrary plugin-authored paths must dispatch to spa#hub
+# without a 404, and the legacy paths must still resolve through the same
+# catch-all.
+class SpaControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:primary_user)
+    @active_hub = hubs(:active_hub)
+  end
+
+  test "wildcard hub route dispatches to spa#hub for an arbitrary plugin path" do
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/plugins/hello"
+    assert_response :success
+    assert_select "#app"
+  end
+
+  test "wildcard hub route handles deeper plugin paths" do
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/plugins/custom-thing/nested/segment"
+    assert_response :success
+    assert_select "#app"
+  end
+
+  test "wildcard hub route still accepts the legacy sessions path" do
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/sessions/some-session-uuid"
+    assert_response :success
+    assert_select "#app"
+  end
+
+  test "wildcard hub route still accepts the legacy settings path" do
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/settings"
+    assert_response :success
+    assert_select "#app"
+  end
+
+  test "wildcard hub route requires authentication" do
+    get "/hubs/#{@active_hub.id}/plugins/hello"
+    # spa#hub calls authenticate_user! which redirects unauthenticated users
+    # to the Devise sign-in. Devise routes to the GitHub authorization flow
+    # in this project; either redirect or 401 is acceptable — just assert
+    # that unauthenticated requests do NOT render the SPA shell.
+    assert_not_equal 200, response.status, "expected auth gate, got #{response.status}"
+  end
+end


### PR DESCRIPTION
## Summary

Hub Lua can now register entire browser pages — the substrate for Phase 4b+ plugin UIs (kanban boards, custom dashboards, etc.) without touching Rails or React source.

**Wire-level**: new `ui_route_registry_v1` broadcast, multi-surface `ui_layout_tree_v1` iteration, FNV-1a dedup purge on unregister (`forget_surface`).

**Hub Lua**:
- `cli/lua/lib/surfaces.lua` — registry: `register/unregister/list/get/path/render_node/build_route_registry_payload/build_input`, `hub.state`-backed persistence
- `cli/lua/hub/builtin_surfaces.lua` — registers `workspace_sidebar` + `workspace_panel` as ordinary registry entries (no special-casing)
- `cli/lua/plugins/hello_surface/plugin.lua` — demo plugin, gated behind `BOTSTER_DEV=1` or `BOTSTER_ENV=test`

**Rails**: collapsed 3 enumerated `spa#hub` routes into one catch-all `get "/hubs/:hub_id/*path", to: "spa#hub", as: :spa_hub`.

**React SPA**:
- `app/frontend/components/pages/DynamicSurface.jsx` — wildcard `<Route path="*">` that mounts `<UiTree targetSurface={entry.surface}>` by matching route registry entries; uses `snapshotReceivedAtByHubId` to distinguish loading from 404
- `app/frontend/store/route-registry-store.js` — Zustand store keyed by `hub_id`
- `app/frontend/lib/actions.js` — `botster.nav.open` handler does `history.pushState` + `popstate` dispatch (`LOCAL_ONLY_ACTIONS`)
- `applyNavSelectionOverrides` — browser-side decorator on hub-authored trees for active-nav UI state, chained with existing collapse decorator

## Rebased onto main

This branch was rebased on `8667af10` (PR #175 — reload model + quiet-idle). Two conflicts resolved:

1. **`app/frontend/components/UiTree.jsx`** — chained decorators: `applyNavSelectionOverrides(applyCollapseOverrides(tree, collapsedIds), hubId, currentPathname)`. Both pure, both memoized.
2. **`cli/lua/handlers/connections.lua`** — kept both `broadcast_ui_layout_trees` and `broadcast_ui_route_registry` exports.

## Test plan

- [x] Full `./test.sh` — 1308 unit + 246 integration = 1554 passed
- [x] Frontend `vitest` — 18 files, 135 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Rails `test/controllers/spa_controller_test.rb` — 5 passed, 13 assertions
- [x] Codex audit on `7c6a07fc` → **APPROVED**, no blocking findings
- [ ] Live-test: `BOTSTER_DEV=1`, reload plugins, confirm `Hello Surface` nav entry appears, click navigates to `/hubs/:hub_id/hello-surface`
- [ ] Confirm workspace sidebar + panel still render correctly (both now go through the same registry path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)