### PR TITLE
feat: deterministic readiness hooks for system tests

### DIFF
--- a/app/frontend/components/AppShell.jsx
+++ b/app/frontend/components/AppShell.jsx
@@ -31,6 +31,14 @@ import DialogHost from './DialogHost'
 import TerminalCache from './terminal/TerminalCache'
 import { setHubId } from '../lib/modal-bridge'
 import { subscribeHubListUpdates, useHubStore } from '../store/hub-store'
+import {
+  useRouteRegistryStore,
+  selectHasRouteRegistrySnapshot,
+} from '../store/route-registry-store'
+import {
+  useSurfaceReadinessStore,
+  selectHasAnySurfaceForHub,
+} from '../store/surface-readiness-store'
 
 // Lazy-loaded route components
 const Home = React.lazy(() => import('./pages/Home'))
@@ -46,6 +54,91 @@ function SuspenseFallback() {
       <div className="text-sm text-zinc-500">Loading...</div>
     </div>
   )
+}
+
+// ---------------------------------------------------------------------------
+// System-test readiness: root-level DOM signals
+//
+// These write state directly to `<html>` as data attributes so Capybara can
+// wait on causal preconditions instead of downstream leaf UI effects. See
+// `test/support/system_readiness_helpers.rb` for the test-side helpers.
+//
+//   <html data-cli-status="unknown|handshaking|connected|offline">
+//     The integrated browser-to-hub dispatch path. Derived from
+//     `useHubStore.connectionState` which already combines browser socket +
+//     relay + hub health. 'connected' means the browser CAN send and expect
+//     responses; any other value means it can't yet.
+//
+//   <html data-hub-snapshot="pending|received">
+//     Flips to 'received' when BOTH the `ui_route_registry_v1` snapshot for
+//     the selected hub has landed AND at least one `ui_layout_tree_v1` frame
+//     for that hub has arrived. Resets to 'pending' on hub switch.
+// ---------------------------------------------------------------------------
+
+function mapConnectionStateToCliStatus(connectionState, selectedHubId) {
+  if (!selectedHubId) return 'unknown'
+  switch (connectionState) {
+    case 'connected':
+      return 'connected'
+    case 'connecting':
+    case 'pairing_needed':
+      return 'handshaking'
+    case 'disconnected':
+    case 'error':
+      return 'offline'
+    default:
+      return 'unknown'
+  }
+}
+
+function RootReadinessSignals() {
+  const selectedHubId = useHubStore((s) => s.selectedHubId)
+  const connectionState = useHubStore((s) => s.connectionState)
+  const hasRouteRegistry = useRouteRegistryStore((s) =>
+    selectHasRouteRegistrySnapshot(s, selectedHubId),
+  )
+  const hasAnySurface = useSurfaceReadinessStore((s) =>
+    selectHasAnySurfaceForHub(s, selectedHubId),
+  )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const status = mapConnectionStateToCliStatus(
+      connectionState,
+      selectedHubId,
+    )
+    document.documentElement.dataset.cliStatus = status
+  }, [connectionState, selectedHubId])
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const received = !!selectedHubId && hasRouteRegistry && hasAnySurface
+    document.documentElement.dataset.hubSnapshot = received
+      ? 'received'
+      : 'pending'
+  }, [selectedHubId, hasRouteRegistry, hasAnySurface])
+
+  // Clear the surface-readiness record for the PREVIOUS hub when the
+  // selection changes. Route-registry state is per-hub and lives in
+  // its own store; surface readiness needs the same per-hub reset so the
+  // hub-snapshot signal returns to 'pending' on hub switch until the new
+  // hub's first tree arrives.
+  const lastHubRef = useRef(null)
+  useEffect(() => {
+    const prev = lastHubRef.current
+    lastHubRef.current = selectedHubId
+    if (prev && prev !== selectedHubId) {
+      useSurfaceReadinessStore.getState().clearForHub(prev)
+    }
+  }, [selectedHubId])
+
+  return null
+}
+
+// Exported for vitest.
+export {
+  mapConnectionStateToCliStatus as _mapConnectionStateToCliStatusForTests,
+  RootReadinessSignals as _RootReadinessSignalsForTests,
 }
 
 function CogIcon() {
@@ -335,6 +428,7 @@ export function AppRoutes() {
 export default function AppShell() {
   return (
     <BrowserRouter>
+      <RootReadinessSignals />
       <React.Suspense fallback={<SuspenseFallback />}>
         <AppRoutes />
       </React.Suspense>

--- a/app/frontend/components/UiTree.jsx
+++ b/app/frontend/components/UiTree.jsx
@@ -14,6 +14,7 @@ import {
 } from '../ui_contract'
 import { getHub } from '../lib/hub-bridge'
 import { useWorkspaceStore } from '../store/workspace-store'
+import { useSurfaceReadinessStore } from '../store/surface-readiness-store'
 
 // ---------------------------------------------------------------------------
 // Tree decoration — applies browser-local ephemeral UI state (workspace
@@ -432,9 +433,19 @@ export default function UiTree({
         return
       }
       setTree(message.tree ?? null)
+      // System-test readiness: first tree for this (hub, surface) pair
+      // records into the readiness store, feeding `<html data-hub-snapshot>`.
+      // Record on EVERY frame: the store is idempotent per (hub, surface),
+      // so this is cheap, and it means hub-switch + remount still records
+      // correctly after `clearForHub`.
+      if (hubId) {
+        useSurfaceReadinessStore
+          .getState()
+          .recordFirstTree(hubId, targetSurface)
+      }
     }
     return transport.on('message', handler)
-  }, [transport, targetSurface, subpath])
+  }, [transport, targetSurface, subpath, hubId])
 
   // Phase 4b: whenever the (target_surface, subpath) pair changes, tell
   // the hub so it can re-render for this client.
@@ -540,21 +551,33 @@ export default function UiTree({
     [register, dispatch],
   )
 
+  // System-test readiness attributes: Capybara waits `[data-surface-ready=X]`
+  // to exist and `[...state=loading]` to disappear before interacting with the
+  // surface. The wrapper div is a zero-cost addition (display: contents) so it
+  // doesn't affect layout of the hub-authored tree inside.
+  const surfaceReadyState = tree ? 'ready' : 'loading'
+
   return (
     <InterceptorContext.Provider value={interceptorValue}>
-      <UiTreeErrorBoundary tree={decoratedTree} fallback={errorFallback}>
-        {decoratedTree ? (
-          <UiTreeBody
-            node={decoratedTree}
-            dispatch={dispatch}
-            capabilities={capabilities}
-            hubId={hubId}
-          />
-        ) : (
-          loadingFallback()
-        )}
-      </UiTreeErrorBoundary>
-      {children}
+      <div
+        data-surface-ready={targetSurface || undefined}
+        data-surface-ready-state={targetSurface ? surfaceReadyState : undefined}
+        style={{ display: 'contents' }}
+      >
+        <UiTreeErrorBoundary tree={decoratedTree} fallback={errorFallback}>
+          {decoratedTree ? (
+            <UiTreeBody
+              node={decoratedTree}
+              dispatch={dispatch}
+              capabilities={capabilities}
+              hubId={hubId}
+            />
+          ) : (
+            loadingFallback()
+          )}
+        </UiTreeErrorBoundary>
+        {children}
+      </div>
     </InterceptorContext.Provider>
   )
 }

--- a/app/frontend/components/settings/ConfigEditor.jsx
+++ b/app/frontend/components/settings/ConfigEditor.jsx
@@ -682,9 +682,21 @@ function TargetSelector() {
 export default function ConfigEditor({ agentTemplates }) {
   const treeState = useSettingsStore((s) => s.treeState)
   const treeFeedback = useSettingsStore((s) => s.treeFeedback)
+  const configScope = useSettingsStore((s) => s.configScope)
+
+  // System-test readiness signal: the scope-specific tree scan has completed.
+  // Absent during 'loading'/'disconnected'; present when 'tree' (files found)
+  // or 'empty' (scan done, nothing there). The `data-settings-ready-state`
+  // lets helpers optionally narrow to one. See test/support/system_readiness_helpers.rb.
+  const settingsReadyState =
+    treeState === 'tree' || treeState === 'empty' ? treeState : null
 
   return (
-    <div className="max-w-4xl mx-auto px-4 py-6 lg:py-8">
+    <div
+      className="max-w-4xl mx-auto px-4 py-6 lg:py-8"
+      data-settings-ready={settingsReadyState ? configScope : undefined}
+      data-settings-ready-state={settingsReadyState || undefined}
+    >
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Tree Navigation (left) */}
         <div className="lg:col-span-1">

--- a/app/frontend/store/surface-readiness-store.js
+++ b/app/frontend/store/surface-readiness-store.js
@@ -1,0 +1,55 @@
+import { create } from 'zustand'
+
+// Per-hub, per-surface record of "first ui_layout_tree_v1 frame landed".
+// Feeds the root-level `<html data-hub-snapshot>` signal (in AppShell) and
+// is the second precondition alongside the route-registry snapshot.
+//
+// Deliberately a separate store from `route-registry-store`: the two
+// preconditions have independent sources (route registry is a single
+// per-hub broadcast, surface readiness is per-surface, published by each
+// `UiTree` mount) and keeping them decoupled avoids coupling the
+// registry's normalisation logic to UiTree's frame loop.
+//
+// Shape:
+//   surfacesByHubId: { [hubId]: Set<targetSurface> }
+//
+// `recordFirstTree` is idempotent: the first call per (hub, surface)
+// mutates; subsequent calls with the same pair are no-ops (identity
+// preserved so zustand subscribers don't re-render on repeat frames).
+
+export const useSurfaceReadinessStore = create((set, get) => ({
+  surfacesByHubId: {},
+
+  recordFirstTree(hubId, surface) {
+    if (!hubId || !surface) return
+    const key = String(hubId)
+    const existing = get().surfacesByHubId[key]
+    if (existing && existing.has(surface)) return
+    const next = new Set(existing ?? [])
+    next.add(surface)
+    set((s) => ({
+      surfacesByHubId: { ...s.surfacesByHubId, [key]: next },
+    }))
+  },
+
+  clearForHub(hubId) {
+    if (!hubId) return
+    const key = String(hubId)
+    set((s) => {
+      if (!(key in s.surfacesByHubId)) return s
+      const copy = { ...s.surfacesByHubId }
+      delete copy[key]
+      return { surfacesByHubId: copy }
+    })
+  },
+}))
+
+export function selectHasAnySurfaceForHub(state, hubId) {
+  if (!hubId) return false
+  const entry = state.surfacesByHubId[String(hubId)]
+  return !!entry && entry.size > 0
+}
+
+export function resetSurfaceReadinessStoreForTest() {
+  useSurfaceReadinessStore.setState({ surfacesByHubId: {} })
+}

--- a/app/frontend/test/system-readiness-signals.test.jsx
+++ b/app/frontend/test/system-readiness-signals.test.jsx
@@ -1,0 +1,322 @@
+import React from 'react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+import {
+  _mapConnectionStateToCliStatusForTests as mapCliStatus,
+  _RootReadinessSignalsForTests as RootReadinessSignals,
+} from '../components/AppShell'
+
+import { useHubStore } from '../store/hub-store'
+import { useRouteRegistryStore } from '../store/route-registry-store'
+import {
+  useSurfaceReadinessStore,
+  resetSurfaceReadinessStoreForTest,
+} from '../store/surface-readiness-store'
+
+import * as hubBridge from '../lib/hub-bridge'
+import UiTree from '../components/UiTree'
+
+// The ui_contract interpreter is imported transitively by UiTree. Mock the
+// actions module (UiTree's only external dependency from ../lib/actions)
+// the same way ui-tree.test.jsx does so we can focus on the readiness
+// wrapper's DOM attributes.
+vi.mock('../lib/actions', () => ({
+  ACTION: { SESSION_SELECT: 'botster.session.select' },
+  safeUrl: (u) => u ?? null,
+  dispatch: vi.fn(),
+}))
+
+class FakeTransport {
+  constructor() {
+    this._listeners = new Map()
+    this.send = vi.fn(async () => true)
+  }
+  on(event, callback) {
+    if (!this._listeners.has(event)) this._listeners.set(event, new Set())
+    this._listeners.get(event).add(callback)
+    return () => this._listeners.get(event)?.delete(callback)
+  }
+  emit(event, payload) {
+    const callbacks = this._listeners.get(event)
+    if (!callbacks) return
+    for (const cb of callbacks) cb(payload)
+  }
+}
+
+const HELLO_TREE = {
+  type: 'stack',
+  props: { direction: 'vertical' },
+  children: [{ type: 'text', props: { text: 'hello' } }],
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// mapConnectionStateToCliStatus — pure function, no DOM needed
+// ────────────────────────────────────────────────────────────────────────
+
+describe('mapConnectionStateToCliStatus', () => {
+  it('returns unknown when no hub is selected', () => {
+    expect(mapCliStatus('connected', null)).toBe('unknown')
+    expect(mapCliStatus('disconnected', null)).toBe('unknown')
+    expect(mapCliStatus(undefined, null)).toBe('unknown')
+  })
+
+  it('maps connected → connected', () => {
+    expect(mapCliStatus('connected', '42')).toBe('connected')
+  })
+
+  it('maps connecting and pairing_needed → handshaking', () => {
+    expect(mapCliStatus('connecting', '42')).toBe('handshaking')
+    expect(mapCliStatus('pairing_needed', '42')).toBe('handshaking')
+  })
+
+  it('maps disconnected and error → offline', () => {
+    expect(mapCliStatus('disconnected', '42')).toBe('offline')
+    expect(mapCliStatus('error', '42')).toBe('offline')
+  })
+
+  it('falls back to unknown for unexpected states', () => {
+    expect(mapCliStatus('weird_state', '42')).toBe('unknown')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────
+// RootReadinessSignals — writes to <html data-cli-status> / data-hub-snapshot
+//
+// We mount the full AppRoutes-less shell: just <RootReadinessSignals /> is
+// enough since it's a rendering null component that only has side effects.
+// Importing AppRoutes pulls lazy-loaded pages we don't need.
+// ────────────────────────────────────────────────────────────────────────
+
+describe('html data-cli-status', () => {
+  beforeEach(() => {
+    // Reset the html dataset between tests
+    delete document.documentElement.dataset.cliStatus
+    delete document.documentElement.dataset.hubSnapshot
+
+    useHubStore.setState({
+      hubList: [],
+      hubListLoading: false,
+      selectedHubId: null,
+      connectionState: 'disconnected',
+      connectionDetail: '',
+      _connectionRef: null,
+      _statusUnsub: null,
+      fetchHubList: vi.fn(async () => []),
+      selectHub: vi.fn(async () => {}),
+      disconnectHub: vi.fn(),
+      getLastHubId: vi.fn(() => null),
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // Rather than mount the whole AppShell (which has lazy routes and wants
+  // a real hub connection), we mount just the RootReadinessSignals island
+  // by hand. Using React's lazy machinery in unit tests is fragile, and
+  // the island's only input is two zustand stores + one document side-
+  // effect that we can exercise directly.
+  function mountOnlyRootReadinessSignals() {
+    return render(
+      <MemoryRouter>
+        <RootReadinessSignals />
+      </MemoryRouter>,
+    )
+  }
+
+  it('starts unknown when no hub is selected', () => {
+    mountOnlyRootReadinessSignals()
+    expect(document.documentElement.dataset.cliStatus).toBe('unknown')
+  })
+
+  it('transitions through handshaking to connected as state changes', async () => {
+    mountOnlyRootReadinessSignals()
+
+    act(() => {
+      useHubStore.setState({
+        selectedHubId: '42',
+        connectionState: 'connecting',
+      })
+    })
+    expect(document.documentElement.dataset.cliStatus).toBe('handshaking')
+
+    act(() => {
+      useHubStore.setState({ connectionState: 'connected' })
+    })
+    expect(document.documentElement.dataset.cliStatus).toBe('connected')
+
+    act(() => {
+      useHubStore.setState({ connectionState: 'disconnected' })
+    })
+    expect(document.documentElement.dataset.cliStatus).toBe('offline')
+  })
+})
+
+describe('html data-hub-snapshot', () => {
+  beforeEach(() => {
+    delete document.documentElement.dataset.cliStatus
+    delete document.documentElement.dataset.hubSnapshot
+    resetSurfaceReadinessStoreForTest()
+    useRouteRegistryStore.setState({
+      routesByHubId: {},
+      snapshotReceivedAtByHubId: {},
+    })
+    useHubStore.setState({
+      selectedHubId: null,
+      connectionState: 'disconnected',
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  function mountOnlyRootReadinessSignals() {
+    return render(
+      <MemoryRouter>
+        <RootReadinessSignals />
+      </MemoryRouter>,
+    )
+  }
+
+  it('stays pending until both preconditions land', () => {
+    mountOnlyRootReadinessSignals()
+    act(() => {
+      useHubStore.setState({ selectedHubId: '42' })
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('pending')
+
+    // Route registry only → still pending.
+    act(() => {
+      useRouteRegistryStore.getState().setRoutes('42', [])
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('pending')
+
+    // Surface readiness only (reset registry to prove the AND) → still pending.
+    act(() => {
+      useRouteRegistryStore.setState({
+        routesByHubId: {},
+        snapshotReceivedAtByHubId: {},
+      })
+      useSurfaceReadinessStore
+        .getState()
+        .recordFirstTree('42', 'workspace_panel')
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('pending')
+
+    // BOTH land → flips to received.
+    act(() => {
+      useRouteRegistryStore.getState().setRoutes('42', [])
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('received')
+  })
+
+  it('reverts to pending on hub switch and re-arms for the new hub', () => {
+    mountOnlyRootReadinessSignals()
+
+    act(() => {
+      useHubStore.setState({ selectedHubId: '42' })
+      useRouteRegistryStore.getState().setRoutes('42', [])
+      useSurfaceReadinessStore
+        .getState()
+        .recordFirstTree('42', 'workspace_panel')
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('received')
+
+    act(() => {
+      useHubStore.setState({ selectedHubId: '99' })
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('pending')
+
+    act(() => {
+      useRouteRegistryStore.getState().setRoutes('99', [])
+      useSurfaceReadinessStore
+        .getState()
+        .recordFirstTree('99', 'workspace_panel')
+    })
+    expect(document.documentElement.dataset.hubSnapshot).toBe('received')
+  })
+})
+
+// ────────────────────────────────────────────────────────────────────────
+// UiTree data-surface-ready wrapper
+// ────────────────────────────────────────────────────────────────────────
+
+describe('UiTree [data-surface-ready]', () => {
+  let fakeTransport
+
+  beforeEach(() => {
+    resetSurfaceReadinessStoreForTest()
+    fakeTransport = new FakeTransport()
+    vi.spyOn(hubBridge, 'getHub').mockReturnValue({ transport: fakeTransport })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('starts loading and flips to ready when the first frame lands', async () => {
+    const { container } = render(
+      <UiTree hubId="42" targetSurface="workspace_panel" />,
+    )
+
+    const wrapper = container.querySelector(
+      '[data-surface-ready="workspace_panel"]',
+    )
+    expect(wrapper).not.toBeNull()
+    expect(wrapper.dataset.surfaceReadyState).toBe('loading')
+
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'workspace_panel',
+        tree: HELLO_TREE,
+      })
+      // Let the transport-acquisition useEffect poll complete.
+      await Promise.resolve()
+    })
+
+    const wrapperAfter = container.querySelector(
+      '[data-surface-ready="workspace_panel"]',
+    )
+    expect(wrapperAfter.dataset.surfaceReadyState).toBe('ready')
+    // Also: recordFirstTree was called.
+    expect(
+      useSurfaceReadinessStore
+        .getState()
+        .surfacesByHubId['42']?.has('workspace_panel'),
+    ).toBe(true)
+  })
+
+  it('reverts to loading when targetSurface changes', async () => {
+    const { container, rerender } = render(
+      <UiTree hubId="42" targetSurface="workspace_panel" />,
+    )
+
+    await act(async () => {
+      fakeTransport.emit('message', {
+        type: 'ui_layout_tree_v1',
+        target_surface: 'workspace_panel',
+        tree: HELLO_TREE,
+      })
+      await Promise.resolve()
+    })
+    expect(
+      container
+        .querySelector('[data-surface-ready="workspace_panel"]')
+        .dataset.surfaceReadyState,
+    ).toBe('ready')
+
+    rerender(<UiTree hubId="42" targetSurface="kanban" />)
+    expect(
+      container.querySelector('[data-surface-ready="kanban"]').dataset
+        .surfaceReadyState,
+    ).toBe('loading')
+  })
+})

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Warden::Test::Helpers
   include SpaSystemHelper
+  include SystemReadinessHelpers
 
   # Disable transactional tests - system tests spawn external processes (CLI)
   # that need to see committed data in the database

--- a/test/helpers/system_readiness_helpers_test.rb
+++ b/test/helpers/system_readiness_helpers_test.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Shape-only test for SystemReadinessHelpers. These helpers wrap Capybara's
+# assert_selector / assert_no_selector with fixed selector strings — the
+# real assertion is that the selectors match what the React shell emits
+# (covered by the vitest suite `system-readiness-signals.test.jsx` and by
+# the 3 migrated flaking system tests). This suite guards the wrapping
+# layer: that each helper exists, takes the expected args, and issues the
+# correct Capybara call shape with the correct selector.
+class SystemReadinessHelpersTest < ActiveSupport::TestCase
+  class FakeCapybara
+    include SystemReadinessHelpers
+
+    attr_reader :calls
+
+    def initialize
+      @calls = []
+    end
+
+    def assert_selector(selector, **opts)
+      @calls << [:assert_selector, selector, opts]
+      true
+    end
+
+    def assert_no_selector(selector, **opts)
+      @calls << [:assert_no_selector, selector, opts]
+      true
+    end
+  end
+
+  setup do
+    @fake = FakeCapybara.new
+  end
+
+  test "wait_for_hub_ready asserts cli-status=connected and hub-snapshot=received" do
+    @fake.wait_for_hub_ready(timeout: 7)
+
+    assert_equal 2, @fake.calls.size
+    kind, selector, opts = @fake.calls[0]
+    assert_equal :assert_selector, kind
+    assert_equal "html[data-cli-status='connected']", selector
+    assert_equal 7, opts[:wait]
+
+    kind, selector, opts = @fake.calls[1]
+    assert_equal :assert_selector, kind
+    assert_equal "html[data-hub-snapshot='received']", selector
+    assert_equal 7, opts[:wait]
+  end
+
+  test "wait_for_surface_ready asserts present then absent-loading" do
+    @fake.wait_for_surface_ready("workspace_panel")
+
+    assert_equal [
+      [ :assert_selector, "[data-surface-ready='workspace_panel']", { wait: 15 } ],
+      [ :assert_no_selector,
+       "[data-surface-ready='workspace_panel'][data-surface-ready-state='loading']",
+       { wait: 1 } ]
+    ], @fake.calls
+  end
+
+  test "wait_for_settings_ready with default :any asserts scope only" do
+    @fake.wait_for_settings_ready("device")
+
+    assert_equal [
+      [ :assert_selector, "[data-settings-ready='device']", { wait: 15 } ]
+    ], @fake.calls
+  end
+
+  test "wait_for_settings_ready narrows by state when given" do
+    @fake.wait_for_settings_ready("repo", state: "tree", timeout: 9)
+
+    assert_equal [
+      [ :assert_selector,
+       "[data-settings-ready='repo'][data-settings-ready-state='tree']",
+       { wait: 9 } ]
+    ], @fake.calls
+  end
+end

--- a/test/helpers/system_readiness_helpers_test.rb
+++ b/test/helpers/system_readiness_helpers_test.rb
@@ -20,12 +20,12 @@ class SystemReadinessHelpersTest < ActiveSupport::TestCase
     end
 
     def assert_selector(selector, **opts)
-      @calls << [:assert_selector, selector, opts]
+      @calls << [ :assert_selector, selector, opts ]
       true
     end
 
     def assert_no_selector(selector, **opts)
-      @calls << [:assert_no_selector, selector, opts]
+      @calls << [ :assert_no_selector, selector, opts ]
       true
     end
   end

--- a/test/helpers/system_readiness_helpers_test.rb
+++ b/test/helpers/system_readiness_helpers_test.rb
@@ -49,15 +49,43 @@ class SystemReadinessHelpersTest < ActiveSupport::TestCase
     assert_equal 7, opts[:wait]
   end
 
-  test "wait_for_surface_ready asserts present then absent-loading" do
+  test "wait_for_surface_ready waits on the compound ready selector in a single assertion" do
     @fake.wait_for_surface_ready("workspace_panel")
 
     assert_equal [
-      [ :assert_selector, "[data-surface-ready='workspace_panel']", { wait: 15 } ],
-      [ :assert_no_selector,
-       "[data-surface-ready='workspace_panel'][data-surface-ready-state='loading']",
-       { wait: 1 } ]
+      [ :assert_selector,
+       "[data-surface-ready='workspace_panel'][data-surface-ready-state='ready']",
+       { wait: 15 } ]
     ], @fake.calls
+  end
+
+  test "wait_for_surface_ready respects an overridden timeout" do
+    @fake.wait_for_surface_ready("kanban", timeout: 30)
+
+    assert_equal [
+      [ :assert_selector,
+       "[data-surface-ready='kanban'][data-surface-ready-state='ready']",
+       { wait: 30 } ]
+    ], @fake.calls
+  end
+
+  # Regression: the prior two-assertion shape split the wait budget
+  # (timeout for present, hidden 1s for loading-gone) and flaked under CI
+  # slowness. This test pins the new shape — the helper issues exactly ONE
+  # Capybara assertion keyed on the READY-STATE compound selector, passing
+  # the full `timeout` through. No hidden sub-budget, no separate
+  # "presence" check that would match a still-loading surface.
+  test "wait_for_surface_ready hands the full timeout to a single ready-state assertion" do
+    @fake.wait_for_surface_ready("workspace_panel", timeout: 12)
+
+    assert_equal 1, @fake.calls.size,
+      "helper must NOT split the budget across multiple assertions"
+    kind, selector, opts = @fake.calls.first
+    assert_equal :assert_selector, kind
+    assert_includes selector, "data-surface-ready-state='ready'",
+      "must wait on the READY state, not just presence of the surface-ready attribute"
+    assert_equal 12, opts[:wait],
+      "full timeout must be passed to Capybara; no fixed sub-budget"
   end
 
   test "wait_for_settings_ready with default :any asserts scope only" do

--- a/test/support/system_readiness_helpers.rb
+++ b/test/support/system_readiness_helpers.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Capybara helpers that wait on CAUSAL preconditions instead of downstream
+# leaf UI effects. Paired with DOM signals written by the React shell:
+#
+#   <html data-cli-status="unknown|handshaking|connected|offline">
+#   <html data-hub-snapshot="pending|received">
+#   [data-surface-ready="<surface>" data-surface-ready-state="loading|ready"]
+#   [data-settings-ready="device|repo" data-settings-ready-state="tree|empty"]
+#
+# All signals are derived from real state (no timers). Source of each is
+# documented in app/frontend/components/AppShell.jsx (RootReadinessSignals),
+# app/frontend/components/UiTree.jsx, and
+# app/frontend/components/settings/ConfigEditor.jsx.
+module SystemReadinessHelpers
+  # Wait until the browser can dispatch to the hub AND the hub has shipped
+  # its first snapshots (route registry + primary surface tree). After this
+  # returns, button clicks / asserts can rely on the hub being reachable
+  # without layering their own timeouts on top of the causal path.
+  def wait_for_hub_ready(timeout: 30)
+    assert_selector "html[data-cli-status='connected']", wait: timeout
+    assert_selector "html[data-hub-snapshot='received']", wait: timeout
+  end
+
+  # Wait until a specific surface's UiTree has received its first frame.
+  # `name` matches the `targetSurface` identifier (e.g. "workspace_panel",
+  # "workspace_sidebar", or a plugin-registered surface).
+  def wait_for_surface_ready(name, timeout: 15)
+    assert_selector "[data-surface-ready='#{name}']", wait: timeout
+    assert_no_selector(
+      "[data-surface-ready='#{name}'][data-surface-ready-state='loading']",
+      wait: 1
+    )
+  end
+
+  # Wait until the Hub Settings config tab has finished scanning the given
+  # scope ("device" or "repo"). Default `state: :any` accepts both "tree"
+  # (files found) and "empty" (scan complete, nothing there) — narrow if
+  # the test specifically needs one.
+  def wait_for_settings_ready(scope, state: :any, timeout: 15)
+    selector = "[data-settings-ready='#{scope}']"
+    selector += "[data-settings-ready-state='#{state}']" unless state == :any
+    assert_selector selector, wait: timeout
+  end
+end

--- a/test/support/system_readiness_helpers.rb
+++ b/test/support/system_readiness_helpers.rb
@@ -25,11 +25,17 @@ module SystemReadinessHelpers
   # Wait until a specific surface's UiTree has received its first frame.
   # `name` matches the `targetSurface` identifier (e.g. "workspace_panel",
   # "workspace_sidebar", or a plugin-registered surface).
+  #
+  # The compound selector matches ONLY when the surface has flipped to ready
+  # — there is no fixed sub-timeout budget on the loading→ready transition,
+  # so a slow surface on a slow CI still resolves as long as the total wait
+  # fits within `timeout`. The UiTree wrapper mounts in `loading` state on
+  # first paint, which is why we cannot key on the surface-ready attribute
+  # alone: its presence means "the surface mounted", not "its tree arrived".
   def wait_for_surface_ready(name, timeout: 15)
-    assert_selector "[data-surface-ready='#{name}']", wait: timeout
-    assert_no_selector(
-      "[data-surface-ready='#{name}'][data-surface-ready-state='loading']",
-      wait: 1
+    assert_selector(
+      "[data-surface-ready='#{name}'][data-surface-ready-state='ready']",
+      wait: timeout
     )
   end
 

--- a/test/system/config_editing_test.rb
+++ b/test/system/config_editing_test.rb
@@ -59,6 +59,7 @@ class ConfigEditingTest < ApplicationSystemTestCase
     sign_in_and_connect
     click_settings_link
     switch_to_device_scope
+    wait_for_settings_ready("device")
 
     add_agent_named("alpha")
     select_agent_file("alpha")
@@ -76,7 +77,7 @@ class ConfigEditingTest < ApplicationSystemTestCase
     assert_not_equal "Select a file", editor_title.text
 
     # Textarea should be visible
-    assert_selector "[data-hub-settings-target='editor']", wait: 10
+    assert_selector "[data-hub-settings-target='editor']"
   end
 
   test "editing and saving a config file" do
@@ -218,6 +219,10 @@ class ConfigEditingTest < ApplicationSystemTestCase
 
     # Wait for WebRTC DataChannel to be established (direct or relay)
     assert_sidebar_webrtc_connected(wait: 30)
+
+    # Readiness gate: browser CAN dispatch AND hub has shipped its first
+    # snapshots. Prevents downstream leaf-wait flakes when CI is slow.
+    wait_for_hub_ready
   end
 
   # Navigate to settings via Turbo by clicking the Settings link on the hub page.

--- a/test/system/hub_state_flows_test.rb
+++ b/test/system/hub_state_flows_test.rb
@@ -72,8 +72,9 @@ class HubStateFlowsTest < ApplicationSystemTestCase
     sign_in_and_connect
 
     click_link "Hub Settings"
-    click_button "Device", wait: 10
-    assert_selector "[data-hub-settings-target='treePanel'][data-view='tree']", wait: 15
+    click_button "Device"
+    wait_for_settings_ready("device", state: "tree")
+    assert_selector "[data-hub-settings-target='treePanel'][data-view='tree']"
     assert_no_selector "[data-hub-setup-banner-target='banner']", wait: 2
     assert_button "+ Add Agent"
     assert_button "+ Add Accessory"
@@ -102,6 +103,9 @@ class HubStateFlowsTest < ApplicationSystemTestCase
 
     complete_pairing_for(@hub, pairing_url: url)
     assert_webrtc_connected
+
+    # Causal gate — see SystemReadinessHelpers.
+    wait_for_hub_ready
   end
 
   def assert_webrtc_connected(wait: 30)

--- a/test/system/spa_test.rb
+++ b/test/system/spa_test.rb
@@ -88,8 +88,9 @@ class SpaTest < ApplicationSystemTestCase
 
   test "selecting spawn target enables agent and accessory buttons" do
     sign_in_and_connect
+    wait_for_surface_ready("workspace_panel")
 
-    all("button", text: "New session", wait: 10).last.click
+    all("button", text: "New session").last.click
 
     # Wait for spawn targets
     select_el = find("[data-testid='spawn-target-select']", wait: 10)
@@ -101,8 +102,8 @@ class SpaTest < ApplicationSystemTestCase
     }, "Expected a spawn target option"
 
     # Buttons should be disabled before selection
-    assert_selector "[data-testid='choose-agent'][disabled]", wait: 5
-    assert_selector "[data-testid='choose-accessory'][disabled]", wait: 5
+    assert_selector "[data-testid='choose-agent'][disabled]"
+    assert_selector "[data-testid='choose-accessory'][disabled]"
 
     # Select the spawn target
     select_el.select(option_text)
@@ -262,6 +263,9 @@ class SpaTest < ApplicationSystemTestCase
 
     visit "/hubs/#{@hub.id}"
     assert_webrtc_connected
+
+    # Causal gate — see SystemReadinessHelpers.
+    wait_for_hub_ready
   end
 
   def assert_webrtc_connected(wait: 30)


### PR DESCRIPTION
## Summary

Adds DOM readiness signals + Capybara helpers so system tests wait on **causal preconditions** (hub connected, snapshots received, surface rendered) instead of leaf-element timeouts. Three recently-flaking tests are retrofitted as the reference migration.

User's framing: *"We need concrete, repeatable hooks to know when things are ready. No race conditions if we wait on the causal signal, not the leaf effect."*

## What ships

### DOM signals (all derived from real state, zero timers)

- **`<html data-cli-status>`** — `unknown | handshaking | connected | offline`, from `useHubStore().connectionState`
- **`<html data-hub-snapshot>`** — `pending | received`; flips to `received` only when BOTH `ui_route_registry_v1` snapshot present AND ≥1 surface tree recorded for the selected hub. Reset on hub switch.
- **`[data-surface-ready=<name>][data-surface-ready-state=loading|ready]`** — on UiTree wrapper (`display: contents`). Flips `ready` when first matching tree renders; resets on `(hubId, surface, subpath)` change.
- **`[data-settings-ready=<scope>][data-settings-ready-state=tree|empty]`** — on ConfigEditor panels. Absent while loading; `tree` when files present, `empty` when scan finished with none.

### Capybara helpers

```ruby
wait_for_hub_ready(timeout: 30)         # cli-status='connected' AND hub-snapshot='received'
wait_for_surface_ready(name, timeout: 15)  # compound ready selector — no hidden sub-budget
wait_for_settings_ready(scope, state: :any|'tree'|'empty', timeout: 15)
```

Included in `ApplicationSystemTestCase`.

### Reference migration

- `test/system/config_editing_test.rb`
- `test/system/hub_state_flows_test.rb`
- `test/system/spa_test.rb`

Each calls `wait_for_hub_ready` at the end of its local `sign_in_and_connect`, then `wait_for_surface_ready` / `wait_for_settings_ready` at the appropriate beats before interacting with UI.

Remaining 34 system tests migrate incrementally when touched.

## Flakiness proof

Deterministic 3-consecutive-run of the 3 migrated tests, including a slow-CI simulation:

| Run | Time | Result |
|-----|------|--------|
| 1   | 30.1s | 3/3 pass |
| 2   | 15.5s | 3/3 pass |
| 3   | 39.3s | 3/3 pass |

Run 3 ran 2.5x slower than run 2 and still passed. The old tests with `wait: 10` would have flaked on run 3.

## Codex audit

- Initial verdict: **BLOCKING** — `wait_for_surface_ready` had a hidden 1-second budget for the loading→ready transition (two-phase assertion).
- Fix commit `79e04f22`: single compound ready-state selector, full timeout flows through, selector cannot match until actually ready.
- Re-audit verdict: **APPROVED**, no findings.

## Test plan

- [x] `./test.sh` (CLI) — 1308 pass
- [x] `npx vitest --run` — 21 files / 172 tests pass (+11 for readiness signals)
- [x] `bin/rails test test/helpers/system_readiness_helpers_test.rb` — 6/6 pass
- [x] `bin/rails test:system` — 37/37 pass, zero regressions
- [x] 3-in-a-row deterministic rerun of migrated tests: all green across wide timing variance
- [x] Codex approved on `79e04f22`

## Follow-ups (not in this PR)

- Centralize the four copies of `sign_in_and_connect` across `test/system/*.rb` into a shared helper
- Incrementally migrate the remaining 34 system tests to use `wait_for_*` instead of `wait: N`

🤖 Generated with [Claude Code](https://claude.com/claude-code)