### PR TITLE
fix(web+cli): UiTree fresh-mount send + hello plugin padding + integration tests

### DIFF
--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -459,8 +459,16 @@ export default function UiTree({
     const normalisedSubpath =
       typeof subpath === 'string' && subpath !== '' ? subpath : '/'
 
+    // transport.send returns a Promise that REJECTS when the DataChannel
+    // isn't open yet (e.g. cold mount during WebRTC handshake). If we
+    // don't attach a .catch handler, the rejection surfaces as an
+    // "Uncaught Error: DataChannel closed" in the browser console —
+    // harmless for the user (the subscribe envelope already primed the
+    // hub and the hub will dedup if we resend later) but the system
+    // tests assert on an empty console.
+    let sendPromise
     try {
-      void transport.send('ui_action_v1', {
+      sendPromise = transport.send('ui_action_v1', {
         target_surface: targetSurface,
         envelope: {
           id: 'botster.surface.subpath',
@@ -469,6 +477,12 @@ export default function UiTree({
       })
     } catch (err) {
       console.warn('[UiTree] failed to send surface.subpath', err)
+      return undefined
+    }
+    if (sendPromise && typeof sendPromise.catch === 'function') {
+      sendPromise.catch((err) => {
+        console.warn('[UiTree] surface.subpath send rejected', err)
+      })
     }
     return undefined
   }, [transport, targetSurface, subpath])

--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -437,54 +437,28 @@ export default function UiTree({
   }, [transport, targetSurface, subpath])
 
   // Phase 4b: whenever the (target_surface, subpath) pair changes, tell
-  // the hub so it can re-render for this client. The initial subpath for
-  // the surface the user LANDED on is already primed via the subscribe
-  // envelope (`channelParams().surface_subpaths` in `hub_connection.js`);
-  // that primed surface+subpath is skipped so we don't double-send on
-  // cold load.
+  // the hub so it can re-render for this client.
   //
-  // All other cases fire:
-  //   * Cross-surface navigation on the SAME transport (hub has never
-  //     heard about the new surface's subpath — the envelope only primed
-  //     the one surface the user cold-loaded into).
-  //   * Intra-surface navigation (subpath changes within the current
-  //     targetSurface).
-  //   * Hub switch: the new transport is brand-new, so re-prime from
-  //     whatever surface the user is currently viewing.
+  // We send unconditionally on every mount / change. Idempotency lives on
+  // the hub: `Client:set_surface_subpath` early-returns when the incoming
+  // subpath equals the previously-stored value, so repeating what the
+  // subscribe envelope already primed is a cheap no-op.
   //
-  // Tracking: per-transport map of `surface -> last-sent subpath`. A
-  // brand-new transport installs a single entry reflecting the currently
-  // rendered surface (that's what the subscribe envelope primed) and
-  // suppresses the send. Every other transition updates the map and
-  // sends.
-  const subpathSyncRef = useRef({ transport: null, sentBySurface: null })
+  // An earlier revision tried to skip the first send on a "cold transport"
+  // under the assumption that a single UiTree instance would persist
+  // across surface transitions. In practice UiTree is mounted by
+  // different parent routes (HubShow for workspace_panel, DynamicSurface
+  // for plugin surfaces), so crossing a Route boundary mounts a FRESH
+  // UiTree instance whose per-instance skip-cache looks "cold" even
+  // though the transport has been open for a while. That left the hub
+  // without the new surface's subpath and the UiTree stuck on loading.
+  // The always-send path above sidesteps the remount-vs-rerender
+  // distinction entirely.
   useEffect(() => {
     if (!transport || !targetSurface) return undefined
-    const sync = subpathSyncRef.current
     const normalisedSubpath =
       typeof subpath === 'string' && subpath !== '' ? subpath : '/'
 
-    const isColdTransport = sync.transport !== transport
-    if (isColdTransport) {
-      // Brand-new subscription — the subscribe envelope already primed
-      // the hub for THIS (surface, subpath). Seed the sent-cache so
-      // future renders compare against it.
-      subpathSyncRef.current = {
-        transport,
-        sentBySurface: new Map([[targetSurface, normalisedSubpath]]),
-      }
-      return undefined
-    }
-
-    // Same transport — did we already tell the hub about this
-    // (surface, subpath)? If not, send.
-    const lastSent = sync.sentBySurface.get(targetSurface)
-    if (lastSent === normalisedSubpath) return undefined
-    sync.sentBySurface.set(targetSurface, normalisedSubpath)
-
-    // Best-effort — a failed send is harmless; the hub's default is "/"
-    // and the next user action will re-fire. No await; fire-and-forget
-    // keeps the render path fast.
     try {
       void transport.send('ui_action_v1', {
         target_surface: targetSurface,

--- a/app/frontend/test/session-actions-menu.test.jsx
+++ b/app/frontend/test/session-actions-menu.test.jsx
@@ -109,6 +109,10 @@ describe('<SessionActionsMenu> interceptor', () => {
     const trigger = await screen.findByRole('button', {
       name: 'Session actions',
     })
+    // Drop the initial surface.subpath send — this test only cares that
+    // the clicked menu-open action is CONSUMED by the interceptor and
+    // never forwarded to transport.
+    fakeTransport.send.mockClear()
     fireEvent.click(trigger)
     await Promise.resolve()
     await Promise.resolve()

--- a/app/frontend/test/ui-tree.test.jsx
+++ b/app/frontend/test/ui-tree.test.jsx
@@ -142,6 +142,11 @@ describe('<UiTree>', () => {
     await act(async () => {
       await new Promise((resolve) => setTimeout(resolve, 150))
     })
+    // Clear pre-switch sends (transportA got its initial surface.subpath
+    // send on mount; that is expected and unrelated to the cross-transport
+    // routing we are asserting).
+    transportA.send.mockClear()
+    transportB.send.mockClear()
     captured?.({
       id: 'botster.session.select',
       payload: { sessionId: 's-x' },
@@ -243,7 +248,6 @@ describe('<UiTree>', () => {
   })
 
   it('falls back to legacy dispatch when transport.send returns false', async () => {
-    fakeTransport.send.mockResolvedValueOnce(false)
     render(<UiTree hubId="hub-1" targetSurface="workspace_panel" />)
 
     await act(async () => {
@@ -253,6 +257,13 @@ describe('<UiTree>', () => {
         tree: SELECT_BUTTON_TREE,
       })
     })
+
+    // Let the initial surface.subpath send settle before arming the
+    // next-send-fails behaviour we're actually testing here.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+    })
+    fakeTransport.send.mockResolvedValueOnce(false)
 
     fireEvent.click(await screen.findByRole('button', { name: 'Select' }))
     await Promise.resolve()
@@ -388,6 +399,10 @@ describe('<UiTree> interceptor context', () => {
         tree: SELECT_BUTTON_TREE,
       })
     })
+    // Clear the initial surface.subpath send (unrelated to this test's
+    // intercept semantics — we only care that the clicked action is
+    // consumed, not forwarded).
+    fakeTransport.send.mockClear()
     fireEvent.click(await screen.findByRole('button', { name: 'Select' }))
     await Promise.resolve()
     expect(intercept).toHaveBeenCalledOnce()
@@ -442,10 +457,14 @@ describe('<UiTree> interceptor context', () => {
 })
 
 describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
-  it('does NOT send a surface.subpath action on first mount (subscribe envelope primes)', async () => {
-    // The subscribe channelParams already include `surface_subpaths`, so
-    // the hub is primed BEFORE the UiTree mounts. Sending another action
-    // on first mount would double-send for every cold load.
+  it('sends surface.subpath on first mount', async () => {
+    // UiTree always announces its current (surface, subpath) to the hub on
+    // mount. The subscribe envelope also primes `surface_subpaths` server-
+    // side, so repeating the value is a no-op on the hub
+    // (`set_surface_subpath` early-returns on identical subpath). The fresh
+    // mount send is what keeps cross-Route boundary navigation correct —
+    // HubShow → DynamicSurface mounts a NEW UiTree instance for a new
+    // surface, and the hub must hear about it.
     render(
       <UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />,
     )
@@ -455,23 +474,27 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     const subpathCalls = fakeTransport.send.mock.calls.filter(
       ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
     )
-    expect(subpathCalls).toHaveLength(0)
+    expect(subpathCalls).toHaveLength(1)
+    expect(subpathCalls[0][1]).toEqual({
+      target_surface: 'kanban',
+      envelope: {
+        id: 'botster.surface.subpath',
+        payload: { target_surface: 'kanban', subpath: '/board/42' },
+      },
+    })
   })
 
   it('sends surface.subpath on subpath prop change and clears the tree', async () => {
     const { rerender } = render(
       <UiTree hubId="hub-1" targetSurface="kanban" subpath="/" />,
     )
-    // Wait for transport attach.
+    // Wait for transport attach + initial mount send.
     await act(async () => {
       await new Promise((r) => setTimeout(r, 120))
     })
-    // Initial render has no tree yet, but the first subpath must not fire.
-    expect(
-      fakeTransport.send.mock.calls.filter(
-        ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
-      ),
-    ).toHaveLength(0)
+    // Clear the initial mount send so the assertion below only counts the
+    // subpath-change send we're testing.
+    fakeTransport.send.mockClear()
 
     // Push a home-render tree so the panel is visible.
     await act(async () => {
@@ -496,7 +519,7 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     // sub-page for a tick).
     expect(screen.queryByText('home')).toBeNull()
 
-    // Exactly one surface.subpath action fired.
+    // Exactly one surface.subpath action fired for the new subpath.
     const calls = fakeTransport.send.mock.calls.filter(
       ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
     )
@@ -553,28 +576,16 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
 
   // Regression: codex-found blocker (2026-04-21). Cross-surface navigation
   // on the SAME transport must fire `botster.surface.subpath` for the new
-  // (surface, subpath) pair. Previously the first-mount-skip was keyed on
-  // `(transport, targetSurface)`, which incorrectly treated every surface
-  // change as "cold mount" and suppressed the send. That left the hub's
-  // `client.surface_subpaths` empty for the new surface, so the dispatcher
-  // routed to the surface's default "/" render — the user sees the wrong
-  // sub-page (or loading) indefinitely.
+  // (surface, subpath) pair so the hub's dispatcher routes to the right
+  // sub-route instead of leaving the UiTree stuck on loading.
   it('fires surface.subpath when targetSurface changes on an existing transport', async () => {
     const { rerender } = render(
       <UiTree hubId="hub-1" targetSurface="hello" subpath="/details/1" />,
     )
-    // Let the transport attach (cold mount — suppressed, correctly).
     await act(async () => {
       await new Promise((r) => setTimeout(r, 120))
     })
-    expect(
-      fakeTransport.send.mock.calls.filter(
-        ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
-      ),
-    ).toHaveLength(0)
 
-    // Navigate to a different surface with a non-root subpath. Same
-    // transport, same hubId — just a surface switch.
     rerender(
       <UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />,
     )
@@ -586,8 +597,14 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     const calls = fakeTransport.send.mock.calls.filter(
       ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
     )
-    expect(calls).toHaveLength(1)
-    expect(calls[0][1]).toEqual({
+    // Expect sends for BOTH the initial mount and the kanban transition.
+    // The hub-side `set_surface_subpath` early-returns on equal subpath so
+    // the extra initial send is harmless; we drop the per-instance cache.
+    const kanbanSends = calls.filter(
+      ([, body]) => body.envelope.payload.target_surface === 'kanban',
+    )
+    expect(kanbanSends).toHaveLength(1)
+    expect(kanbanSends[0][1]).toEqual({
       target_surface: 'kanban',
       envelope: {
         id: 'botster.surface.subpath',
@@ -596,47 +613,43 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     })
   })
 
-  it('does not refire when the user navigates back to a surface at a subpath already sent', async () => {
-    // Hello → Kanban(/board/42) → Hello → Kanban(/board/42). The first
-    // Kanban visit sends; the second should NOT (last-sent cache hit).
-    const { rerender } = render(
-      <UiTree hubId="hub-1" targetSurface="hello" subpath="/" />,
+  // Regression (2026-04-22): UiTree must send `botster.surface.subpath` on
+  // FRESH MOUNT, not just on prop rerender. Real-world navigation crosses
+  // Route boundaries (HubShow for workspace_panel → DynamicSurface for
+  // plugin surfaces) and each boundary mounts a NEW UiTree instance.
+  // An earlier revision kept a per-instance skip-cache that treated every
+  // new instance as "cold transport" and silently suppressed the send,
+  // leaving the hub without the new surface's subpath and the user stuck
+  // on loading.
+  it('fires surface.subpath on a fresh mount for a non-cold transport', async () => {
+    // Simulate a stable transport by mounting UiTree once first (its own
+    // initial send won't be suppressed), then UNMOUNT and mount a fresh
+    // instance for a different surface — this is the HubShow→DynamicSurface
+    // transition in the real app.
+    const first = render(
+      <UiTree hubId="hub-1" targetSurface="workspace_panel" subpath="/" />,
     )
     await act(async () => {
       await new Promise((r) => setTimeout(r, 120))
     })
+    first.unmount()
+    fakeTransport.send.mockClear()
 
-    rerender(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />)
+    render(<UiTree hubId="hub-1" targetSurface="hello" subpath="/" />)
     await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
+      await new Promise((r) => setTimeout(r, 120))
     })
 
-    rerender(<UiTree hubId="hub-1" targetSurface="hello" subpath="/" />)
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-
-    rerender(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/board/42" />)
-    await act(async () => {
-      await Promise.resolve()
-      await Promise.resolve()
-    })
-
-    const subpathCalls = fakeTransport.send.mock.calls.filter(
+    const calls = fakeTransport.send.mock.calls.filter(
       ([, body]) => body?.envelope?.id === 'botster.surface.subpath',
     )
-    // Expected sends:
-    //   1. hello(cold): skipped
-    //   2. kanban(new): send kanban /board/42
-    //   3. hello(new for this sync map after hello cold-skip): send hello "/"
-    //   4. kanban(cached same): skipped
-    // => 2 sends total. The important invariant (regression guard) is
-    //    that the kanban re-visit at step 4 does NOT refire.
-    const kanbanSends = subpathCalls.filter(
-      ([, body]) => body.envelope.payload.target_surface === 'kanban',
-    )
-    expect(kanbanSends).toHaveLength(1)
+    expect(calls).toHaveLength(1)
+    expect(calls[0][1]).toEqual({
+      target_surface: 'hello',
+      envelope: {
+        id: 'botster.surface.subpath',
+        payload: { target_surface: 'hello', subpath: '/' },
+      },
+    })
   })
 })

--- a/app/frontend/test/ui-tree.test.jsx
+++ b/app/frontend/test/ui-tree.test.jsx
@@ -484,6 +484,42 @@ describe('<UiTree> subpath wire protocol (Phase 4b)', () => {
     })
   })
 
+  // Regression (2026-04-22): system-test caught "Uncaught Error: DataChannel
+  // closed" in the browser console during WebRTC handshake because
+  // transport.send returns a rejecting Promise when the DataChannel isn't
+  // open yet. `void transport.send(...)` swallows the return value but the
+  // rejection still fires as an unhandled rejection. UiTree must attach a
+  // .catch handler so the rejection is consumed — the subscribe envelope
+  // already primed the hub and the next nav will re-fire.
+  it('handles a rejecting transport.send without raising unhandled rejection', async () => {
+    const rejected = Promise.reject(new Error('DataChannel closed'))
+    // Keep the rejection plumbing: attach a noop catch to the PROMISE WE
+    // RETURN from send so Node's test runner sees a handled rejection too.
+    rejected.catch(() => {})
+    fakeTransport.send.mockReturnValueOnce(rejected)
+
+    const unhandledSpy = vi.fn()
+    const onUnhandled = (event) => {
+      unhandledSpy(event.reason)
+    }
+    window.addEventListener('unhandledrejection', onUnhandled)
+
+    try {
+      render(<UiTree hubId="hub-1" targetSurface="kanban" subpath="/" />)
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 120))
+      })
+      // Microtask flush so the rejecting promise has a chance to report.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(unhandledSpy).not.toHaveBeenCalled()
+    } finally {
+      window.removeEventListener('unhandledrejection', onUnhandled)
+    }
+  })
+
   it('sends surface.subpath on subpath prop change and clears the tree', async () => {
     const { rerender } = render(
       <UiTree hubId="hub-1" targetSurface="kanban" subpath="/" />,

--- a/cli/lua/lib/surfaces.lua
+++ b/cli/lua/lib/surfaces.lua
@@ -299,7 +299,7 @@ local function render_sub_404(surface_name, subpath)
         children = {
             {
                 type = "stack",
-                props = { direction = "vertical", gap = "2", padding = "4" },
+                props = { direction = "vertical", gap = "2" },
                 children = {
                     {
                         type = "text",

--- a/cli/lua/plugins/hello_surface/plugin.lua
+++ b/cli/lua/plugins/hello_surface/plugin.lua
@@ -38,7 +38,6 @@ local function home_page(_state, ctx)
     return ui.stack{
         direction = "vertical",
         gap = "3",
-        padding = "4",
         children = {
             ui.panel{
                 tone = "default",
@@ -88,7 +87,6 @@ local function details_page(state, ctx)
     return ui.stack{
         direction = "vertical",
         gap = "3",
-        padding = "4",
         children = {
             ui.panel{
                 tone = "default",

--- a/cli/tests/ui_surface_registry_test.rs
+++ b/cli/tests/ui_surface_registry_test.rs
@@ -1271,3 +1271,152 @@ fn demo_hello_plugin_registers_with_two_routes() {
         assert_eq!(route_count, 2);
     });
 }
+
+// -------------------------------------------------------------------------
+// End-to-end: web_layout.render → registry fallback → plugin render
+// -------------------------------------------------------------------------
+//
+// These tests exercise the exact path the hub takes when the browser sends
+// `botster.surface.subpath` for a plugin-registered surface: the Rust
+// `web_layout.render(surface, state)` consults the override layout table
+// (nothing for plugin names), falls through to `_G.surfaces.render_node`,
+// the dispatcher matches the subpath against declared routes, and the
+// plugin's sub-route render fn returns a tree.
+//
+// Regression bar: a user clicking the Hello sidebar entry must receive a
+// real Hello home tree, NOT the error-fallback panel (`Layout error:
+// hello` / "The hub layout failed to render. Showing fallback.").
+
+fn assert_not_error_fallback(json: &serde_json::Value, surface_name: &str) {
+    let title = json
+        .pointer("/props/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        !title.starts_with("Layout error"),
+        "web_layout.render returned the error fallback for `{surface_name}` \
+         (title={title:?}); the registry fallback did not resolve the \
+         plugin-registered surface. Full tree: {json}"
+    );
+}
+
+#[test]
+fn hello_plugin_home_renders_through_web_layout() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let json: String = lua
+            .load(
+                r#"
+                require("plugins.hello_surface.plugin")
+                return web_layout.render("hello", { hub_id = "hub-test", path = "/" })
+                "#,
+            )
+            .eval()
+            .expect("render hello home");
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_not_error_fallback(&parsed, "hello");
+
+        let text_blob = parsed.to_string();
+        assert!(
+            text_blob.contains("Phase 4b sub-routes demo"),
+            "hello home tree must contain the home_page text, got: {text_blob}"
+        );
+    });
+}
+
+#[test]
+fn hello_plugin_details_renders_with_param_through_web_layout() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let json: String = lua
+            .load(
+                r#"
+                require("plugins.hello_surface.plugin")
+                return web_layout.render("hello", {
+                    hub_id = "hub-test",
+                    path = "/details/7",
+                })
+                "#,
+            )
+            .eval()
+            .expect("render hello details");
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_not_error_fallback(&parsed, "hello");
+
+        let text_blob = parsed.to_string();
+        assert!(
+            text_blob.contains("Details for id=7"),
+            "details render must interpolate :id=7 into state.params, got: {text_blob}"
+        );
+    });
+}
+
+#[test]
+fn hello_plugin_default_path_falls_through_to_home() {
+    // When the browser hasn't yet announced its subpath, the hub renders
+    // with an unset state.path; the dispatcher normalises to "/" which
+    // must match the home route.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let json: String = lua
+            .load(
+                r#"
+                require("plugins.hello_surface.plugin")
+                return web_layout.render("hello", { hub_id = "hub-test" })
+                "#,
+            )
+            .eval()
+            .expect("render hello with no path");
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_not_error_fallback(&parsed, "hello");
+
+        let text_blob = parsed.to_string();
+        assert!(
+            text_blob.contains("Phase 4b sub-routes demo"),
+            "nil/unset state.path must route to the home sub-page, got: {text_blob}"
+        );
+    });
+}
+
+#[test]
+fn hello_plugin_unknown_subpath_renders_sub_404_not_error_fallback() {
+    // A known surface with an unknown subpath is NOT the same as an unknown
+    // surface: the dispatcher returns the sub-route 404 tree, which is
+    // still a valid UiNodeV1 and must NOT be confused with the
+    // Rust-level "Layout error:" fallback.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    with_demo_env(None, Some("test"), || {
+        let json: String = lua
+            .load(
+                r#"
+                require("plugins.hello_surface.plugin")
+                return web_layout.render("hello", {
+                    hub_id = "hub-test",
+                    path = "/does-not-exist",
+                })
+                "#,
+            )
+            .eval()
+            .expect("render hello unknown sub");
+
+        let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+        assert_not_error_fallback(&parsed, "hello");
+
+        let text_blob = parsed.to_string();
+        assert!(
+            text_blob.contains("Sub-route not found"),
+            "unknown subpath must render the dispatcher 404 tree, got: {text_blob}"
+        );
+    });
+}


### PR DESCRIPTION
## Summary

Two interrelated bugs surfaced by manual testing after Phase 4b merged (PR #177). Both caught by the user clicking the \`Hello\` sidebar entry and watching it fail.

### Bug 1 — UiTree fresh-mount suppression (e33d29de)

Phase 4b's cross-surface-nav fix assumed a single UiTree instance persists across surface transitions. In production, UiTree is mounted by different parent routes — \`HubShow\` owns workspace_panel, \`DynamicSurface\` owns plugin-surface instances — so crossing a Route boundary mounts a FRESH component whose per-instance \`subpathSyncRef\` starts in \"cold transport\" state and silently suppresses the first \`botster.surface.subpath\` send. Result: hub never learned about the new surface's subpath, UiTree stuck on \"Loading…\" forever.

Fix: drop the per-instance skip-cache. Always send \`botster.surface.subpath\` on mount. Hub-side \`Client:set_surface_subpath\` early-returns when the incoming subpath equals the previously-stored value, so re-asserting what the subscribe envelope already primed is a cheap no-op.

Tests: collapsed the old \"no send on first mount\" tests; added a **fresh-mount-on-existing-transport** regression test that unmount+remounts for a new surface.

### Bug 2 — Invalid \`padding\` prop on \`ui.stack\` (7b0a58fb)

Once Bug 1 was fixed, clicking Hello rendered \"Layout error: hello / no layout surface registered for \`hello\`\" instead of the plugin's home page. Root cause: \`hello_surface/plugin.lua\` and \`lib/surfaces.lua\`'s sub-404 helper both passed \`padding = \"4\"\` to \`ui.stack{}\` — but Stack's allowed props are only \`direction\`, \`gap\`, \`align\`, \`justify\` (\`cli/src/ui_contract/lua.rs:153\`). Registration succeeded (render fns are closures), the error only fired when the dispatcher actually called them, and the Rust fallback surfaced it as the misleading \"no layout surface registered\" message.

Fix: remove \`padding\` from both call sites. \`DynamicSurface\` already wraps the tree in \`p-4/lg:p-6\` on the React side.

**Why existing tests didn't catch this:** \`demo_hello_plugin_registers_with_two_routes\` verified registration lands in the registry but never called \`web_layout.render(\"hello\", ...)\`. Registration alone is cheap; the bug only shows when the dispatcher invokes the render closure.

### New integration tests (closes the gap)

Four tests in \`ui_surface_registry_test.rs\` that exercise the full render pipeline end-to-end:

- \`hello_plugin_home_renders_through_web_layout\`
- \`hello_plugin_details_renders_with_param_through_web_layout\`
- \`hello_plugin_default_path_falls_through_to_home\`
- \`hello_plugin_unknown_subpath_renders_sub_404_not_error_fallback\`

Each asserts the resulting tree is **NOT** the \"Layout error:\" fallback and contains the expected plugin content. These reproduce exactly the failure modes manual testing caught, so any future regression in the Rust-side fallback path or plugin-side render-time errors fails loudly in CI.

## Test plan

- [x] \`./test.sh\` — 1308 unit + all integration suites pass (including 36 surface-registry tests, +4 from this PR)
- [x] \`npx vitest --run\` — 20 files, 160 tests pass (ui-tree.test.jsx covers the fresh-mount regression)
- [x] Live: click Hello in sidebar → see the home page with the link to \`/details/1\` → click through and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)