### PR TITLE
test(system): centralize sign-in helpers and sweep leaf waits

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -4,6 +4,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   include Warden::Test::Helpers
   include SpaSystemHelper
   include SystemReadinessHelpers
+  include CliIntegrationHelper
 
   # Disable transactional tests - system tests spawn external processes (CLI)
   # that need to see committed data in the database

--- a/test/support/cli_integration_helper.rb
+++ b/test/support/cli_integration_helper.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Shared helpers for system tests that drive a running CLI and exercise the
+# full pairing + WebRTC + readiness flow. Centralizes the `sign_in_as` /
+# `sign_in_and_connect` / `revisit_pairing_url_if_needed` helpers that were
+# previously duplicated across test/system/*.rb.
+#
+# Relies on helpers provided by ApplicationSystemTestCase:
+#   - SpaSystemHelper (complete_pairing_for, assert_sidebar_webrtc_connected, ...)
+#   - SystemReadinessHelpers (wait_for_hub_ready, wait_for_surface_ready, ...)
+module CliIntegrationHelper
+  # Visit the test-only bypass login endpoint. All system tests use this to
+  # establish a Warden session without driving the full GitHub OAuth flow.
+  def sign_in_as(user)
+    visit "/test/sessions/new?user_id=#{user.id}"
+  end
+
+  # Drive the browser through the CLI's connection URL (carrying the E2E key
+  # bundle in the fragment), complete the pairing confirmation, and land on
+  # the hub page with WebRTC up.
+  #
+  # Defaults match the common case: `@user`, `@hub`, `@cli` are set by the
+  # test's setup block and the CLI has already been started. Options cover
+  # the two legitimate variations observed across the suite:
+  #
+  #   prewarm_hub_page: visit hub_path BEFORE the pairing URL (file_input).
+  #   retry_if_stale: run revisit_pairing_url_if_needed after pairing to
+  #     recover from "pairing_needed" state on re-pair scenarios.
+  #   gate_hub_ready: block on wait_for_hub_ready at the end. Default true.
+  def sign_in_and_connect(
+    user: @user,
+    hub: @hub,
+    cli: @cli,
+    prewarm_hub_page: false,
+    webrtc_timeout: 30,
+    retry_if_stale: false,
+    gate_hub_ready: true
+  )
+    url = cli.connection_url
+    assert url.present?, "CLI should produce a connection URL"
+
+    sign_in_as(user)
+    visit hub_path(hub) if prewarm_hub_page
+    visit url
+
+    complete_pairing_for(hub, pairing_url: url)
+    revisit_pairing_url_if_needed(url, hub: hub) if retry_if_stale
+
+    assert_sidebar_webrtc_connected(wait: webrtc_timeout)
+    wait_for_hub_ready if gate_hub_ready
+  end
+
+  # If the SPA has dropped into a "pairing_needed" state (stale session or a
+  # lost Olm handshake), revisit the pairing URL once to re-drive the flow.
+  # Otherwise a no-op. Used by tests that do a pre-pair visit to the hub page
+  # and by tests that stop/restart the CLI mid-test.
+  def revisit_pairing_url_if_needed(url, hub: @hub)
+    return unless page.has_button?("Start pairing", wait: 2) ||
+      page.has_selector?(
+        "#{SpaSystemHelper::SIDEBAR_CONNECTION_STATUS_SELECTOR}[data-connection-state='pairing_needed']",
+        wait: 2
+      )
+
+    visit url
+    complete_pairing_for(hub, pairing_url: url)
+  end
+end

--- a/test/system/cli_pairing_test.rb
+++ b/test/system/cli_pairing_test.rb
@@ -166,10 +166,6 @@ class CliPairingTest < ApplicationSystemTestCase
 
   private
 
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
   # Decode Base32 (RFC 4648) to byte array, matching the browser's base32Decode.
   def base32_decode(input)
     alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"

--- a/test/system/config_editing_test.rb
+++ b/test/system/config_editing_test.rb
@@ -200,31 +200,6 @@ class ConfigEditingTest < ApplicationSystemTestCase
 
   private
 
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
-  # Visit the hub page using the connection URL (which carries the E2E key
-  # bundle in the URL fragment). Wait for the WebRTC DataChannel to be fully
-  # established. The active Olm session stays in the SharedWorker while the
-  # browser session remains alive, so nearby navigations can reconnect cleanly.
-  def sign_in_and_connect
-    url = @cli.connection_url
-    assert url.present?, "CLI should produce a connection URL"
-
-    sign_in_as(@user)
-    visit url
-
-    complete_pairing_for(@hub, pairing_url: url)
-
-    # Wait for WebRTC DataChannel to be established (direct or relay)
-    assert_sidebar_webrtc_connected(wait: 30)
-
-    # Readiness gate: browser CAN dispatch AND hub has shipped its first
-    # snapshots. Prevents downstream leaf-wait flakes when CI is slow.
-    wait_for_hub_ready
-  end
-
   # Navigate to settings via Turbo by clicking the Settings link on the hub page.
   # The link is enabled by requires-connection controller once DataChannel is up.
   def click_settings_link

--- a/test/system/file_input_test.rb
+++ b/test/system/file_input_test.rb
@@ -126,21 +126,8 @@ class FileInputTest < ApplicationSystemTestCase
 
   private
 
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
   def sign_in_and_connect
-    url = @cli.connection_url
-    assert url.present?, "CLI should produce a connection URL"
-
-    sign_in_as(@user)
-    visit hub_path(runtime_hub)
-    visit url
-
-    complete_pairing_for(runtime_hub, pairing_url: url, wait: 30)
-    revisit_pairing_url_if_needed(url)
-    assert_sidebar_webrtc_connected(wait: 30)
+    super(hub: runtime_hub, prewarm_hub_page: true, retry_if_stale: true)
   end
 
   def runtime_hub
@@ -179,7 +166,8 @@ class FileInputTest < ApplicationSystemTestCase
   end
 
   def create_accessory_session
-    find("[data-testid='new-session-button']:not([disabled])", match: :first, wait: 15).click
+    wait_for_surface_ready("workspace_panel")
+    find("[data-testid='new-session-button']:not([disabled])", match: :first).click
     assert_text "New Session", wait: 10
 
     selectable_option_text = nil
@@ -213,17 +201,6 @@ class FileInputTest < ApplicationSystemTestCase
     session_link.click
     assert_current_path "/hubs/#{runtime_hub.id}/sessions/#{session_uuid}", wait: 15
     session_uuid
-  end
-
-  def revisit_pairing_url_if_needed(url)
-    return unless page.has_button?("Start pairing", wait: 2) ||
-      page.has_selector?(
-        "#{SIDEBAR_CONNECTION_STATUS_SELECTOR}[data-connection-state='pairing_needed']",
-        wait: 2
-      )
-
-    visit url
-    complete_pairing_for(runtime_hub, pairing_url: url)
   end
 
   def current_paste_files

--- a/test/system/hub_state_flows_test.rb
+++ b/test/system/hub_state_flows_test.rb
@@ -19,9 +19,7 @@ class HubStateFlowsTest < ApplicationSystemTestCase
   end
 
   test "new session chooser loads admitted spawn targets and unlocks choices after selection" do
-    prime_server!
     @cli = start_cli(@hub)
-    associate_hub_device!
 
     sign_in_and_connect
 
@@ -46,9 +44,7 @@ class HubStateFlowsTest < ApplicationSystemTestCase
   end
 
   test "new agent modal preserves the selected target from the chooser" do
-    prime_server!
     @cli = start_cli(@hub)
-    associate_hub_device!
 
     sign_in_and_connect
 
@@ -65,9 +61,7 @@ class HubStateFlowsTest < ApplicationSystemTestCase
   end
 
   test "device config tree shows add-session controls when hub config is available" do
-    prime_server!
     @cli = start_cli(@hub)
-    associate_hub_device!
 
     sign_in_and_connect
 
@@ -82,38 +76,9 @@ class HubStateFlowsTest < ApplicationSystemTestCase
 
   private
 
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
-  def prime_server!
-    sign_in_as(@user)
-  end
-
-  def associate_hub_device!
-    # No-op after Device→Hub collapse: Hub IS the device now.
-  end
-
-  def sign_in_and_connect
-    url = @cli.connection_url
-    assert url.present?, "CLI should produce a connection URL"
-
-    sign_in_as(@user)
-    visit url
-
-    complete_pairing_for(@hub, pairing_url: url)
-    assert_webrtc_connected
-
-    # Causal gate — see SystemReadinessHelpers.
-    wait_for_hub_ready
-  end
-
-  def assert_webrtc_connected(wait: 30)
-    assert_sidebar_webrtc_connected(wait:)
-  end
-
   def open_new_session_chooser
-    find("[data-testid='new-session-button']:not([disabled])", match: :first, wait: 10).click
+    wait_for_surface_ready("workspace_panel")
+    find("[data-testid='new-session-button']:not([disabled])", match: :first).click
     assert_text "New Session", wait: 10
   end
 

--- a/test/system/spa_test.rb
+++ b/test/system/spa_test.rb
@@ -21,7 +21,6 @@ class SpaTest < ApplicationSystemTestCase
   # --- Pairing + Connection ---
 
   test "full pairing flow: visit connection URL, pair, verify connected" do
-    prime_server!
     @cli = start_cli(@hub)
 
     url = @cli.connection_url
@@ -42,6 +41,7 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   test "hub page shows connected status after pairing" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     # Connection status should show direct or relay (not connecting)
@@ -51,6 +51,7 @@ class SpaTest < ApplicationSystemTestCase
   # --- Hub page ---
 
   test "hub page renders sidebar with workspace list" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     # Sidebar shows Workspaces heading
@@ -61,6 +62,7 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   test "hub page renders hub information card" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     assert_text "HUB INFORMATION", wait: 10
@@ -71,9 +73,11 @@ class SpaTest < ApplicationSystemTestCase
   # --- Session creation flow ---
 
   test "new session chooser opens and loads spawn targets" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
+    wait_for_surface_ready("workspace_panel")
 
-    all("button", text: "New session", wait: 10).last.click
+    all("button", text: "New session").last.click
 
     # Chooser dialog opens
     assert_text "New Session", wait: 10
@@ -87,6 +91,7 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   test "selecting spawn target enables agent and accessory buttons" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
     wait_for_surface_ready("workspace_panel")
 
@@ -116,10 +121,12 @@ class SpaTest < ApplicationSystemTestCase
   # --- Session spawning ---
 
   test "full agent creation flow: chooser -> agent form -> submit without JS errors" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
+    wait_for_surface_ready("workspace_panel")
 
     # Open new session chooser
-    all("button", text: "New session", wait: 10).last.click
+    all("button", text: "New session").last.click
 
     # Select spawn target
     select_el = find("[data-testid='spawn-target-select']", wait: 10)
@@ -155,10 +162,12 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   test "full accessory creation flow: chooser -> accessory form -> submit without JS errors" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
+    wait_for_surface_ready("workspace_panel")
 
     # Open new session chooser
-    all("button", text: "New session", wait: 10).last.click
+    all("button", text: "New session").last.click
 
     # Select spawn target
     select_el = find("[data-testid='spawn-target-select']", wait: 10)
@@ -195,6 +204,7 @@ class SpaTest < ApplicationSystemTestCase
   # --- Navigation ---
 
   test "sidebar navigation to settings and back preserves connection" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     # Click Hub Settings in sidebar
@@ -211,6 +221,7 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   test "sidebar navigation is SPA — no full page reload" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     # Set a JS marker on the window — survives SPA navigation, dies on full reload
@@ -231,6 +242,7 @@ class SpaTest < ApplicationSystemTestCase
   # --- No JS errors ---
 
   test "no severe JS console errors on hub page" do
+    @cli = start_cli(@hub)
     sign_in_and_connect
 
     errors = relevant_browser_errors
@@ -238,35 +250,6 @@ class SpaTest < ApplicationSystemTestCase
   end
 
   private
-
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
-  def prime_server!
-    sign_in_as(@user)
-  end
-
-  def sign_in_and_connect
-    prime_server!
-    @cli = start_cli(@hub)
-
-    url = @cli.connection_url
-    assert url.present?, "CLI should produce a connection URL"
-
-    sign_in_as(@user)
-    visit url
-
-    assert_selector "[data-testid='pairing-ready']", wait: 15
-    click_button "Complete Pairing"
-    assert_selector "[data-testid='pairing-success']", wait: 15
-
-    visit "/hubs/#{@hub.id}"
-    assert_webrtc_connected
-
-    # Causal gate — see SystemReadinessHelpers.
-    wait_for_hub_ready
-  end
 
   def assert_webrtc_connected(wait: 30)
     # Connection status shows Direct or Relay (text rendered by ConnectionStatus component)

--- a/test/system/webrtc_connection_test.rb
+++ b/test/system/webrtc_connection_test.rb
@@ -241,10 +241,6 @@ class WebrtcConnectionTest < ApplicationSystemTestCase
 
   private
 
-  def sign_in_as(user)
-    visit "/test/sessions/new?user_id=#{user.id}"
-  end
-
   # Visit connection URL, complete the pairing confirmation, and land on the hub page.
   def pair_browser_with_cli(cli)
     url = cli.connection_url
@@ -278,17 +274,6 @@ class WebrtcConnectionTest < ApplicationSystemTestCase
   # confirmation button, then redirects to the hub after session creation.
   def complete_pairing(pairing_url = current_url)
     complete_pairing_for(@hub, pairing_url:)
-  end
-
-  def revisit_pairing_url_if_needed(url)
-    return unless page.has_button?("Start pairing", wait: 2) ||
-      page.has_selector?(
-        "#{SIDEBAR_CONNECTION_STATUS_SELECTOR}[data-connection-state='pairing_needed']",
-        wait: 2
-      )
-
-    visit url
-    complete_pairing(url)
   end
 
   # Assert WebRTC data channel is connected (direct P2P or TURN relay).


### PR DESCRIPTION
## Summary

Finishes the flakiness elimination started in PR #179. Centralizes the 4 copies of `sign_in_and_connect`, 6 copies of `sign_in_as`, and 2 copies of `revisit_pairing_url_if_needed` into one shared helper. Sweeps the remaining system tests to replace leaf-element `wait: N` patterns with the Phase 1 readiness helpers where the wait is gated on a causal state signal.

**Test-only PR.** No state management, no React components, no production Ruby changed.

## What ships

### New helper — `test/support/cli_integration_helper.rb`

```ruby
sign_in_as(user)
sign_in_and_connect(user:, hub:, cli:,
                    prewarm_hub_page: false,
                    webrtc_timeout: 30,
                    retry_if_stale: false,
                    gate_hub_ready: true)
revisit_pairing_url_if_needed(url, hub:)
```

Behaviour preserved for all 4 prior callers via kwargs:
- `config_editing_test`, `hub_state_flows_test` — default behaviour
- `spa_test` — CLI lifecycle lifted into test bodies (explicit `@cli = start_cli(@hub)` before `sign_in_and_connect`)
- `file_input_test` — passes `prewarm_hub_page: true, retry_if_stale: true` + gains the `wait_for_hub_ready` gate (strictly-better)

### Sweep

Readiness gates added before "New session" / `new-session-button` clicks:
- `test/system/spa_test.rb` — 3 tests
- `test/system/hub_state_flows_test.rb#open_new_session_chooser`
- `test/system/file_input_test.rb#create_accessory_session`

**Deliberately NOT touched**: `webrtc_connection_test` and `cli_pairing_test`. Their `wait: 30` IS the connection-state probe — replacing with `wait_for_hub_ready` would defeat their purpose.

## Codex audit

Verdict: **APPROVED**, no findings.

One concern was flagged pre-audit: `file_input_test`'s pairing `wait: 30` on the initial pass implicitly dropped to the helper's `15s` default. Codex investigated and confirmed this is **non-blocking**: the stale-retry path in the old code already used the 15s default, every other caller in the suite already relies on 15s, and the PR adds `wait_for_hub_ready` *after* pairing which is a stronger post-pair causal gate than the old code had.

## Test plan

- [x] `./test.sh` (CLI) — 1308 + integration = 1573 pass
- [x] `npx vitest --run` — 21 files / 172 pass (unchanged)
- [x] `bin/rails test` — 442 runs, 0 failures
- [x] `bin/rails test:system` — 37/37 pass, 0 failures, 0 errors
- [x] **Deterministic 3-in-a-row system rerun** — green × 3, real CI-like variance (242s / 224s / 232s)
- [x] `bin/rubocop` — 0 offenses
- [x] Codex APPROVED on `eeeb9770`

## Stats

8 files changed, +89 / −140 net LOC. Test inventory unchanged (37 tests on both main and HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)