### PR TITLE
feat(cli+web): sub-routes + scoped URL helper for plugin surfaces (Phase 4b)

### DIFF
--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -436,36 +436,55 @@ export default function UiTree({
     return transport.on('message', handler)
   }, [transport, targetSurface, subpath])
 
-  // Phase 4b: whenever the subpath changes within this surface, tell the
-  // hub so it can re-render for this client. The initial subpath is
-  // already primed via the subscribe envelope (see
-  // `channelParams().surface_subpaths` in `hub_connection.js`), so we
-  // skip the FIRST run per (transport, targetSurface) pair to avoid a
-  // redundant send on cold load. Subsequent subpath changes — the user
-  // navigating within the surface — always fire.
-  const subpathSyncRef = useRef({
-    transport: null,
-    surface: null,
-    subpath: null,
-  })
+  // Phase 4b: whenever the (target_surface, subpath) pair changes, tell
+  // the hub so it can re-render for this client. The initial subpath for
+  // the surface the user LANDED on is already primed via the subscribe
+  // envelope (`channelParams().surface_subpaths` in `hub_connection.js`);
+  // that primed surface+subpath is skipped so we don't double-send on
+  // cold load.
+  //
+  // All other cases fire:
+  //   * Cross-surface navigation on the SAME transport (hub has never
+  //     heard about the new surface's subpath — the envelope only primed
+  //     the one surface the user cold-loaded into).
+  //   * Intra-surface navigation (subpath changes within the current
+  //     targetSurface).
+  //   * Hub switch: the new transport is brand-new, so re-prime from
+  //     whatever surface the user is currently viewing.
+  //
+  // Tracking: per-transport map of `surface -> last-sent subpath`. A
+  // brand-new transport installs a single entry reflecting the currently
+  // rendered surface (that's what the subscribe envelope primed) and
+  // suppresses the send. Every other transition updates the map and
+  // sends.
+  const subpathSyncRef = useRef({ transport: null, sentBySurface: null })
   useEffect(() => {
     if (!transport || !targetSurface) return undefined
     const sync = subpathSyncRef.current
     const normalisedSubpath =
       typeof subpath === 'string' && subpath !== '' ? subpath : '/'
-    const isFirstRun =
-      sync.transport !== transport || sync.surface !== targetSurface
-    subpathSyncRef.current = {
-      transport,
-      surface: targetSurface,
-      subpath: normalisedSubpath,
+
+    const isColdTransport = sync.transport !== transport
+    if (isColdTransport) {
+      // Brand-new subscription — the subscribe envelope already primed
+      // the hub for THIS (surface, subpath). Seed the sent-cache so
+      // future renders compare against it.
+      subpathSyncRef.current = {
+        transport,
+        sentBySurface: new Map([[targetSurface, normalisedSubpath]]),
+      }
+      return undefined
     }
-    if (isFirstRun) return undefined
-    if (sync.subpath === normalisedSubpath) return undefined
+
+    // Same transport — did we already tell the hub about this
+    // (surface, subpath)? If not, send.
+    const lastSent = sync.sentBySurface.get(targetSurface)
+    if (lastSent === normalisedSubpath) return undefined
+    sync.sentBySurface.set(targetSurface, normalisedSubpath)
 
     // Best-effort — a failed send is harmless; the hub's default is "/"
-    // and dedup will sort out any divergence on the next meaningful
-    // update. No await; fire-and-forget keeps the render path fast.
+    // and the next user action will re-fire. No await; fire-and-forget
+    // keeps the render path fast.
     try {
       void transport.send('ui_action_v1', {
         target_surface: targetSurface,

--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -307,6 +307,7 @@ function defaultLoadingFallback() {
 export default function UiTree({
   hubId,
   targetSurface,
+  subpath = '/',
   capabilities,
   initialTree = null,
   loadingFallback = defaultLoadingFallback,
@@ -357,6 +358,25 @@ export default function UiTree({
     setTransport(null)
   }
 
+  // Phase 4b: subpath OR targetSurface changes within a mount must reset
+  // the tree. The hub renders a different tree for each subpath within a
+  // surface AND for each surface entirely; keeping the stale tree visible
+  // while the new one arrives would flash the wrong content for one
+  // frame. Pair this with the subpath filter in the frame subscriber
+  // below (accept only frames whose subpath matches the current prop) so
+  // we're guaranteed the next render is for the new subpath, not a
+  // late-arriving frame from the old.
+  const lastSurfaceRef = useRef(targetSurface)
+  const lastSubpathRef = useRef(subpath)
+  if (
+    lastSurfaceRef.current !== targetSurface ||
+    lastSubpathRef.current !== subpath
+  ) {
+    lastSurfaceRef.current = targetSurface
+    lastSubpathRef.current = subpath
+    setTree(null)
+  }
+
   // Acquire the hub transport (HubTransport) for send + message subscription.
   // hub-bridge.connect() resolves asynchronously, so we poll briefly until
   // getHub(hubId) returns a session. Bounded to MAX_POLL_MS so a hub that
@@ -395,15 +415,70 @@ export default function UiTree({
   }, [hubId])
 
   // Subscribe to ui_layout_tree_v1 frames matching this target_surface.
+  //
+  // Phase 4b: also filter on `subpath`. The hub echoes back the subpath it
+  // routed for, so a frame produced from the OLD subpath (still en route
+  // when the URL changed) is discarded. A frame without a subpath field
+  // (older hub) falls through the filter so back-compat still works.
   useEffect(() => {
     if (!transport || !targetSurface) return undefined
     const handler = (message) => {
       if (!message || message.type !== 'ui_layout_tree_v1') return
       if (message.target_surface !== targetSurface) return
+      if (
+        typeof message.subpath === 'string' &&
+        message.subpath !== subpath
+      ) {
+        return
+      }
       setTree(message.tree ?? null)
     }
     return transport.on('message', handler)
-  }, [transport, targetSurface])
+  }, [transport, targetSurface, subpath])
+
+  // Phase 4b: whenever the subpath changes within this surface, tell the
+  // hub so it can re-render for this client. The initial subpath is
+  // already primed via the subscribe envelope (see
+  // `channelParams().surface_subpaths` in `hub_connection.js`), so we
+  // skip the FIRST run per (transport, targetSurface) pair to avoid a
+  // redundant send on cold load. Subsequent subpath changes — the user
+  // navigating within the surface — always fire.
+  const subpathSyncRef = useRef({
+    transport: null,
+    surface: null,
+    subpath: null,
+  })
+  useEffect(() => {
+    if (!transport || !targetSurface) return undefined
+    const sync = subpathSyncRef.current
+    const normalisedSubpath =
+      typeof subpath === 'string' && subpath !== '' ? subpath : '/'
+    const isFirstRun =
+      sync.transport !== transport || sync.surface !== targetSurface
+    subpathSyncRef.current = {
+      transport,
+      surface: targetSurface,
+      subpath: normalisedSubpath,
+    }
+    if (isFirstRun) return undefined
+    if (sync.subpath === normalisedSubpath) return undefined
+
+    // Best-effort — a failed send is harmless; the hub's default is "/"
+    // and dedup will sort out any divergence on the next meaningful
+    // update. No await; fire-and-forget keeps the render path fast.
+    try {
+      void transport.send('ui_action_v1', {
+        target_surface: targetSurface,
+        envelope: {
+          id: 'botster.surface.subpath',
+          payload: { target_surface: targetSurface, subpath: normalisedSubpath },
+        },
+      })
+    } catch (err) {
+      console.warn('[UiTree] failed to send surface.subpath', err)
+    }
+    return undefined
+  }, [transport, targetSurface, subpath])
 
   // -------- Interceptor registry --------
   const interceptorsRef = useRef(new Map())

--- a/app/frontend/components/pages/DynamicSurface.jsx
+++ b/app/frontend/components/pages/DynamicSurface.jsx
@@ -3,28 +3,36 @@ import { useParams } from 'react-router-dom'
 import UiTree from '../UiTree'
 import SessionActionsMenu from '../workspace/SessionActionsMenu'
 import {
+  matchSurfaceForPath,
   useRouteRegistryStore,
   selectRoutesForHub,
   selectHasRouteRegistrySnapshot,
 } from '../../store/route-registry-store'
 
 /**
- * Phase 4a: dynamic hub-authored surface route.
+ * Phase 4a/4b: dynamic hub-authored surface route.
  *
  * Matches `useParams()`'s splat (`*`) against the hub's
- * `ui_route_registry_v1` entries and mounts `<UiTree>` for the matching
- * surface. A plugin that registers `surfaces.register("hello", { path =
- * "/plugins/hello", ... })` becomes reachable at
- * `/hubs/:hubId/plugins/hello` with zero Rails changes — the Rails
- * catch-all routes every `/hubs/:hubId/*` URL to `spa#hub`, React Router
- * routes it here, and this component subscribes the hub to the surface's
- * tree frames.
+ * `ui_route_registry_v1` entries using `matchSurfaceForPath`. The match is
+ * **prefix-scoped to `base_path`**, not an exact-path compare: the first
+ * hub-relative segment identifies the surface, and everything after it is
+ * the **subpath** (sub-route) handed to `<UiTree>` so the hub dispatcher
+ * can route to the correct sub-page. A plugin that registers
+ * `surfaces.register("kanban", { routes = { { path = "/" }, { path =
+ * "/board/:id" } } })` becomes reachable at
+ *   * `/hubs/:hubId/kanban`            → subpath "/"            → home
+ *   * `/hubs/:hubId/kanban/board/42`   → subpath "/board/42"    → board(id=42)
+ *
+ * Phase 4a's exact-match form (`path === requestedPath`) is superseded by
+ * the prefix form, which now covers both the root-of-surface case and any
+ * nested sub-path. `base_path` always falls back to `path` for backwards
+ * compat with older hubs.
  *
  * Three resolution states for the current URL:
  *   1. Registry hasn't shipped its first snapshot yet for this hub
  *      (cold deep-link, hub still connecting) → loading state.
- *   2. Snapshot received, path matches a registered surface → mount
- *      `<UiTree>` for that surface.
+ *   2. Snapshot received, path matches a registered surface's base_path →
+ *      mount `<UiTree>` for that surface with the extracted subpath.
  *   3. Snapshot received, no match → true 404.
  *
  * Distinguishing (1) from (3) avoids the "flash of 404" that would
@@ -64,7 +72,7 @@ export default function DynamicSurfaceRoute() {
     )
   }
 
-  const match = routes.find((r) => r.path === requestedPath)
+  const match = matchSurfaceForPath(routes, requestedPath)
 
   if (!match) {
     // Unknown path — render a minimal local 404. Phase 4a intentionally
@@ -91,7 +99,11 @@ export default function DynamicSurfaceRoute() {
 
   return (
     <div className="h-full overflow-y-auto p-4 lg:p-6">
-      <UiTree hubId={hubId} targetSurface={match.surface}>
+      <UiTree
+        hubId={hubId}
+        targetSurface={match.entry.surface}
+        subpath={match.subpath}
+      >
         <SessionActionsMenu />
       </UiTree>
     </div>

--- a/app/frontend/lib/connections/hub_connection.js
+++ b/app/frontend/lib/connections/hub_connection.js
@@ -32,6 +32,42 @@
 
 import { HubRoute } from "connections/hub_route";
 
+/**
+ * Extract a `{ [surfaceName]: subpath }` prime map from the current
+ * browser URL. Called at subscribe time so the hub can apply the map
+ * before its initial force-broadcast.
+ *
+ * The browser does not know the surface registry yet (the registry
+ * broadcast comes back AFTER subscribe), so we guess: the first URL
+ * segment after `/hubs/<hubId>/` is the surface name; everything after
+ * is the subpath. A guessed-wrong segment is benign — the hub stores the
+ * entry under a name no surface matches, and nothing reads it.
+ *
+ * Returns `{}` when:
+ *   * `window` is unavailable (SSR / test harness)
+ *   * The current URL doesn't match `/hubs/<hubId>[/...]`
+ *   * The URL is exactly `/hubs/<hubId>` or `/hubs/<hubId>/` (no subpath)
+ */
+function computeInitialSurfaceSubpaths(hubId) {
+  if (!hubId || typeof window === "undefined" || !window.location) {
+    return {};
+  }
+  const pathname = window.location.pathname || "";
+  const prefix = `/hubs/${hubId}`;
+  if (!pathname.startsWith(prefix)) return {};
+  const tail = pathname.slice(prefix.length);
+  if (tail === "" || tail === "/") return {};
+  const match = tail.match(/^\/([^/]+)(\/.*)?$/);
+  if (!match) return {};
+  const firstSegment = match[1];
+  const rest = match[2] || "/";
+  // Skip built-in sibling routes that aren't registered surfaces. These
+  // have dedicated React components and never flow through DynamicSurface.
+  const RESERVED = new Set(["sessions", "settings", "pairing"]);
+  if (RESERVED.has(firstSegment)) return {};
+  return { [firstSegment]: rest };
+}
+
 export class HubTransport extends HubRoute {
   constructor(key, options, manager) {
     super(key, options, manager);
@@ -83,6 +119,15 @@ export class HubTransport extends HubRoute {
     return {
       hub_id: this.getHubId(),
       browser_identity: this.browserIdentity,
+      // Phase 4b: prime per-surface subpaths from the current URL so the
+      // initial `ui_layout_tree_v1` broadcast lands on the right sub-page.
+      // Without this, cold-loading a deep link (e.g.
+      // `/hubs/:id/kanban/board/42`) would flash the default "/" render
+      // of the kanban surface before the browser's follow-up
+      // `botster.surface.subpath` action landed. The hub applies these to
+      // `client.surface_subpaths` BEFORE the force-broadcast primes
+      // frames. See handle_subscribe in `cli/lua/lib/client.lua`.
+      surface_subpaths: computeInitialSurfaceSubpaths(this.getHubId()),
     };
   }
 

--- a/app/frontend/store/route-registry-store.js
+++ b/app/frontend/store/route-registry-store.js
@@ -1,14 +1,24 @@
 import { create } from 'zustand'
 
-// Phase 4a: per-hub registry of routable browser surfaces. Populated from
+// Phase 4a/4b: per-hub registry of routable browser surfaces. Populated from
 // the `ui_route_registry_v1` broadcast (see `lib/connections/hub_connection.js`
 // and the bridge in `lib/hub-bridge.js`). Components subscribe via the
 // `useRouteRegistryStore` hook; `DynamicSurfaceRoute` matches the current
-// URL splat against an entry's `path` to decide which hub-authored surface
-// to mount.
+// URL's first hub-scoped segment against an entry's `base_path` to decide
+// which hub-authored surface to mount.
 //
 // Shape:
-//   routesByHubId: { [hubId]: Array<{ path, surface, label, icon, hide_from_nav? }> }
+//   routesByHubId: {
+//     [hubId]: Array<{
+//       path,              // canonical URL path for the surface root
+//       base_path,         // matches `path`; explicit for sub-route slicing
+//       surface,           // wire target_surface identifier
+//       label,
+//       icon,
+//       hide_from_nav?,
+//       routes?,           // Phase 4b sub-patterns: [{ path }]
+//     }>,
+//   }
 //   snapshotReceivedAtByHubId: { [hubId]: number }
 //
 // Routes are replaced wholesale per frame so the hub always owns the
@@ -24,7 +34,7 @@ export const useRouteRegistryStore = create((set) => ({
 
   setRoutes(hubId, routes) {
     if (!hubId) return
-    const next = Array.isArray(routes) ? routes : []
+    const next = Array.isArray(routes) ? routes.map(normaliseEntry) : []
     set((s) => ({
       routesByHubId: { ...s.routesByHubId, [String(hubId)]: next },
       snapshotReceivedAtByHubId: {
@@ -63,6 +73,68 @@ export const useRouteRegistryStore = create((set) => ({
 // protection. A frozen module-level constant is safe here because the
 // selector never mutates.
 const EMPTY_ROUTES = Object.freeze([])
+
+/**
+ * Normalise an entry so consumers can rely on `base_path` without reaching
+ * through legacy shapes. Phase 4a emitted only `path`; Phase 4b also emits
+ * `base_path` and an optional `routes` array of sub-patterns. Older hubs
+ * talking to a newer browser fall back to `path` for `base_path`.
+ */
+function normaliseEntry(entry) {
+  if (!entry || typeof entry !== 'object') return entry
+  const basePath = typeof entry.base_path === 'string' && entry.base_path !== ''
+    ? entry.base_path
+    : typeof entry.path === 'string' ? entry.path : null
+  return {
+    ...entry,
+    base_path: basePath,
+  }
+}
+
+/**
+ * Given a set of normalised registry entries and a hub-relative URL (e.g.
+ * "/kanban/board/42"), return the matching entry AND the remaining subpath
+ * (e.g. "/board/42"). Preference order:
+ *   1. Exact base_path match with no additional segments ("/kanban" vs
+ *      entry.base_path "/kanban") → subpath "/".
+ *   2. Prefix match where the character after the base is "/" (so
+ *      "/kanban/board/42" matches base "/kanban" but "/kanbana" doesn't
+ *      match base "/kanban").
+ *   3. Root base_path ("/") matches only the literal root.
+ *
+ * When multiple entries' base_paths are prefixes of one another (e.g.
+ * "/admin" vs "/admin/users"), the longer base wins.
+ */
+export function matchSurfaceForPath(entries, pathname) {
+  if (!Array.isArray(entries) || typeof pathname !== 'string') {
+    return null
+  }
+  const normalised = pathname.length === 0 ? '/' : pathname
+
+  let best = null
+  let bestLen = -1
+  for (const entry of entries) {
+    const base = entry?.base_path
+    if (typeof base !== 'string' || base.length === 0) continue
+
+    let subpath = null
+    if (base === '/') {
+      if (normalised === '/' || normalised === '') {
+        subpath = '/'
+      }
+    } else if (normalised === base) {
+      subpath = '/'
+    } else if (normalised.startsWith(base + '/')) {
+      subpath = normalised.slice(base.length)
+    }
+
+    if (subpath !== null && base.length > bestLen) {
+      best = { entry, subpath }
+      bestLen = base.length
+    }
+  }
+  return best
+}
 
 /** Selector: return the routes for a given hub id, or an empty array. */
 export function selectRoutesForHub(state, hubId) {

--- a/app/frontend/test/dynamic-surface-route.test.jsx
+++ b/app/frontend/test/dynamic-surface-route.test.jsx
@@ -6,12 +6,13 @@ import { useRouteRegistryStore } from '../store/route-registry-store'
 
 // UiTree is the hub-subscribing mount. For this unit test we don't want to
 // exercise real subscription / transport code — we just want to assert that
-// DynamicSurfaceRoute passes the right `targetSurface` through.
+// DynamicSurfaceRoute passes the right `targetSurface` and `subpath` through.
 vi.mock('../components/UiTree', () => ({
-  default: ({ hubId, targetSurface, children }) => (
+  default: ({ hubId, targetSurface, subpath, children }) => (
     <div data-testid="ui-tree">
       <span>{`hubId=${hubId}`}</span>
       <span>{`targetSurface=${targetSurface}`}</span>
+      <span>{`subpath=${subpath ?? '/'}`}</span>
       {children}
     </div>
   ),
@@ -154,5 +155,77 @@ describe('DynamicSurfaceRoute', () => {
 
     expect(screen.getByText(/Not found/i)).toBeInTheDocument()
     expect(screen.queryByText(/Loading/i)).toBeNull()
+  })
+
+  // Phase 4b: prefix-match by base_path, extract subpath from the URL.
+  it('matches by base_path prefix and passes the subpath to UiTree', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      {
+        path: '/kanban',
+        base_path: '/kanban',
+        surface: 'kanban',
+        label: 'Kanban',
+        routes: [{ path: '/' }, { path: '/board/:id' }, { path: '/settings' }],
+      },
+    ])
+    renderDynamic('/hubs/h1/kanban/board/42')
+
+    const tree = screen.getByTestId('ui-tree')
+    expect(tree).toHaveTextContent('targetSurface=kanban')
+    expect(tree).toHaveTextContent('subpath=/board/42')
+  })
+
+  it('surface-root URL produces subpath "/"', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/kanban', base_path: '/kanban', surface: 'kanban', label: 'Kanban' },
+    ])
+    renderDynamic('/hubs/h1/kanban')
+
+    const tree = screen.getByTestId('ui-tree')
+    expect(tree).toHaveTextContent('subpath=/')
+  })
+
+  it('prefix-matches prefer the longest matching base_path', () => {
+    // Regression guard for an "/admin" vs "/admin/users" pair — the
+    // longer base wins so `/admin/users/bob` resolves to the nested
+    // surface, not `/admin` with subpath "/users/bob".
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/admin', base_path: '/admin', surface: 'admin', label: 'Admin' },
+      {
+        path: '/admin/users',
+        base_path: '/admin/users',
+        surface: 'admin_users',
+        label: 'Admin Users',
+      },
+    ])
+    renderDynamic('/hubs/h1/admin/users/bob')
+
+    const tree = screen.getByTestId('ui-tree')
+    expect(tree).toHaveTextContent('targetSurface=admin_users')
+    expect(tree).toHaveTextContent('subpath=/bob')
+  })
+
+  it('does not confuse sibling paths that share a prefix but not a segment boundary', () => {
+    // "/kanban" should NOT match "/kanbana" even though it's a string
+    // prefix. The segment boundary ("/" after the base) is required.
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/kanban', base_path: '/kanban', surface: 'kanban', label: 'Kanban' },
+    ])
+    renderDynamic('/hubs/h1/kanbana')
+
+    expect(screen.getByText(/Not found/i)).toBeInTheDocument()
+  })
+
+  it('falls back to legacy `path` when base_path is omitted (old hub compat)', () => {
+    // Older hubs emit only `path`. The store normaliser maps it to
+    // base_path so DynamicSurfaceRoute still resolves correctly.
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello', label: 'Hello' },
+    ])
+    renderDynamic('/hubs/h1/plugins/hello/details')
+
+    const tree = screen.getByTestId('ui-tree')
+    expect(tree).toHaveTextContent('targetSurface=hello')
+    expect(tree).toHaveTextContent('subpath=/details')
   })
 })

--- a/app/frontend/test/hub-connection-subpath-prime.test.js
+++ b/app/frontend/test/hub-connection-subpath-prime.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Under test: `computeInitialSurfaceSubpaths` is a private helper in
+// hub_connection.js. We test through `channelParams()` — the public shape
+// that flows to the subscribe envelope — by instantiating the transport
+// with a minimal stub and flipping `window.location.pathname`.
+//
+// The helper's guarantee: for a URL of the form `/hubs/<hubId>/<segment>[/<rest>]`,
+// return `{ [segment]: "/<rest>" }` (or `{ [segment]: "/" }` when no rest).
+// Reserved segments (`sessions`, `settings`, `pairing`) must NOT be
+// primed — those routes have dedicated React components.
+
+import { HubTransport } from '../lib/connections/hub_connection'
+
+const originalPath = typeof window !== 'undefined' ? window.location.pathname : '/'
+
+function setPath(pathname) {
+  // jsdom lets us mutate location.pathname via history.replaceState.
+  window.history.replaceState({}, '', pathname)
+}
+
+describe('HubTransport.channelParams.surface_subpaths prime (Phase 4b)', () => {
+  let transport
+
+  beforeEach(() => {
+    // HubTransport is a HubRoute subclass that expects a manager + options
+    // bundle. For this unit test we only touch `channelParams()` which
+    // reads `this.getHubId()` and `this.browserIdentity`. Use Object.create
+    // to sidestep the full constructor's manager wiring.
+    transport = Object.create(HubTransport.prototype)
+    transport.getHubId = () => 'hub-1'
+    transport.browserIdentity = 'browser-ident'
+  })
+
+  afterEach(() => {
+    setPath(originalPath)
+  })
+
+  it('empty prime at the hub root', () => {
+    setPath('/hubs/hub-1')
+    const params = transport.channelParams()
+    expect(params.surface_subpaths).toEqual({})
+  })
+
+  it('empty prime at /hubs/hub-1/', () => {
+    setPath('/hubs/hub-1/')
+    expect(transport.channelParams().surface_subpaths).toEqual({})
+  })
+
+  it('surface root primes subpath "/"', () => {
+    setPath('/hubs/hub-1/kanban')
+    expect(transport.channelParams().surface_subpaths).toEqual({
+      kanban: '/',
+    })
+  })
+
+  it('surface deep link primes the full subpath', () => {
+    setPath('/hubs/hub-1/kanban/board/42')
+    expect(transport.channelParams().surface_subpaths).toEqual({
+      kanban: '/board/42',
+    })
+  })
+
+  it('reserved first segments (sessions/settings/pairing) do not prime', () => {
+    setPath('/hubs/hub-1/sessions/abc')
+    expect(transport.channelParams().surface_subpaths).toEqual({})
+    setPath('/hubs/hub-1/settings')
+    expect(transport.channelParams().surface_subpaths).toEqual({})
+    setPath('/hubs/hub-1/pairing')
+    expect(transport.channelParams().surface_subpaths).toEqual({})
+  })
+
+  it('other hubs URLs do not match', () => {
+    setPath('/hubs/hub-2/kanban/board/42')
+    expect(transport.channelParams().surface_subpaths).toEqual({})
+  })
+})

--- a/app/frontend/test/route-registry-store.test.js
+++ b/app/frontend/test/route-registry-store.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  matchSurfaceForPath,
+  useRouteRegistryStore,
+  selectRoutesForHub,
+} from '../store/route-registry-store'
+
+describe('matchSurfaceForPath', () => {
+  const entries = [
+    {
+      surface: 'kanban',
+      path: '/kanban',
+      base_path: '/kanban',
+      routes: [{ path: '/' }, { path: '/board/:id' }, { path: '/settings' }],
+    },
+    {
+      surface: 'workspace_panel',
+      path: '/',
+      base_path: '/',
+      label: 'Hub',
+    },
+    {
+      surface: 'admin',
+      path: '/admin',
+      base_path: '/admin',
+    },
+    {
+      surface: 'admin_users',
+      path: '/admin/users',
+      base_path: '/admin/users',
+    },
+  ]
+
+  it('returns null for non-matching paths', () => {
+    expect(matchSurfaceForPath(entries, '/nope')).toBeNull()
+    expect(matchSurfaceForPath(entries, '/kanbana')).toBeNull()
+  })
+
+  it('surface root returns subpath "/"', () => {
+    const m = matchSurfaceForPath(entries, '/kanban')
+    expect(m?.entry.surface).toBe('kanban')
+    expect(m?.subpath).toBe('/')
+  })
+
+  it('nested path yields the trailing subpath', () => {
+    const m = matchSurfaceForPath(entries, '/kanban/board/42')
+    expect(m?.entry.surface).toBe('kanban')
+    expect(m?.subpath).toBe('/board/42')
+  })
+
+  it('longest base_path wins when multiple match', () => {
+    const m = matchSurfaceForPath(entries, '/admin/users/bob')
+    expect(m?.entry.surface).toBe('admin_users')
+    expect(m?.subpath).toBe('/bob')
+  })
+
+  it('root `/` entry matches only "/" literally', () => {
+    const m = matchSurfaceForPath(entries, '/')
+    expect(m?.entry.surface).toBe('workspace_panel')
+    expect(m?.subpath).toBe('/')
+    // "/kanban" must NOT be absorbed by the root entry.
+    const m2 = matchSurfaceForPath(entries, '/kanban/whatever')
+    expect(m2?.entry.surface).toBe('kanban')
+  })
+
+  it('handles non-string / non-array inputs gracefully', () => {
+    expect(matchSurfaceForPath(null, '/foo')).toBeNull()
+    expect(matchSurfaceForPath(entries, null)).toBeNull()
+  })
+})
+
+describe('route-registry-store normalisation', () => {
+  beforeEach(() => {
+    useRouteRegistryStore.setState({
+      routesByHubId: {},
+      snapshotReceivedAtByHubId: {},
+    })
+  })
+
+  it('assigns base_path from legacy `path` when base_path is absent', () => {
+    // Old hub still shipping only `path`. Store should fill in base_path so
+    // consumers don't have to branch on schema version.
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/plugins/hello', surface: 'hello' },
+    ])
+    const routes = selectRoutesForHub(useRouteRegistryStore.getState(), 'h1')
+    expect(routes[0].base_path).toBe('/plugins/hello')
+  })
+
+  it('preserves explicit base_path when supplied', () => {
+    useRouteRegistryStore.getState().setRoutes('h1', [
+      { path: '/kanban', base_path: '/kanban', surface: 'kanban' },
+    ])
+    const routes = selectRoutesForHub(useRouteRegistryStore.getState(), 'h1')
+    expect(routes[0].base_path).toBe('/kanban')
+  })
+})

--- a/app/frontend/test/ui-tree.test.jsx
+++ b/app/frontend/test/ui-tree.test.jsx
@@ -550,4 +550,93 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     })
     expect(await screen.findByText('hub')).toBeInTheDocument()
   })
+
+  // Regression: codex-found blocker (2026-04-21). Cross-surface navigation
+  // on the SAME transport must fire `botster.surface.subpath` for the new
+  // (surface, subpath) pair. Previously the first-mount-skip was keyed on
+  // `(transport, targetSurface)`, which incorrectly treated every surface
+  // change as "cold mount" and suppressed the send. That left the hub's
+  // `client.surface_subpaths` empty for the new surface, so the dispatcher
+  // routed to the surface's default "/" render — the user sees the wrong
+  // sub-page (or loading) indefinitely.
+  it('fires surface.subpath when targetSurface changes on an existing transport', async () => {
+    const { rerender } = render(
+      <UiTree hubId="hub-1" targetSurface="hello" subpath="/details/1" />,
+    )
+    // Let the transport attach (cold mount — suppressed, correctly).
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120))
+    })
+    expect(
+      fakeTransport.send.mock.calls.filter(
+        ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+      ),
+    ).toHaveLength(0)
+
+    // Navigate to a different surface with a non-root subpath. Same
+    // transport, same hubId — just a surface switch.
+    rerender(
+      <UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />,
+    )
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const calls = fakeTransport.send.mock.calls.filter(
+      ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0][1]).toEqual({
+      target_surface: 'kanban',
+      envelope: {
+        id: 'botster.surface.subpath',
+        payload: { target_surface: 'kanban', subpath: '/board/42' },
+      },
+    })
+  })
+
+  it('does not refire when the user navigates back to a surface at a subpath already sent', async () => {
+    // Hello → Kanban(/board/42) → Hello → Kanban(/board/42). The first
+    // Kanban visit sends; the second should NOT (last-sent cache hit).
+    const { rerender } = render(
+      <UiTree hubId="hub-1" targetSurface="hello" subpath="/" />,
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120))
+    })
+
+    rerender(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    rerender(<UiTree hubId="hub-1" targetSurface="hello" subpath="/" />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    rerender(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const subpathCalls = fakeTransport.send.mock.calls.filter(
+      ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+    )
+    // Expected sends:
+    //   1. hello(cold): skipped
+    //   2. kanban(new): send kanban /board/42
+    //   3. hello(new for this sync map after hello cold-skip): send hello "/"
+    //   4. kanban(cached same): skipped
+    // => 2 sends total. The important invariant (regression guard) is
+    //    that the kanban re-visit at step 4 does NOT refire.
+    const kanbanSends = subpathCalls.filter(
+      ([, body]) => body.envelope.payload.target_surface === 'kanban',
+    )
+    expect(kanbanSends).toHaveLength(1)
+  })
 })

--- a/app/frontend/test/ui-tree.test.jsx
+++ b/app/frontend/test/ui-tree.test.jsx
@@ -440,3 +440,114 @@ describe('<UiTree> interceptor context', () => {
     })
   })
 })
+
+describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
+  it('does NOT send a surface.subpath action on first mount (subscribe envelope primes)', async () => {
+    // The subscribe channelParams already include `surface_subpaths`, so
+    // the hub is primed BEFORE the UiTree mounts. Sending another action
+    // on first mount would double-send for every cold load.
+    render(
+      <UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />,
+    )
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120))
+    })
+    const subpathCalls = fakeTransport.send.mock.calls.filter(
+      ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+    )
+    expect(subpathCalls).toHaveLength(0)
+  })
+
+  it('sends surface.subpath on subpath prop change and clears the tree', async () => {
+    const { rerender } = render(
+      <UiTree hubId="hub-1" targetSurface="kanban" subpath="/" />,
+    )
+    // Wait for transport attach.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120))
+    })
+    // Initial render has no tree yet, but the first subpath must not fire.
+    expect(
+      fakeTransport.send.mock.calls.filter(
+        ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+      ),
+    ).toHaveLength(0)
+
+    // Push a home-render tree so the panel is visible.
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'kanban',
+        subpath: '/',
+        tree: { type: 'text', props: { text: 'home' } },
+      })
+    })
+    expect(await screen.findByText('home')).toBeInTheDocument()
+
+    // Now navigate — subpath prop changes.
+    rerender(
+      <UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />,
+    )
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    // Tree state was cleared (old subpath's tree must not paint the new
+    // sub-page for a tick).
+    expect(screen.queryByText('home')).toBeNull()
+
+    // Exactly one surface.subpath action fired.
+    const calls = fakeTransport.send.mock.calls.filter(
+      ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
+    )
+    expect(calls).toHaveLength(1)
+    expect(calls[0][1]).toEqual({
+      target_surface: 'kanban',
+      envelope: {
+        id: 'botster.surface.subpath',
+        payload: { target_surface: 'kanban', subpath: '/board/42' },
+      },
+    })
+  })
+
+  it('ignores tree frames whose subpath does not match the current prop', async () => {
+    render(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />)
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 120))
+    })
+    // Late frame from old subpath arriving after the user navigated away
+    // — UiTree must discard it, not paint it.
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'kanban',
+        subpath: '/',
+        tree: { type: 'text', props: { text: 'stale home' } },
+      })
+    })
+    expect(screen.queryByText('stale home')).toBeNull()
+    // Matching-subpath frame does paint.
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'kanban',
+        subpath: '/board/42',
+        tree: { type: 'text', props: { text: 'board 42' } },
+      })
+    })
+    expect(await screen.findByText('board 42')).toBeInTheDocument()
+  })
+
+  it('accepts frames with no subpath field (back-compat with older hubs)', async () => {
+    render(<UiTree hubId="hub-1" targetSurface="workspace_panel" subpath="/" />)
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'workspace_panel',
+        // no subpath field
+        tree: { type: 'text', props: { text: 'hub' } },
+      })
+    })
+    expect(await screen.findByText('hub')).toBeInTheDocument()
+  })
+})

--- a/cli/lua/handlers/commands.lua
+++ b/cli/lua/handlers/commands.lua
@@ -545,6 +545,41 @@ commands.register("ui_action_v1", function(client, sub_id, command)
     })
 end, { description = "Dispatch a semantic UI action envelope to hub handlers" })
 
+-- Phase 4b: surface subpath notifier. The browser fires this whenever its
+-- URL changes within a registered surface so the hub updates per-client
+-- `surface_subpaths[surface_name]` and re-renders just that surface for
+-- this subscription. Returns `action.HANDLED` so we don't silently drop
+-- into a legacy command fallback if one is ever added.
+--
+-- Payload shape: `{ target_surface = "kanban", subpath = "/board/42" }`.
+-- Browser also accepts `surface` / `path` aliases in case a plugin emits a
+-- slightly different shape from a Lua action builder — action observers
+-- plan on normalising.
+do
+    local action = require("lib.action")
+    action.on("botster.surface.subpath", "builtin.surface.subpath", function(envelope, ctx)
+        local client = ctx and ctx.client
+        if not client then return action.HANDLED end
+        local payload = envelope.payload or {}
+        local surface_name = payload.target_surface or payload.surface
+        local subpath = payload.subpath or payload.path or "/"
+        if type(surface_name) ~= "string" or surface_name == "" then
+            log.debug("botster.surface.subpath: missing target_surface; ignoring")
+            return action.HANDLED
+        end
+        if type(subpath) ~= "string" or subpath == "" then subpath = "/" end
+        if type(client.set_surface_subpath) == "function" then
+            client:set_surface_subpath(surface_name, subpath)
+        else
+            -- Hot-reload seam: Client methods upgrade in place but defend
+            -- against a stale VM where the method hasn't landed yet.
+            client.surface_subpaths = client.surface_subpaths or {}
+            client.surface_subpaths[surface_name] = subpath
+        end
+        return action.HANDLED
+    end)
+end
+
 commands.register("clear_notification", function(_client, _sub_id, command)
     local session_uuid = command.session_uuid
     if session_uuid then

--- a/cli/lua/lib/client.lua
+++ b/cli/lua/lib/client.lua
@@ -38,6 +38,13 @@ function Client.new(peer_id, transport)
         -- `botster.session.select` action fallback) so each subscriber
         -- gets its own `tree_item.selected` row rendered hub-side.
         selected_session_uuid = nil,
+        -- Phase 4b: per-browser URL state, mirroring the selection design.
+        -- `{ [surface_name] = subpath }` — the browser sends
+        -- `botster.surface.subpath` actions (and primes this map via the
+        -- subscribe envelope) so `layout_broadcast` can thread the right
+        -- `state.path` into each surface's render dispatcher. Unset entries
+        -- default to "/".
+        surface_subpaths = {},
     }, Client)
 
     log.info(string.format("Client created: %s...", peer_id:sub(1, 8)))
@@ -263,6 +270,21 @@ function Client:handle_subscribe(msg)
                 "send_ui_route_registry failed for %s: %s",
                 self.peer_id:sub(1, 8), tostring(reg_err)))
         end
+        -- Phase 4b: prime per-surface subpaths BEFORE the force-broadcast
+        -- so cold-load deep links (e.g. /hubs/:id/kanban/board/42) produce
+        -- the right sub-page on the very first frame. Without this the hub
+        -- would render "/" first (the default), ship it, then receive the
+        -- browser's surface.subpath action and re-render. That causes a
+        -- visible flash even with dedup because the "/" and "/board/42"
+        -- trees legitimately differ. `rebroadcast = false` because the
+        -- force-broadcast call below will emit the frames anyway.
+        if type(params.surface_subpaths) == "table" then
+            for surface_name, subpath in pairs(params.surface_subpaths) do
+                if type(surface_name) == "string" and type(subpath) == "string" then
+                    self:set_surface_subpath(surface_name, subpath, { rebroadcast = false })
+                end
+            end
+        end
         -- Prime Phase 2b layout trees so a fresh subscriber renders
         -- immediately without waiting for the next session_updated.
         -- `force=true` bypasses dedup; this is the only call that does so
@@ -365,8 +387,13 @@ end
 -- should set `opts.force = true` on priming (so a newly-subscribing browser
 -- always receives both densities) and leave `force` false/nil for routine
 -- broadcasts so dedup can suppress unchanged trees.
+--
+-- Phase 4b: `opts.only_surface` re-renders a single surface, used by the
+-- `botster.surface.subpath` action handler. Other surfaces stay on their
+-- existing dedup baselines — a URL change within one surface must NOT
+-- churn every other surface's version.
 -- @param sub_id The subscription ID to send to
--- @param opts table? { force = bool }
+-- @param opts table? { force = bool, only_surface = string }
 function Client:send_ui_layout_trees(sub_id, opts)
     local LayoutInput = require("lib.layout_input")
     local LayoutBroadcast = require("lib.layout_broadcast")
@@ -386,6 +413,7 @@ function Client:send_ui_layout_trees(sub_id, opts)
         subscription_key = sub_id,
         client = self,
         force = force,
+        only_surface = opts.only_surface,
     })
     if #frames == 0 then
         return 0
@@ -396,6 +424,42 @@ function Client:send_ui_layout_trees(sub_id, opts)
     end
     LayoutBroadcast.mark_sent(frames, { subscription_key = sub_id })
     return #frames
+end
+
+--- Record the browser's current subpath for a surface and trigger a
+--- targeted re-render. Called from the `botster.surface.subpath` action
+--- handler (action.lua) and from `handle_subscribe` when the initial
+--- subscribe envelope carries `surface_subpaths` (cold-load priming).
+--
+-- @param surface_name string
+-- @param subpath string Sub-path within the surface ("/" / "/board/42" / ...)
+-- @param opts table? { rebroadcast = bool } — default true. Set false during
+--        subscribe-time priming so we don't fire a broadcast before the
+--        initial force-broadcast call runs.
+function Client:set_surface_subpath(surface_name, subpath, opts)
+    if type(surface_name) ~= "string" or surface_name == "" then return end
+    if type(subpath) ~= "string" or subpath == "" then subpath = "/" end
+    if not self.surface_subpaths then self.surface_subpaths = {} end
+    local previous = self.surface_subpaths[surface_name]
+    if previous == subpath then return end
+    self.surface_subpaths[surface_name] = subpath
+    opts = opts or {}
+    if opts.rebroadcast == false then return end
+    -- Only re-render THIS surface for subscriptions on the hub channel.
+    -- `force = true` guarantees the frame ships even if the surface's
+    -- rendered tree happens to hash-match the previous one; otherwise the
+    -- browser would stay in its loading state forever waiting for a
+    -- subpath-matched frame that dedup silently suppressed. Dedup remains
+    -- correct for ordinary data-change re-broadcasts because those use
+    -- `send_ui_layout_trees(sub_id)` without `force`.
+    for sub_id, sub in pairs(self.subscriptions or {}) do
+        if sub.channel == "hub" then
+            pcall(self.send_ui_layout_trees, self, sub_id, {
+                only_surface = surface_name,
+                force = true,
+            })
+        end
+    end
 end
 
 --- Send the `ui_route_registry_v1` frame for a HubChannel subscription.

--- a/cli/lua/lib/layout_broadcast.lua
+++ b/cli/lua/lib/layout_broadcast.lua
@@ -95,8 +95,9 @@ end
 -- -------------------------------------------------------------------------
 
 --- Render one frame for `surface_name` using `surface_state` as input.
---- Returns a table `{ type, target_surface, tree, version, hub_id }` ready
---- to ship via `client:send(frame)`, or nil if rendering / decoding failed.
+--- Returns a table `{ type, target_surface, tree, version, hub_id, subpath }`
+--- ready to ship via `client:send(frame)`, or nil if rendering / decoding
+--- failed.
 ---
 --- Uses `web_layout.render(surface_name, state)` uniformly so:
 ---   * override files (`.botster/layout_web.lua`) keep their precedence
@@ -104,6 +105,12 @@ end
 ---     when the workspace wrappers delegate to it
 ---   * plugin-registered surfaces fall through to
 ---     `_G.surfaces.render_node(...)` via the Rust fallback (Phase 4a).
+---
+--- Phase 4b: the emitted frame echoes back `subpath` — the value the
+--- dispatcher routed on — so the browser can ignore frames produced for a
+--- subpath it no longer cares about. Critical for preventing the cold-load
+--- flash when the hub's initial default-"/" frame would otherwise paint the
+--- wrong sub-page before the browser's surface.subpath action lands.
 local function render_one(surface_name, surface_state)
     local ok, result_json = pcall(function()
         return web_layout.render(surface_name, surface_state)
@@ -131,7 +138,11 @@ local function render_one(surface_name, surface_state)
 
     -- Fingerprint from the JSON string directly — web_layout.render emits
     -- it via serde_json with a stable field order, so same inputs yield
-    -- identical bytes.
+    -- identical bytes. We do NOT fold the subpath into the hash: two
+    -- subpaths that render to the same tree should dedup to one frame
+    -- (rare in practice, but the invariant keeps us aligned with
+    -- `fnv1a64_hex(tree_json)` which downstream tests assert on).
+    local subpath = (type(surface_state) == "table") and surface_state.path or nil
     local version = fnv1a64_hex(result_json)
 
     return {
@@ -140,7 +151,27 @@ local function render_one(surface_name, surface_state)
         tree = tree,
         version = version,
         hub_id = (type(surface_state) == "table") and surface_state.hub_id or nil,
+        subpath = subpath,
     }
+end
+
+-- Resolve the subpath the client is currently viewing for this surface.
+-- Callers pre-build input via `entry.input_builder(...)` OR the shared
+-- `LayoutInput.build_for_subscription` default; neither of those know about
+-- the current URL. We layer the URL-bound state on top here so every
+-- surface's render gets the right `state.path` threaded through the
+-- dispatcher built by `surfaces.lua`.
+--
+-- Storage: `client.surface_subpaths` is a `{ [surface_name] = subpath }`
+-- map owned by the hub-side client (see `cli/lua/lib/client.lua`). Unset
+-- entries fall back to "/", which matches every surface's default route.
+local function resolve_subpath(client, surface_name)
+    if type(client) ~= "table" then return "/" end
+    local paths = client.surface_subpaths
+    if type(paths) ~= "table" then return "/" end
+    local sub = paths[surface_name]
+    if type(sub) == "string" and sub ~= "" then return sub end
+    return "/"
 end
 
 --- Normalise a subscription key. Missing/nil keys fall back to the global
@@ -212,33 +243,53 @@ function M.build_frames(base_state, opts)
         return {}
     end
 
+    -- Allow callers to target a single surface. Production uses this for
+    -- surface.subpath-driven re-renders — re-rendering EVERY surface per URL
+    -- change would be wasteful and also churn the dedup state. Tests leave
+    -- `only_surface` unset and fan out to the full registry.
+    local only_surface = nil
+    if type(opts.only_surface) == "string" and opts.only_surface ~= "" then
+        only_surface = opts.only_surface
+    end
+
     local frames = {}
     for _, summary in ipairs(surfaces_mod.list()) do
         local surface_name = summary.name
-        local entry = surfaces_mod.get(surface_name)
-        if entry then
-            local surface_state
-            if entry.input_builder then
-                local ok, built = pcall(entry.input_builder, opts.client, opts.subscription_key)
-                if ok then
-                    surface_state = built
+        if only_surface == nil or only_surface == surface_name then
+            local entry = surfaces_mod.get(surface_name)
+            if entry then
+                local surface_state
+                if entry.input_builder then
+                    local ok, built = pcall(entry.input_builder, opts.client, opts.subscription_key)
+                    if ok then
+                        surface_state = built
+                    else
+                        log.warn(string.format(
+                            "layout_broadcast: input_builder for %s threw: %s",
+                            surface_name, tostring(built)))
+                    end
+                elseif opts.client then
+                    local LayoutInput = require("lib.layout_input")
+                    surface_state = LayoutInput.build_for_subscription(opts.client, opts.subscription_key)
                 else
-                    log.warn(string.format(
-                        "layout_broadcast: input_builder for %s threw: %s",
-                        surface_name, tostring(built)))
+                    surface_state = base_state
                 end
-            elseif opts.client then
-                local LayoutInput = require("lib.layout_input")
-                surface_state = LayoutInput.build_for_subscription(opts.client, opts.subscription_key)
-            else
-                surface_state = base_state
-            end
 
-            if type(surface_state) == "table" then
-                local frame = render_one(surface_name, surface_state)
-                if frame then
-                    if force or bucket[surface_name] ~= frame.version then
-                        frames[#frames + 1] = frame
+                if type(surface_state) == "table" then
+                    -- Thread the current subpath through the render input so
+                    -- the surface dispatcher (lib.surfaces) can route it to
+                    -- the correct sub-route. `client.surface_subpaths` is
+                    -- updated by the `botster.surface.subpath` action, and
+                    -- primed at subscribe-time so cold-load lands on the
+                    -- right sub-page without flashing "/".
+                    if surface_state.path == nil then
+                        surface_state.path = resolve_subpath(opts.client, surface_name)
+                    end
+                    local frame = render_one(surface_name, surface_state)
+                    if frame then
+                        if force or bucket[surface_name] ~= frame.version then
+                            frames[#frames + 1] = frame
+                        end
                     end
                 end
             end

--- a/cli/lua/lib/surfaces.lua
+++ b/cli/lua/lib/surfaces.lua
@@ -1,9 +1,42 @@
--- Surface registry (Phase 4a) — the Lua-side source of truth for browser
+-- Surface registry (Phase 4a + 4b) — the Lua-side source of truth for browser
 -- surfaces. A "surface" is the unit the hub composes and ships to browsers:
 --   * it has a stable `name` (the `target_surface` on the wire)
---   * a `render(state)` function returning a UiNodeV1 table
---   * optional `path` making it a routable browser page
+--   * a `routes = { ... }` array OR a single `render(state)` function
 --   * optional `input_builder(client, sub_id)` for per-subscription state
+--
+-- Phase 4b introduces sub-routes:
+--
+--   surfaces.register("kanban", {
+--       label = "Kanban",
+--       icon  = "squares-2x2",
+--       -- base path = "/kanban" (derived from name). URL =
+--       -- /hubs/<hub_id>/kanban. Each route's `path` is relative to that base.
+--       routes = {
+--           { path = "/",           render = kanban_home },
+--           { path = "/board/:id",  render = kanban_board },
+--           { path = "/settings",   render = kanban_settings },
+--       },
+--       input_builder = function(client, sub_id) ... end,
+--   })
+--
+-- The sub-route's `render(state, ctx)` receives:
+--   * `state.path`   — the subpath the browser is currently on ("/board/42")
+--   * `state.params` — the named captures from the matched pattern
+--                      (`{ id = "42" }` for "/board/:id")
+--   * `ctx.hub_id`, `ctx.surface`, `ctx.base_path`
+--   * `ctx.path(subpath, params)` — build a full `/hubs/<hub_id>/<base>/<sub>`
+--     URL with `:name` interpolation from `params`.
+--
+-- Cross-surface helper:
+--
+--   surfaces.path("kanban", "/board/:id", { id = 42 })
+--     -> "/hubs/<current-hub>/kanban/board/42"
+--
+-- Backwards compatibility: registrations that pass a single top-level `render`
+-- (and optional top-level `path` for the URL base) are still accepted and
+-- internally wrapped into `routes = { { path = "/", render = opts.render } }`.
+-- The top-level `path` becomes the base for that surface (this is the escape
+-- hatch built-in surfaces like `workspace_panel` use to keep their URL at "/").
 --
 -- Plugins call `surfaces.register(...)` from their own Lua init and the
 -- registration flows through three places automatically:
@@ -28,7 +61,10 @@ local M = {}
 
 -- Storage shape:
 --   registry.by_name[name] = {
---       name, path, label, icon, render, input_builder,
+--       name, base_path, label, icon,
+--       render,                -- auto-generated dispatcher (or passthrough)
+--       compiled_routes,       -- array of { pattern, param_names, regex, render }
+--       input_builder,
 --       hide_from_nav, order, source,
 --   }
 --   registry.seq — monotonically increasing insertion counter for stable
@@ -51,6 +87,273 @@ local function notify_changed()
     end
 end
 
+-- Escape Lua pattern metacharacters so literal path segments can be matched
+-- via `string.match`. `/board/42.json` must match the literal pattern "/board/42.json"
+-- exactly; the dot must not act as a Lua pattern wildcard. Belt-and-suspenders
+-- — plugin-declared patterns are short strings with tight alphabets, but we
+-- don't want to constrain that in the future.
+local LUA_PATTERN_MAGIC = "([%(%)%.%%%+%-%*%?%[%]%^%$])"
+local function escape_lua_pattern(s)
+    return (s:gsub(LUA_PATTERN_MAGIC, "%%%1"))
+end
+
+-- Normalise a pattern fragment to start with "/". Plugins may write
+-- `path = "board/:id"` (no leading slash) — accept it.
+local function ensure_leading_slash(s)
+    if s == nil or s == "" then return "/" end
+    return s:sub(1, 1) == "/" and s or ("/" .. s)
+end
+
+-- Strip a trailing slash unless it's the root "/".
+local function strip_trailing_slash(s)
+    if s == "/" or s == "" then return "/" end
+    return s:gsub("/+$", "")
+end
+
+-- Compile a route pattern into a matcher.
+--
+-- Pattern syntax:
+--   * "/" — matches the empty/root subpath ("" or "/").
+--   * Literal segments like "/settings" — exact match after normalisation.
+--   * Named params like "/board/:id" — `:id` captures one segment (no slashes)
+--     and is exposed as `params.id`.
+--
+-- Returns a table:
+--   { pattern, lua_pattern, param_names, render }
+local function compile_route(path_pattern, render)
+    assert(type(render) == "function",
+        "surfaces.register: each route must declare `render = function(state, ctx) ... end`")
+    local normalised = ensure_leading_slash(path_pattern)
+    normalised = strip_trailing_slash(normalised)
+    if normalised == "" then normalised = "/" end
+
+    local param_names = {}
+    if normalised == "/" then
+        return {
+            pattern = "/",
+            lua_pattern = "^/?$",
+            param_names = param_names,
+            render = render,
+        }
+    end
+
+    local parts = { "^" }
+    for segment in normalised:gmatch("[^/]+") do
+        if segment:sub(1, 1) == ":" then
+            local name = segment:sub(2)
+            assert(name ~= "",
+                "surfaces.register: empty param name in route pattern `" .. path_pattern .. "`")
+            param_names[#param_names + 1] = name
+            parts[#parts + 1] = "/([^/]+)"
+        else
+            parts[#parts + 1] = "/" .. escape_lua_pattern(segment)
+        end
+    end
+    -- Accept either the exact form or a trailing slash so nav from `/board/42`
+    -- vs `/board/42/` lands the same route.
+    parts[#parts + 1] = "/?$"
+    return {
+        pattern = normalised,
+        lua_pattern = table.concat(parts),
+        param_names = param_names,
+        render = render,
+    }
+end
+
+-- Match a subpath against a single compiled route.
+-- @return params table on match, nil otherwise.
+local function match_compiled_route(compiled, subpath)
+    local s = ensure_leading_slash(subpath or "/")
+    -- Strip any query/fragment that leaked through — we only route by path.
+    s = s:gsub("[?#].*$", "")
+    -- For non-root routes, drop a trailing slash so "/board/42/" behaves like
+    -- "/board/42". The compiled regex already tolerates it but the `/` form
+    -- is canonical. Root stays root.
+    if s ~= "/" then s = strip_trailing_slash(s) end
+
+    if #compiled.param_names == 0 then
+        if s:match(compiled.lua_pattern) then return {} end
+        return nil
+    end
+    local captures = { s:match(compiled.lua_pattern) }
+    if captures[1] == nil then return nil end
+    local params = {}
+    for i, name in ipairs(compiled.param_names) do
+        params[name] = captures[i]
+    end
+    return params
+end
+
+-- Match `subpath` against each compiled route in order; return the first one
+-- that matches along with its extracted params, or nil.
+local function match_routes(compiled_routes, subpath)
+    for _, compiled in ipairs(compiled_routes) do
+        local params = match_compiled_route(compiled, subpath)
+        if params ~= nil then
+            return compiled, params
+        end
+    end
+    return nil, nil
+end
+
+-- Build a full hub-scoped URL by combining the hub_id, surface's base path,
+-- and a (possibly templated) subpath. `params` supplies values for `:name`
+-- placeholders in the subpath.
+--
+-- Rules:
+--   * `hub_id` must be a non-empty string; assertion otherwise.
+--   * `base_path` must start with "/"; "/" means "the hub root".
+--   * `subpath` may be "", "/", or start with "/". `:name` interpolated from
+--     params; missing params are left as `:name` literals so test output is
+--     easy to spot (and we don't paper over a bug).
+local function build_url(hub_id, base_path, subpath, params)
+    assert(is_nonempty_string(hub_id),
+        "surfaces.path: hub_id is required (pass it explicitly or ensure hub.server_id() is set)")
+    local base = base_path
+    if base == nil or base == "" then base = "/" end
+    base = ensure_leading_slash(base)
+
+    local sub = subpath
+    if sub == nil or sub == "" then sub = "/" end
+    sub = ensure_leading_slash(sub)
+
+    -- Interpolate params into the subpath. Missing params leave the literal
+    -- `:name` token so tests (and plugin authors) can spot the miss.
+    if params and next(params) ~= nil then
+        sub = sub:gsub(":([%w_]+)", function(name)
+            local v = params[name]
+            if v == nil then return ":" .. name end
+            return tostring(v)
+        end)
+    end
+
+    -- Assemble: /hubs/<hub_id> + base + sub. Avoid double slashes.
+    local prefix = "/hubs/" .. hub_id
+    local path
+    if base == "/" then
+        path = prefix
+    else
+        path = prefix .. strip_trailing_slash(base)
+    end
+    if sub == "/" then
+        if base == "/" then
+            -- Root hub page: prefer "/hubs/<id>" (no trailing slash)
+            return path
+        end
+        return path
+    end
+    return path .. sub
+end
+
+-- Construct the `ctx` table threaded to a sub-route's render fn.
+local function build_ctx(hub_id, surface_name, base_path)
+    return {
+        hub_id = hub_id,
+        surface = surface_name,
+        base_path = base_path,
+        path = function(sub, params)
+            return build_url(hub_id, base_path, sub, params)
+        end,
+    }
+end
+
+-- Derive the base path for a surface from its `name` unless `opts.path` is
+-- explicitly set (back-compat escape hatch used by `workspace_panel` to keep
+-- its URL at "/"). Pure plugin-authored surfaces always use the name-derived
+-- default so `surfaces.register("kanban", { routes = {...} })` is enough.
+local function derive_base_path(name, opts)
+    if is_nonempty_string(opts.path) then
+        return ensure_leading_slash(opts.path)
+    end
+    return "/" .. name
+end
+
+-- Build the array of compiled routes from the user's registration, applying
+-- the back-compat wrapper (top-level `render` → `routes = {{"/", render}}`).
+local function compile_routes(name, opts)
+    if opts.routes ~= nil then
+        assert(type(opts.routes) == "table" and #opts.routes > 0,
+            "surfaces.register(" .. name .. "): `routes` must be a non-empty array")
+        assert(opts.render == nil,
+            "surfaces.register(" .. name .. "): pass EITHER `routes` OR a single top-level `render`, not both")
+        local compiled = {}
+        for i, route in ipairs(opts.routes) do
+            assert(type(route) == "table",
+                "surfaces.register(" .. name .. "): routes[" .. i .. "] must be a table")
+            compiled[#compiled + 1] = compile_route(route.path or "/", route.render)
+        end
+        return compiled
+    end
+    assert(type(opts.render) == "function",
+        "surfaces.register(" .. name .. "): must provide `routes` or a top-level `render`")
+    return { compile_route("/", opts.render) }
+end
+
+-- Build the sub-route 404 fallback tree. Called when a surface's subpath
+-- doesn't match any declared route. Uses only v1 primitives so the browser
+-- renders it without Phase-4b client support.
+local function render_sub_404(surface_name, subpath)
+    return {
+        type = "panel",
+        props = { tone = "muted", border = true },
+        children = {
+            {
+                type = "stack",
+                props = { direction = "vertical", gap = "2", padding = "4" },
+                children = {
+                    {
+                        type = "text",
+                        props = {
+                            text = "Sub-route not found",
+                            size = "md",
+                            weight = "semibold",
+                            tone = "danger",
+                        },
+                    },
+                    {
+                        type = "text",
+                        props = {
+                            text = string.format(
+                                "Surface `%s` has no route matching `%s`.",
+                                surface_name, subpath or "/"
+                            ),
+                            size = "sm",
+                            tone = "muted",
+                        },
+                    },
+                },
+            },
+        },
+    }
+end
+
+-- Generate the top-level `entry.render(state)` dispatcher. Always goes through
+-- this even in the single-route back-compat case so `ctx` is available to the
+-- user's render fn uniformly.
+local function make_dispatcher(name, base_path, compiled_routes)
+    return function(render_state)
+        local s = type(render_state) == "table" and render_state or {}
+        local subpath = ensure_leading_slash(s.path or "/")
+        local compiled, params = match_routes(compiled_routes, subpath)
+        local hub_id = s.hub_id
+        local ctx = build_ctx(hub_id, name, base_path)
+        if compiled == nil then
+            log.warn(string.format(
+                "surfaces: no route matches subpath `%s` for surface `%s`",
+                subpath, name))
+            return render_sub_404(name, subpath)
+        end
+        -- Build a shallow-copied sub-state so the dispatcher's writes
+        -- (path/params) don't mutate the caller's state — some callers
+        -- reuse `state` across multiple surface renders.
+        local sub_state = {}
+        for k, v in pairs(s) do sub_state[k] = v end
+        sub_state.path = subpath
+        sub_state.params = params
+        return compiled.render(sub_state, ctx)
+    end
+end
+
 -- -------------------------------------------------------------------------
 -- Public API
 -- -------------------------------------------------------------------------
@@ -67,30 +370,53 @@ end
 function M.register(name, opts)
     assert(is_nonempty_string(name), "surfaces.register: name must be non-empty string")
     assert(type(opts) == "table", "surfaces.register: opts must be a table")
-    assert(type(opts.render) == "function", "surfaces.register: opts.render must be a function")
 
     local existing = registry.by_name[name]
     local seq = existing and existing.seq or (registry.seq + 1)
     if not existing then registry.seq = seq end
 
+    local compiled_routes = compile_routes(name, opts)
+    local base_path = derive_base_path(name, opts)
+    local render = make_dispatcher(name, base_path, compiled_routes)
+
     local entry = {
         name = name,
-        path = is_nonempty_string(opts.path) and opts.path or nil,
+        base_path = base_path,
+        -- `path` is preserved for consumers that still read the top-level
+        -- field (sidebar nav, route registry payload). It equals base_path
+        -- for routable surfaces; `nil` for surfaces that opted out via
+        -- `hide_from_nav` OR passed an empty routes+render pair. Since the
+        -- Phase-4b default always derives a base_path, `path` defaults to
+        -- it — meaning every registered surface is routable unless the
+        -- plugin explicitly sets `path = false` (or similar) to suppress it.
+        path = base_path,
         label = is_nonempty_string(opts.label) and opts.label or name,
         icon = is_nonempty_string(opts.icon) and opts.icon or nil,
-        render = opts.render,
+        render = render,
+        compiled_routes = compiled_routes,
         input_builder = type(opts.input_builder) == "function" and opts.input_builder or nil,
         hide_from_nav = opts.hide_from_nav == true,
         order = type(opts.order) == "number" and opts.order or nil,
         source = is_nonempty_string(opts.source) and opts.source or nil,
         seq = seq,
     }
+    -- A small number of legacy surfaces (workspace_sidebar) register WITHOUT
+    -- wanting to appear as a routable page. They omit both `path` and
+    -- `routes` in the old API; in the new API they still omit `routes` and
+    -- we must keep their `path` nil. Detect the "no-path, no-routes, just a
+    -- render" shape by checking that the caller did not pass `routes` AND
+    -- did not pass `path`: that means they registered for multi-surface
+    -- broadcast only, not for a URL route. In that case, strip `path`.
+    if opts.routes == nil and not is_nonempty_string(opts.path) then
+        entry.path = nil
+        entry.base_path = nil
+    end
     registry.by_name[name] = entry
 
     if log and log.debug then
         log.debug(string.format(
-            "surfaces.register: name=%s path=%s label=%s",
-            name, tostring(entry.path), tostring(entry.label)))
+            "surfaces.register: name=%s base_path=%s label=%s routes=%d",
+            name, tostring(entry.base_path), tostring(entry.label), #compiled_routes))
     end
     notify_changed()
     return entry
@@ -131,11 +457,36 @@ function M.get(name)
     return registry.by_name[name]
 end
 
---- Resolve a surface name to its declared path.
--- @return string path, or nil when the surface is non-routable (no `path`).
-function M.path(name)
+--- Build the canonical URL for a surface's subpath.
+---
+--- Cross-surface link helper. Pulls the hub_id from `hub.server_id()` so the
+--- caller doesn't have to thread it through.
+---
+--- Examples:
+---   surfaces.path("kanban", "/board/:id", { id = 42 })
+---     -> "/hubs/<hub_id>/kanban/board/42"
+---   surfaces.path("kanban")
+---     -> "/hubs/<hub_id>/kanban"
+---
+--- @param name string Registered surface name.
+--- @param subpath string? Subpath within the surface; defaults to "/".
+--- @param params table? `:name` param substitutions.
+--- @return string|nil Full URL, or nil when the surface is unknown or has no base_path.
+function M.path(name, subpath, params)
     local entry = M.get(name)
-    return entry and entry.path or nil
+    if not entry then return nil end
+    if not is_nonempty_string(entry.base_path) then
+        return nil
+    end
+    local hub_id
+    if type(hub) == "table" and type(hub.server_id) == "function" then
+        local ok, id = pcall(hub.server_id)
+        if ok and is_nonempty_string(id) then hub_id = id end
+    end
+    if not is_nonempty_string(hub_id) then
+        return nil
+    end
+    return build_url(hub_id, entry.base_path, subpath or "/", params)
 end
 
 --- Return a deterministic array view of the registry.
@@ -155,6 +506,7 @@ function M.list()
         out[#out + 1] = {
             name = name,
             path = entry.path,
+            base_path = entry.base_path,
             label = entry.label,
             icon = entry.icon,
             hide_from_nav = entry.hide_from_nav,
@@ -179,18 +531,33 @@ end
 -- routable page. `hide_from_nav` is passed through so the sidebar renderer
 -- can filter at display time; we still ship it in the registry because
 -- React Router needs to know about hidden paths in order to route to them.
+--
+-- Phase 4b: each registry entry also carries `routes` (the declared
+-- sub-patterns) so the browser can optionally pattern-match before firing
+-- its first subpath action. The hub remains the authority — mismatches
+-- fall through to the hub's auto-dispatcher 404 — but exposing the list
+-- lets the browser render an offline-friendly loading state.
 -- @param hub_id string|nil
 -- @return table
 function M.build_route_registry_payload(hub_id)
     local routes = {}
-    for _, entry in ipairs(M.list()) do
-        if entry.path then
+    for _, summary in ipairs(M.list()) do
+        if summary.path then
+            local entry = registry.by_name[summary.name]
+            local sub_patterns = {}
+            if entry and entry.compiled_routes then
+                for _, compiled in ipairs(entry.compiled_routes) do
+                    sub_patterns[#sub_patterns + 1] = { path = compiled.pattern }
+                end
+            end
             routes[#routes + 1] = {
-                path = entry.path,
-                surface = entry.name,
-                label = entry.label,
-                icon = entry.icon,
-                hide_from_nav = entry.hide_from_nav or nil,
+                path = summary.path,
+                base_path = summary.base_path,
+                surface = summary.name,
+                label = summary.label,
+                icon = summary.icon,
+                hide_from_nav = summary.hide_from_nav or nil,
+                routes = sub_patterns,
             }
         end
     end
@@ -239,6 +606,12 @@ function M._reset_for_tests()
     for k in pairs(registry.by_name) do registry.by_name[k] = nil end
     registry.seq = 0
 end
+
+-- Test-only export: expose internal helpers for unit-level coverage without
+-- requiring the full layout broadcast wire-up.
+M._build_url = build_url
+M._compile_route = compile_route
+M._match_routes = match_routes
 
 -- Hot-reload lifecycle
 function M._before_reload()

--- a/cli/lua/plugins/hello_surface/plugin.lua
+++ b/cli/lua/plugins/hello_surface/plugin.lua
@@ -1,7 +1,20 @@
--- Phase 4a demo plugin — registers a hub-authored surface at
--- `/plugins/hello` so the end-to-end substrate (surface registry +
--- ui_route_registry_v1 broadcast + DynamicSurfaceRoute) can be exercised
--- without any Rails route changes or hand-crafted React components.
+-- Phase 4a/4b demo plugin — registers a hub-authored surface with multiple
+-- sub-routes so the end-to-end substrate (surface registry +
+-- ui_route_registry_v1 broadcast + sub-route dispatcher + DynamicSurface) can
+-- be exercised without any Rails route changes or hand-crafted React
+-- components.
+--
+-- Phase 4b switched the API: instead of a single `render` at a declared
+-- `path`, a surface declares `routes = { { path, render }, ... }` and the
+-- base URL is derived from the registration name. For "hello" the URL tree
+-- is:
+--
+--   /hubs/<hub_id>/hello             → home (first route)
+--   /hubs/<hub_id>/hello/details/:id → details page (pattern params)
+--
+-- This file deliberately shows a cross-sub-route link via `ctx.path(...)` so
+-- the browser exercises the path-change → re-render wire design (new
+-- `botster.surface.subpath` action).
 --
 -- ENV GATE (important): this file is only loaded by `hub/init.lua` when
 -- `BOTSTER_DEV=1` OR `BOTSTER_ENV=test`. Production hubs skip it so real
@@ -17,7 +30,11 @@
 -- author follows the same `surfaces.register(...)` contract regardless of
 -- where their `plugin.lua` lives.
 
-local function build_tree(_state)
+local function home_page(_state, ctx)
+    -- The link target is built via `ctx.path` so the URL always matches the
+    -- surface's own base, even if somebody later renames the registration.
+    -- Passing `{ id = 1 }` substitutes into ":id" in the pattern.
+    local details_url = ctx.path("/details/:id", { id = 1 })
     return ui.stack{
         direction = "vertical",
         gap = "3",
@@ -32,24 +49,75 @@ local function build_tree(_state)
                         gap = "2",
                         children = {
                             ui.text{
-                                text = "Hello from a plugin-registered surface",
+                                text = "Hello — Phase 4b sub-routes demo",
                                 size = "md",
                                 weight = "semibold",
                             },
                             ui.text{
-                                text = "This page is rendered by cli/lua/plugins/hello_surface/plugin.lua. "
-                                    .. "It was reachable at /hubs/:hub_id/plugins/hello without a "
-                                    .. "single Rails route, React component, or controller change — "
-                                    .. "the hub broadcasts ui_route_registry_v1 and ui_layout_tree_v1, "
-                                    .. "and the browser mounts a UiTree bound to this surface.",
+                                text = "This surface declares TWO sub-routes: `/` (this page) and "
+                                    .. "`/details/:id`. The hub's sub-route dispatcher extracts "
+                                    .. ":id from the URL and threads it into the details render. "
+                                    .. "Click below to navigate — the browser sends a "
+                                    .. "`botster.surface.subpath` action and the hub re-renders "
+                                    .. "just this surface with the new state.",
                                 size = "sm",
                                 tone = "muted",
                             },
+                            ui.button{
+                                label = "Open details for id=1",
+                                icon = "arrow-right",
+                                variant = "ghost",
+                                tone = "default",
+                                action = ui.action("botster.nav.open", { path = details_url }),
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    }
+end
+
+local function details_page(state, ctx)
+    -- state.params.id comes from the `/details/:id` pattern match. Missing
+    -- params should never happen here (the dispatcher only routes us here
+    -- on a match) but defend anyway so a bad URL typed into the bar doesn't
+    -- emit a nil-formatted string.
+    local id = (state.params and state.params.id) or "?"
+    local home_url = ctx.path("/")
+    return ui.stack{
+        direction = "vertical",
+        gap = "3",
+        padding = "4",
+        children = {
+            ui.panel{
+                tone = "default",
+                border = true,
+                children = {
+                    ui.stack{
+                        direction = "vertical",
+                        gap = "2",
+                        children = {
                             ui.text{
-                                text = "Phase 4a: substrate proven.",
-                                size = "xs",
-                                tone = "accent",
-                                monospace = true,
+                                text = string.format("Details for id=%s", id),
+                                size = "md",
+                                weight = "semibold",
+                            },
+                            ui.text{
+                                text = "Subpath params are extracted by `lib.surfaces` and handed "
+                                    .. "to your sub-route render as `state.params`. The surface "
+                                    .. "base path and `ctx.path(...)` helper mean you never "
+                                    .. "hardcode `/hubs/<hub_id>/...` — rename the registration "
+                                    .. "and every link moves with it.",
+                                size = "sm",
+                                tone = "muted",
+                            },
+                            ui.button{
+                                label = "Back to hello home",
+                                icon = "arrow-left",
+                                variant = "ghost",
+                                tone = "default",
+                                action = ui.action("botster.nav.open", { path = home_url }),
                             },
                         },
                     },
@@ -67,17 +135,19 @@ local function minimal_input(_client, _sub_id)
 end
 
 local entry = surfaces.register("hello", {
-    path = "/plugins/hello",
     label = "Hello",
     icon = "sparkle",
     order = 1000,
     source = "plugin:hello_surface",
-    render = build_tree,
+    routes = {
+        { path = "/",              render = home_page },
+        { path = "/details/:id",   render = details_page },
+    },
     input_builder = minimal_input,
 })
 
 log.info(string.format(
-    "plugins/hello_surface: registered surface `%s` at %s",
-    entry.name, entry.path))
+    "plugins/hello_surface: registered surface `%s` at %s (%d routes)",
+    entry.name, tostring(entry.base_path), #entry.compiled_routes))
 
 return true

--- a/cli/tests/ui_surface_registry_test.rs
+++ b/cli/tests/ui_surface_registry_test.rs
@@ -252,24 +252,95 @@ fn surfaces_unregister_removes_entry() {
 }
 
 #[test]
-fn surfaces_path_resolves_registered_path() {
+fn surfaces_path_derives_base_from_name_and_returns_full_url() {
     let _lock = lock_env();
     let lua = new_test_lua();
 
+    // Phase 4b: `surfaces.path(name)` returns the full hub-scoped URL
+    // (`/hubs/<id>/<name>`) — NOT the relative base. Callers writing
+    // `ui.action("botster.nav.open", { path = surfaces.path("kanban") })`
+    // expect an absolute URL that React Router can `pushState` directly.
+    // The hub id is sourced from `hub.server_id()` ("hub-test" in the
+    // test harness).
     let path: String = lua
         .load(
             r#"
-            surfaces.register("routed", {
-                path = "/foo/bar",
-                render = function() return {type="panel", props={}} end,
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/", render = function() return {type="panel", props={}} end },
+                },
             })
-            return surfaces.path("routed")
+            return surfaces.path("kanban")
             "#,
         )
         .eval()
         .expect("path");
 
-    assert_eq!(path, "/foo/bar");
+    assert_eq!(path, "/hubs/hub-test/kanban");
+}
+
+#[test]
+fn surfaces_path_interpolates_named_params() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let url: String = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/board/:id", render = function() return {type="panel", props={}} end },
+                },
+            })
+            return surfaces.path("kanban", "/board/:id", { id = 42 })
+            "#,
+        )
+        .eval()
+        .expect("interpolate");
+
+    assert_eq!(url, "/hubs/hub-test/kanban/board/42");
+}
+
+#[test]
+fn surfaces_path_honours_legacy_path_escape_hatch() {
+    // Regression guard for built-in surfaces like `workspace_panel` that
+    // register with `path = "/"` (or any other legacy base) instead of
+    // using the name-derived convention. `surfaces.path` must thread the
+    // explicit base through the URL builder so
+    //   surfaces.path("legacy", "/sub") = "/hubs/:id/weird/thing/sub"
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (root, deep): (String, String) = lua
+        .load(
+            r#"
+            surfaces.register("legacy", {
+                path = "/weird/thing",
+                render = function() return {type="panel", props={}} end,
+            })
+            local root = surfaces.path("legacy")
+            local deep = surfaces.path("legacy", "/sub", nil)
+            return root, deep
+            "#,
+        )
+        .eval()
+        .expect("legacy escape hatch");
+
+    assert_eq!(root, "/hubs/hub-test/weird/thing");
+    assert_eq!(deep, "/hubs/hub-test/weird/thing/sub");
+}
+
+#[test]
+fn surfaces_path_returns_nil_for_unknown_surface() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let value: Value = lua
+        .load(r#"return surfaces.path("never_registered")"#)
+        .eval()
+        .expect("unknown surface");
+
+    assert!(matches!(value, Value::Nil));
 }
 
 #[test]
@@ -782,4 +853,421 @@ fn route_registry_includes_hide_from_nav_entries_with_flag() {
         .collect();
     assert!(pairs.contains(&("visible".to_string(), false)));
     assert!(pairs.contains(&("hidden".to_string(), true)));
+}
+
+// -------------------------------------------------------------------------
+// Phase 4b — sub-routes, params, ctx, subpath re-render
+// -------------------------------------------------------------------------
+
+#[test]
+fn multi_route_dispatcher_routes_subpaths_and_extracts_params() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Register a multi-route surface; directly exercise the generated
+    // `entry.render` dispatcher with synthetic `state.path` values to prove
+    // each sub-route fires and `state.params` carries the named captures.
+    let (home_hit, details_id, settings_hit): (String, String, String) = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/",           render = function(s, _ctx) return { type = "panel", props = { tag = "home", path = s.path } } end },
+                    { path = "/board/:id",  render = function(s, _ctx) return { type = "panel", props = { tag = "board", id = s.params.id } } end },
+                    { path = "/settings",   render = function(s, _ctx) return { type = "panel", props = { tag = "settings", path = s.path } } end },
+                },
+            })
+            local entry = surfaces.get("kanban")
+            local home = entry.render({ hub_id = "hub-test", path = "/" })
+            local board = entry.render({ hub_id = "hub-test", path = "/board/42" })
+            local settings = entry.render({ hub_id = "hub-test", path = "/settings" })
+            return home.props.tag, board.props.id, settings.props.tag
+            "#,
+        )
+        .eval()
+        .expect("multi-route dispatcher");
+
+    assert_eq!(home_hit, "home");
+    assert_eq!(details_id, "42");
+    assert_eq!(settings_hit, "settings");
+}
+
+#[test]
+fn multi_route_dispatcher_renders_sub_404_for_unknown_subpath() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (ty, title): (String, String) = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/", render = function() return { type = "panel", props = { tag = "home" } } end },
+                },
+            })
+            local entry = surfaces.get("kanban")
+            local tree = entry.render({ hub_id = "hub-test", path = "/does/not/exist" })
+            -- Sub-404 tree is a panel whose first text child is "Sub-route not found".
+            local text = tree.children[1].children[1].props.text
+            return tree.type, text
+            "#,
+        )
+        .eval()
+        .expect("sub-404");
+
+    assert_eq!(ty, "panel");
+    assert!(
+        title.starts_with("Sub-route not found"),
+        "expected sub-404 tree, got: {title}"
+    );
+}
+
+#[test]
+fn ctx_path_builds_full_hub_scoped_url_from_subpath_template() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (root_url, board_url, missing_param): (String, String, String) = lua
+        .load(
+            r#"
+            local captured_root, captured_board, captured_missing
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/", render = function(_s, ctx)
+                        captured_root = ctx.path("/")
+                        captured_board = ctx.path("/board/:id", { id = 99 })
+                        -- Missing params leave the `:name` literal so tests
+                        -- can catch the miss rather than silently rendering
+                        -- a broken URL.
+                        captured_missing = ctx.path("/board/:id", {})
+                        return { type = "panel", props = {} }
+                    end },
+                },
+            })
+            local entry = surfaces.get("kanban")
+            entry.render({ hub_id = "hub-test", path = "/" })
+            return captured_root, captured_board, captured_missing
+            "#,
+        )
+        .eval()
+        .expect("ctx.path");
+
+    assert_eq!(root_url, "/hubs/hub-test/kanban");
+    assert_eq!(board_url, "/hubs/hub-test/kanban/board/99");
+    assert_eq!(missing_param, "/hubs/hub-test/kanban/board/:id");
+}
+
+#[test]
+fn ctx_surface_and_base_path_are_exposed_to_sub_route_render() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (surface_name, base_path, hub_id): (String, String, String) = lua
+        .load(
+            r#"
+            local captured
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/", render = function(_s, ctx)
+                        captured = { surface = ctx.surface, base_path = ctx.base_path, hub_id = ctx.hub_id }
+                        return { type = "panel", props = {} }
+                    end },
+                },
+            })
+            surfaces.get("kanban").render({ hub_id = "hub-test", path = "/" })
+            return captured.surface, captured.base_path, captured.hub_id
+            "#,
+        )
+        .eval()
+        .expect("ctx introspection");
+
+    assert_eq!(surface_name, "kanban");
+    assert_eq!(base_path, "/kanban");
+    assert_eq!(hub_id, "hub-test");
+}
+
+#[test]
+fn backwards_compat_top_level_render_wraps_in_single_route() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Plugins that pass a single top-level `render` (Phase 4a style) are
+    // internally wrapped into `routes = { { path = "/", render = fn } }`
+    // so the dispatcher path is uniform. This test proves the wrapper:
+    //   * entry.compiled_routes contains exactly one route
+    //   * the render fn still runs for state.path == "/"
+    //   * a non-root path falls through to the sub-404 renderer
+    let (route_count, home_hit, unknown_tag): (i64, String, String) = lua
+        .load(
+            r#"
+            surfaces.register("legacy", {
+                render = function(s, _ctx) return { type = "panel", props = { tag = "legacy", path = s.path } } end,
+            })
+            local entry = surfaces.get("legacy")
+            local home = entry.render({ hub_id = "hub-test", path = "/" })
+            local miss = entry.render({ hub_id = "hub-test", path = "/elsewhere" })
+            -- Sub-404 top-level is a panel wrapping a stack that contains
+            -- a text whose text starts with "Sub-route not found".
+            local miss_text = miss.children[1].children[1].props.text
+            return #entry.compiled_routes, home.props.tag, miss_text
+            "#,
+        )
+        .eval()
+        .expect("back-compat wrapper");
+
+    assert_eq!(route_count, 1);
+    assert_eq!(home_hit, "legacy");
+    assert!(
+        unknown_tag.starts_with("Sub-route not found"),
+        "expected sub-404 for non-root path in back-compat mode, got: {unknown_tag}"
+    );
+}
+
+#[test]
+fn register_rejects_both_routes_and_top_level_render() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Mixing API styles is a programming error — we assert loudly.
+    let result: mlua::Result<Value> = lua
+        .load(
+            r#"
+            surfaces.register("hybrid", {
+                render = function() return { type = "panel", props = {} } end,
+                routes = {
+                    { path = "/", render = function() return { type = "panel", props = {} } end },
+                },
+            })
+            return true
+            "#,
+        )
+        .eval();
+
+    match result {
+        Ok(_) => panic!("expected assertion error for hybrid registration"),
+        Err(err) => {
+            let msg = err.to_string();
+            assert!(
+                msg.contains("EITHER") || msg.contains("routes") || msg.contains("render"),
+                "assertion should mention the hybrid API conflict, got: {msg}"
+            );
+        }
+    }
+}
+
+#[test]
+fn path_segment_matching_escapes_pattern_metacharacters() {
+    // A literal "/" in a segment is fine, but any Lua-pattern metachar (".")
+    // must be matched literally; otherwise "/board.json" would accidentally
+    // match "/boardxjson". This is a regression guard for the pattern
+    // compiler in surfaces.lua.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (literal_hit, wrong_type, wrong_tag, wrong_text): (bool, String, String, String) = lua
+        .load(
+            r#"
+            surfaces.register("plain", {
+                routes = {
+                    { path = "/hello.world", render = function() return { type = "panel", props = { tag = "literal" } } end },
+                },
+            })
+            local entry = surfaces.get("plain")
+            local exact = entry.render({ hub_id = "hub-test", path = "/hello.world" })
+            local wrong = entry.render({ hub_id = "hub-test", path = "/helloXworld" })
+            local is_literal = exact.props and exact.props.tag == "literal"
+            local text = ""
+            if wrong.children and wrong.children[1] and wrong.children[1].children and wrong.children[1].children[1] then
+                text = wrong.children[1].children[1].props.text or ""
+            end
+            return is_literal, wrong.type or "?", (wrong.props and wrong.props.tag) or "?", text
+            "#,
+        )
+        .eval()
+        .expect("pattern escape");
+
+    assert!(literal_hit, "literal dot must match literal dot");
+    assert_eq!(wrong_type, "panel", "wrong should be a panel (sub-404 wrapper)");
+    assert_ne!(
+        wrong_tag, "literal",
+        "literal dot must NOT match arbitrary char (got the literal render instead of sub-404); wrong={wrong_type:?} wrong_tag={wrong_tag:?} text={wrong_text:?}"
+    );
+    assert!(
+        wrong_text.contains("Sub-route not found"),
+        "expected sub-404 text for arbitrary-char mismatch; got: {wrong_text:?}"
+    );
+}
+
+#[test]
+fn route_pattern_matches_trailing_slash_variants() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (no_slash, with_slash): (String, String) = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/board/:id", render = function(s) return { type = "panel", props = { id = s.params.id } } end },
+                },
+            })
+            local entry = surfaces.get("kanban")
+            local a = entry.render({ hub_id = "hub-test", path = "/board/7" }).props.id
+            local b = entry.render({ hub_id = "hub-test", path = "/board/7/" }).props.id
+            return a, b
+            "#,
+        )
+        .eval()
+        .expect("trailing slash");
+
+    assert_eq!(no_slash, "7");
+    assert_eq!(with_slash, "7");
+}
+
+#[test]
+fn layout_broadcast_threads_client_subpath_into_render_state() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Simulate the client carrying a `surface_subpaths` map; `build_frames`
+    // should resolve the subpath into `state.path` before the render, so
+    // the dispatcher routes to the matching sub-route.
+    let rendered_tag: String = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/",          render = function(_s, _ctx) return { type = "panel", props = { tag = "home" } } end },
+                    { path = "/board/:id", render = function(s, _ctx) return { type = "panel", props = { tag = "board", id = s.params.id } } end },
+                },
+                input_builder = function(_c, _s) return { hub_id = "hub-test" } end,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+            -- Stand-in client with a subpath map (production-side client.lua
+            -- owns this; tests stub it so we don't need to boot a full client).
+            local fake_client = { surface_subpaths = { kanban = "/board/9" } }
+            local frames = LayoutBroadcast.build_frames(nil, {
+                subscription_key = "sub-kanban",
+                client = fake_client,
+                force = true,
+            })
+            -- Find the frame for "kanban" — iteration order mirrors registration.
+            local tree
+            for _, f in ipairs(frames) do
+                if f.target_surface == "kanban" then tree = f.tree end
+            end
+            assert(tree, "expected a kanban frame")
+            return tree.props.tag
+            "#,
+        )
+        .eval()
+        .expect("layout_broadcast subpath threading");
+
+    assert_eq!(rendered_tag, "board");
+}
+
+#[test]
+fn layout_broadcast_targeted_only_surface_re_renders_one_surface() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let emitted: Vec<String> = lua
+        .load(
+            r#"
+            surfaces.register("alpha", {
+                render = function(s, _ctx) return { type = "panel", props = { path = s.path } } end,
+                input_builder = function() return { hub_id = "hub-test" } end,
+            })
+            surfaces.register("beta", {
+                render = function(s, _ctx) return { type = "panel", props = { path = s.path } } end,
+                input_builder = function() return { hub_id = "hub-test" } end,
+            })
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+            local frames = LayoutBroadcast.build_frames(nil, {
+                subscription_key = "sub",
+                client = { surface_subpaths = {} },
+                only_surface = "beta",
+                force = true,
+            })
+            local names = {}
+            for _, f in ipairs(frames) do names[#names + 1] = f.target_surface end
+            return names
+            "#,
+        )
+        .eval()
+        .expect("only_surface filter");
+
+    assert_eq!(emitted, vec!["beta"]);
+}
+
+#[test]
+fn route_registry_payload_carries_base_path_and_sub_routes() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let payload_json: String = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                label = "Kanban",
+                icon = "squares-2x2",
+                routes = {
+                    { path = "/",          render = function() return { type = "panel", props = {} } end },
+                    { path = "/board/:id", render = function() return { type = "panel", props = {} } end },
+                    { path = "/settings",  render = function() return { type = "panel", props = {} } end },
+                },
+            })
+            return json.encode(surfaces.build_route_registry_payload("hub-test"))
+            "#,
+        )
+        .eval()
+        .expect("route registry payload");
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&payload_json).expect("parse payload");
+    let routes = parsed.get("routes").and_then(|v| v.as_array()).unwrap();
+    let entry = routes
+        .iter()
+        .find(|r| r.get("surface").and_then(|v| v.as_str()) == Some("kanban"))
+        .expect("kanban entry");
+
+    assert_eq!(entry.get("base_path").and_then(|v| v.as_str()), Some("/kanban"));
+    // `path` mirrors `base_path` for routable surfaces so older browsers
+    // still see a valid top-level URL.
+    assert_eq!(entry.get("path").and_then(|v| v.as_str()), Some("/kanban"));
+
+    let sub_routes = entry.get("routes").and_then(|v| v.as_array()).expect("routes[]");
+    let sub_paths: Vec<&str> = sub_routes
+        .iter()
+        .filter_map(|r| r.get("path").and_then(|v| v.as_str()))
+        .collect();
+    assert_eq!(sub_paths, vec!["/", "/board/:id", "/settings"]);
+}
+
+#[test]
+fn demo_hello_plugin_registers_with_two_routes() {
+    // Regression guard for `plugins/hello_surface/plugin.lua` — Phase 4b
+    // migrated it to the multi-route API. This test is the canonical
+    // "the demo still loads and the substrate is wired up" smoke test.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let (name, base_path, route_count): (String, String, i64) = lua
+            .load(
+                r#"
+                require("plugins.hello_surface.plugin")
+                local entry = surfaces.get("hello")
+                return entry.name, entry.base_path, #entry.compiled_routes
+                "#,
+            )
+            .eval()
+            .expect("hello demo plugin registered");
+
+        assert_eq!(name, "hello");
+        assert_eq!(base_path, "/hello");
+        assert_eq!(route_count, 2);
+    });
 }

--- a/test/controllers/spa_controller_test.rb
+++ b/test/controllers/spa_controller_test.rb
@@ -30,6 +30,27 @@ class SpaControllerTest < ActionDispatch::IntegrationTest
     assert_select "#app"
   end
 
+  test "wildcard hub route handles Phase 4b sub-route URLs with params" do
+    # `surfaces.register("kanban", { routes = { { path = "/board/:id" } } })`
+    # produces `/hubs/:id/kanban/board/42` as the canonical URL. The Rails
+    # catch-all must hand the whole thing to SPA#hub regardless of depth so
+    # React Router's DynamicSurfaceRoute can prefix-match `base_path = "/kanban"`.
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/kanban/board/42"
+    assert_response :success
+    assert_select "#app"
+  end
+
+  test "wildcard hub route tolerates 4+ segment Phase 4b deep links" do
+    # A plugin could register `/team/:team_id/board/:board_id/card/:card_id`
+    # — four segments after the base. The catch-all must still route
+    # regardless of depth.
+    sign_in @user
+    get "/hubs/#{@active_hub.id}/boards/team/42/board/7/card/99"
+    assert_response :success
+    assert_select "#app"
+  end
+
   test "wildcard hub route still accepts the legacy sessions path" do
     sign_in @user
     get "/hubs/#{@active_hub.id}/sessions/some-session-uuid"


### PR DESCRIPTION
## Summary

Evolves the surface registry (shipped in Phase 4a / PR #176) so plugins no longer hand-type `/hubs/:hub_id/...` prefixes. The base path `/hubs/:hub_id/:plugin_name` is derived automatically; plugins declare sub-routes with `:param` capture; a scoped `ctx.path(subpath, params)` helper builds URLs from inside render.

### New API

```lua
surfaces.register("kanban", {
  label = "Kanban",
  routes = {
    { path = "/",          render = kanban_home },
    { path = "/board/:id", render = kanban_board },   -- params.id extracted
    { path = "/settings",  render = kanban_settings },
  },
})
```

Inside a sub-route's `render(state, ctx)`:
- `state.path` — subpath within the surface (e.g. `/board/42`)
- `state.params` — matched `:name` captures (e.g. `{id = "42"}`)
- `ctx.path("/board/:id", {id = 42})` — builds `/hubs/<hub_id>/kanban/board/42`
- `ctx.hub_id`, `ctx.surface`, `ctx.base_path` — convenience
- Cross-surface: `surfaces.path("kanban", "/board/:id", {id = 42})`

**Back-compat**: plugins passing only `render = fn` at the top level (Phase 4a shape) are auto-wrapped into `routes = { {path = "/", render = fn} }`. An explicit `opts.path` escape hatch is honoured for built-ins (`workspace_panel` stays at `/`, `workspace_sidebar` stays unrouted).

### Wire change

New action `botster.surface.subpath` (TRANSPORT): browser tells hub its current subpath when the URL changes within a surface. Hub stores on `client.surface_subpaths[name]` and re-renders just that `(client, surface)` pair — NOT a full broadcast. Mirrors the existing `client.selected_session_uuid` pattern.

### Cold-load & cross-surface nav

- **Cold deep link** `/hubs/:id/kanban/board/42` ships the correct-subpath frame first (not `/` then `/board/42`). Achieved via subscribe-time prime of `surface_subpaths` + UiTree frame.subpath filter.
- **Cross-surface live nav** (e.g. `/hello/details/1` → `/kanban/board/42`): first-mount suppression is keyed on transport identity alone. Per-surface last-sent cache ensures the action fires exactly once on real transitions, and never refires when the user navigates back to an already-sent subpath.

### Reference implementation

`cli/lua/plugins/hello_surface/plugin.lua` migrated to two routes (`/` home + `/details/:id`) with an inter-page link via `ctx.path(...)`. Gated behind `BOTSTER_DEV=1`/`BOTSTER_ENV=test` as before.

## Rails

No changes — the catch-all `/hubs/:hub_id/*path` from Phase 4a handles arbitrary depth. New `spa_controller_test` cases cover 3 and 5 segment depths.

## Codex audit

- Initial verdict: **BLOCKING** — one finding (`UiTree` cross-surface first-mount suppression also suppressed legitimate live transitions).
- Fix commit `084911be`: key first-mount skip on transport identity, not `(transport, targetSurface)`. Per-surface sent-cache.
- 2 regression tests added: exact cross-surface repro + back-nav cache-hit guard.
- Re-audit verdict: **APPROVED**, no findings.

## Test plan

- [x] `./test.sh` (CLI) — 1308 unit + all integration suites PASS (32 surface-registry tests)
- [x] `npx vitest --run` — 20 files, 160 tests PASS (+2 regression)
- [x] `npx tsc --noEmit` — clean
- [x] `bin/rails test` — 436 runs, 0 failures
- [x] Codex approved on `084911be`
- [ ] Live: enable `BOTSTER_DEV=1`, navigate to Hello → Details page; confirm inter-page link uses the scoped helper; deep-link directly to `/hubs/:id/hello/details/7` cold and confirm no `/` flash
- [ ] Live: cross-surface nav between workspace panel and plugin surface, confirm no stale render

🤖 Generated with [Claude Code](https://claude.com/claude-code)