### PR TITLE
feat(cli): plugin-authoring ergonomics — error surfacing + input_builder route_ctx

### DIFF
--- a/cli/lua/lib/layout_broadcast.lua
+++ b/cli/lua/lib/layout_broadcast.lua
@@ -258,9 +258,32 @@ function M.build_frames(base_state, opts)
         if only_surface == nil or only_surface == surface_name then
             local entry = surfaces_mod.get(surface_name)
             if entry then
+                -- Resolve the client's current subpath BEFORE input_builder so
+                -- plugin-authored builders can branch their data-loading on
+                -- the matched sub-route (`/board/:id` loading board N, etc.).
+                -- `client.surface_subpaths` is updated by the
+                -- `botster.surface.subpath` action, and primed at
+                -- subscribe-time so cold-load lands on the right sub-page
+                -- without flashing "/".
+                local subpath = resolve_subpath(opts.client, surface_name)
+                local route_ctx
+                if type(surfaces_mod.resolve_route) == "function" then
+                    local _compiled, params = surfaces_mod.resolve_route(surface_name, subpath)
+                    route_ctx = { path = subpath, params = params or {} }
+                end
+
                 local surface_state
                 if entry.input_builder then
-                    local ok, built = pcall(entry.input_builder, opts.client, opts.subscription_key)
+                    -- Third argument is new (Phase 4b ergonomics). Existing
+                    -- 2-arg builders tolerate the extra arg; 3-arg builders
+                    -- can branch on route_ctx.params for per-sub-route
+                    -- data-loading.
+                    local ok, built = pcall(
+                        entry.input_builder,
+                        opts.client,
+                        opts.subscription_key,
+                        route_ctx
+                    )
                     if ok then
                         surface_state = built
                     else
@@ -278,12 +301,11 @@ function M.build_frames(base_state, opts)
                 if type(surface_state) == "table" then
                     -- Thread the current subpath through the render input so
                     -- the surface dispatcher (lib.surfaces) can route it to
-                    -- the correct sub-route. `client.surface_subpaths` is
-                    -- updated by the `botster.surface.subpath` action, and
-                    -- primed at subscribe-time so cold-load lands on the
-                    -- right sub-page without flashing "/".
+                    -- the correct sub-route. We also let the input_builder
+                    -- override state.path / state.params explicitly — if it
+                    -- sets them we respect its choice.
                     if surface_state.path == nil then
-                        surface_state.path = resolve_subpath(opts.client, surface_name)
+                        surface_state.path = subpath
                     end
                     local frame = render_one(surface_name, surface_state)
                     if frame then

--- a/cli/lua/lib/surfaces.lua
+++ b/cli/lua/lib/surfaces.lua
@@ -586,18 +586,44 @@ end
 --- default `LayoutInput.build_for_subscription`. Callers that want the
 --- workspace-shaped `AgentWorkspaceSurfaceInputV1` get it for free; plugin
 --- surfaces that need less can provide a tiny builder.
+---
+--- Phase 4b ergonomics: when `route_ctx` is passed, it threads to the
+--- plugin-authored `input_builder` as a third argument so per-sub-route
+--- data-loading (e.g. `/board/:id` loading board N) can happen at
+--- input-build time instead of inside render. Backwards compatible —
+--- existing 2-arg input_builders simply ignore the extra arg.
 --- @param name string
 --- @param client any Client instance (passed to input_builder)
 --- @param sub_id string|nil
+--- @param route_ctx table|nil { path = string, params = table }
 --- @return table input state (ready to hand to render())
-function M.build_input(name, client, sub_id)
+function M.build_input(name, client, sub_id, route_ctx)
     local entry = M.get(name)
     if not entry then return nil end
     if entry.input_builder then
-        return entry.input_builder(client, sub_id)
+        return entry.input_builder(client, sub_id, route_ctx)
     end
     local LayoutInput = require("lib.layout_input")
     return LayoutInput.build_for_subscription(client, sub_id)
+end
+
+--- Resolve the compiled route + params for `subpath` against surface `name`.
+---
+--- Pure lookup — does not render. Lets callers (notably
+--- `lib.layout_broadcast`) compute `{ path, params }` before calling the
+--- surface's `input_builder` so per-sub-route data loading has access to
+--- the matched params.
+---
+--- @param name string Registered surface name.
+--- @param subpath string? Subpath to match (defaults to "/").
+--- @return table|nil compiled_route The matched compiled route (internal shape), or nil when no route matches.
+--- @return table|nil params Named captures from the match, or nil.
+function M.resolve_route(name, subpath)
+    local entry = M.get(name)
+    if not entry or type(entry.compiled_routes) ~= "table" then
+        return nil, nil
+    end
+    return match_routes(entry.compiled_routes, subpath or "/")
 end
 
 --- Test-only reset. Production never calls this — hot-reload preserves

--- a/cli/src/lua/primitives/web_layout.rs
+++ b/cli/src/lua/primitives/web_layout.rs
@@ -182,13 +182,21 @@ pub fn reload(lua: &Lua) -> Result<()> {
 fn render_surface(lua: &Lua, surface_name: &str, state: Value) -> Result<String> {
     let layout_table = resolve_layout_table(lua)?;
 
-    let returned = call_layout_table_surface(&layout_table, surface_name, state.clone())?
-        .or_else(|| call_surfaces_registry_fallback(lua, surface_name, state));
-
-    let Some(returned) = returned else {
-        return Err(anyhow!(
-            "no layout surface registered for `{surface_name}` (checked layout table + surfaces registry)"
-        ));
+    // Chain both sources, propagating render-time errors instead of swallowing
+    // them. `call_layout_table_surface` already returns Err when the layout
+    // file's function raised; `call_surfaces_registry_fallback` now mirrors
+    // that — so the outer "no layout surface registered" message only fires
+    // when the surface is genuinely absent from both sources.
+    let returned = match call_layout_table_surface(&layout_table, surface_name, state.clone())? {
+        Some(v) => v,
+        None => match call_surfaces_registry_fallback(lua, surface_name, state)? {
+            Some(v) => v,
+            None => {
+                return Err(anyhow!(
+                    "no layout surface registered for `{surface_name}` (checked layout table + surfaces registry)"
+                ));
+            }
+        },
     };
 
     let node: UiNodeV1 = lua
@@ -222,32 +230,35 @@ fn call_layout_table_surface(
     }
 }
 
-/// Fallback to the Phase-4a Lua-side surface registry (`_G.surfaces`). Any
-/// failure (no surfaces global, no `render_node`, registry has no such
-/// surface, or the registered render function raised) is logged and
-/// resolves to `None` so the caller emits the error fallback tree.
+/// Fallback to the Phase-4a Lua-side surface registry (`_G.surfaces`).
+///
+/// Return semantics:
+///   * `Ok(Some(value))` — the registry rendered the surface.
+///   * `Ok(None)` — no `surfaces` global, no `render_node`, or the registry
+///     has no such surface (`render_node` returned nil). Caller falls through
+///     to "surface not registered" messaging.
+///   * `Err(_)` — the registered render function raised. The error carries
+///     the plugin-author-visible Lua message so `error_fallback_json` can
+///     surface it in the fallback panel (ergonomics fix: previously the
+///     error was swallowed and the user saw the generic "no layout surface
+///     registered" message even though the surface WAS registered).
 fn call_surfaces_registry_fallback(
     lua: &Lua,
     surface_name: &str,
     state: Value,
-) -> Option<Value> {
+) -> Result<Option<Value>> {
     let surfaces: Table = match lua.globals().get("surfaces") {
         Ok(Value::Table(t)) => t,
-        _ => return None,
+        _ => return Ok(None),
     };
     let render_node: Function = match surfaces.get("render_node") {
         Ok(Value::Function(f)) => f,
-        _ => return None,
+        _ => return Ok(None),
     };
     match render_node.call::<Value>((surface_name.to_string(), state)) {
-        Ok(Value::Nil) => None,
-        Ok(v) => Some(v),
-        Err(err) => {
-            log::warn!(
-                "web_layout.render: surfaces.render_node for `{surface_name}` raised: {err}"
-            );
-            None
-        }
+        Ok(Value::Nil) => Ok(None),
+        Ok(v) => Ok(Some(v)),
+        Err(err) => Err(anyhow!("surface `{surface_name}` raised: {err}")),
     }
 }
 

--- a/cli/tests/ui_surface_registry_test.rs
+++ b/cli/tests/ui_surface_registry_test.rs
@@ -1420,3 +1420,313 @@ fn hello_plugin_unknown_subpath_renders_sub_404_not_error_fallback() {
         );
     });
 }
+
+// -------------------------------------------------------------------------
+// Plugin ergonomics — Part 1: render-time errors carry the REAL message
+// -------------------------------------------------------------------------
+//
+// Before this change, a plugin whose render fn threw produced the generic
+// "Layout error: {surface} / no layout surface registered" panel — because
+// the Rust fallback swallowed the Lua error and returned None, making the
+// call site indistinguishable from "surface truly not registered".
+//
+// After the change:
+//   * If the render fn throws, the error-fallback tree carries the actual
+//     Lua message.
+//   * If the surface is GENUINELY missing from both sources, the error
+//     tree still says "no layout surface registered" (regression guard).
+
+#[test]
+fn render_throw_in_plugin_surface_yields_error_fallback_with_real_error() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let json: String = lua
+        .load(
+            r#"
+            surfaces.register("broken", {
+                render = function(_state)
+                    error("ui.stack: unknown prop padding")
+                end,
+            })
+            return web_layout.render("broken", { hub_id = "hub-test" })
+            "#,
+        )
+        .eval()
+        .expect("render broken surface");
+
+    let parsed: serde_json::Value = serde_json::from_str(&json).expect("parse");
+
+    let title = parsed
+        .pointer("/props/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert_eq!(
+        title, "Layout error: broken",
+        "render-time errors must produce the error-fallback panel for the surface"
+    );
+
+    let blob = parsed.to_string();
+    assert!(
+        blob.contains("ui.stack: unknown prop padding"),
+        "error-fallback tree must embed the real Lua error message; got: {blob}"
+    );
+    assert!(
+        !blob.contains("no layout surface registered"),
+        "a registered surface whose render threw must NOT surface the \
+         'no layout surface registered' message; got: {blob}"
+    );
+}
+
+#[test]
+fn missing_surface_still_emits_no_layout_surface_registered() {
+    // Negative guard: a future refactor that collapses error paths must not
+    // reintroduce the "swallow render errors as missing" behaviour.
+    // `web_layout_render_missing_surface_returns_error_fallback` (above)
+    // asserts the error-fallback tree appears; this test additionally pins
+    // the SPECIFIC message so the distinction with render-time errors
+    // remains observable by plugin authors.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let json: String = lua
+        .load(r#"return web_layout.render("genuinely_missing_surface", {})"#)
+        .eval()
+        .expect("render missing surface");
+
+    let blob = json;
+    assert!(
+        blob.contains("no layout surface registered"),
+        "truly-missing surfaces must still surface the registry-miss message; got: {blob}"
+    );
+    assert!(
+        blob.contains("genuinely_missing_surface"),
+        "error message must name the missing surface; got: {blob}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// Plugin ergonomics — Part 2: input_builder receives route_ctx
+// -------------------------------------------------------------------------
+//
+// Phase 4b threads `state.path` / `state.params` through the dispatcher
+// AFTER `input_builder` has already returned, so plugins that want to load
+// different data for different sub-routes (`/board/:id` → load board N)
+// had to stuff everything into render. Ergonomics: `input_builder` now
+// also sees a third arg `route_ctx = { path, params }` computed from the
+// client's current subpath so per-sub-route data-loading belongs where it
+// belongs.
+
+#[test]
+fn input_builder_receives_route_ctx_with_subpath_and_matched_params() {
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    // Register a multi-route surface with an input_builder that captures
+    // its third arg into a table. Then drive `build_frames` with two
+    // different client subpaths and assert the captured route_ctx for each.
+    let (first_path, first_id, second_path, second_tag): (String, String, String, String) = lua
+        .load(
+            r#"
+            _G.__captured = {}
+            local function capturing_builder(_client, sub_id, route_ctx)
+                _G.__captured[sub_id] = route_ctx
+                return { hub_id = "hub-test" }
+            end
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/",           render = function(_s, _ctx) return { type = "panel", props = { tag = "home" } } end },
+                    { path = "/board/:id",  render = function(s, _ctx) return { type = "panel", props = { tag = "board", id = s.params.id } } end },
+                },
+                input_builder = capturing_builder,
+            })
+
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+
+            -- Subscription A: client is viewing /board/7
+            LayoutBroadcast.build_frames(nil, {
+                subscription_key = "sub-A",
+                client = { surface_subpaths = { kanban = "/board/7" } },
+                force = true,
+            })
+            -- Subscription B: client is viewing /
+            LayoutBroadcast.build_frames(nil, {
+                subscription_key = "sub-B",
+                client = { surface_subpaths = {} },
+                force = true,
+            })
+
+            local a = _G.__captured["sub-A"] or {}
+            local b = _G.__captured["sub-B"] or {}
+            return
+                tostring(a.path or "<nil>"),
+                tostring((a.params and a.params.id) or "<nil>"),
+                tostring(b.path or "<nil>"),
+                tostring((b.params and next(b.params)) or "<empty>")
+            "#,
+        )
+        .eval()
+        .expect("input_builder route_ctx");
+
+    assert_eq!(first_path, "/board/7");
+    assert_eq!(
+        first_id, "7",
+        "route_ctx.params must carry matched :id capture for /board/:id"
+    );
+    assert_eq!(second_path, "/");
+    assert_eq!(
+        second_tag, "<empty>",
+        "root subpath has no named captures; params must be an empty table"
+    );
+}
+
+#[test]
+fn legacy_two_arg_input_builder_still_works_with_route_ctx_fanout() {
+    // Backwards compatibility: plugins that declared an input_builder BEFORE
+    // this change took `(client, sub_id)`. Lua tolerates the extra
+    // positional arg, but we pin the behaviour here so nobody silently
+    // breaks these plugins with a future "require 3 args" refactor.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (frame_count, tag): (i64, String) = lua
+        .load(
+            r#"
+            local function legacy_builder(_client, _sub_id) -- only two args
+                return { hub_id = "hub-test" }
+            end
+            surfaces.register("oldschool", {
+                render = function(_s, _ctx) return { type = "panel", props = { tag = "oldschool" } } end,
+                input_builder = legacy_builder,
+            })
+
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+            local frames = LayoutBroadcast.build_frames(nil, {
+                subscription_key = "sub",
+                client = { surface_subpaths = {} },
+                force = true,
+            })
+
+            local found
+            for _, f in ipairs(frames) do
+                if f.target_surface == "oldschool" then found = f end
+            end
+            assert(found, "legacy builder must still produce a frame")
+            return #frames, found.tree.props.tag
+            "#,
+        )
+        .eval()
+        .expect("legacy 2-arg builder");
+
+    assert_eq!(frame_count, 1);
+    assert_eq!(
+        tag, "oldschool",
+        "legacy 2-arg input_builder must still produce the expected tree"
+    );
+}
+
+#[test]
+fn input_builder_can_branch_on_route_ctx_params_for_different_data() {
+    // Integration test of the motivating use case: a plugin that loads
+    // different data based on the matched sub-route param. We use a
+    // fixture table as the "data store" and assert the right entry ends up
+    // in the rendered tree for each subpath.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (root_tag, board_id, board_title): (String, String, String) = lua
+        .load(
+            r#"
+            local BOARDS = { ["1"] = "Alpha Board", ["42"] = "The Ultimate Board" }
+            local function board_input(_client, _sub_id, route_ctx)
+                local state = { hub_id = "hub-test" }
+                if route_ctx and route_ctx.params and route_ctx.params.id then
+                    state.board = { id = route_ctx.params.id, title = BOARDS[route_ctx.params.id] }
+                else
+                    state.boards = BOARDS
+                end
+                return state
+            end
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/", render = function(s, _ctx)
+                        return { type = "panel", props = { tag = "home", count = (s.boards and 1 or 0) } }
+                    end },
+                    { path = "/board/:id", render = function(s, _ctx)
+                        return { type = "panel", props = {
+                            tag = "board",
+                            id = (s.board and s.board.id) or "?",
+                            title = (s.board and s.board.title) or "?",
+                        } }
+                    end },
+                },
+                input_builder = board_input,
+            })
+
+            local LayoutBroadcast = require("lib.layout_broadcast")
+            LayoutBroadcast._reset_for_tests()
+
+            local f_home = LayoutBroadcast.build_frames(nil, {
+                subscription_key = "home",
+                client = { surface_subpaths = {} },
+                force = true,
+            })
+            local f_board = LayoutBroadcast.build_frames(nil, {
+                subscription_key = "board",
+                client = { surface_subpaths = { kanban = "/board/42" } },
+                force = true,
+            })
+
+            local function find(frames, name)
+                for _, f in ipairs(frames) do
+                    if f.target_surface == name then return f end
+                end
+                return nil
+            end
+            local home = find(f_home, "kanban").tree
+            local board = find(f_board, "kanban").tree
+            return home.props.tag, board.props.id, board.props.title
+            "#,
+        )
+        .eval()
+        .expect("branching input_builder");
+
+    assert_eq!(root_tag, "home");
+    assert_eq!(
+        board_id, "42",
+        "input_builder must have loaded board 42 based on route_ctx.params.id"
+    );
+    assert_eq!(board_title, "The Ultimate Board");
+}
+
+#[test]
+fn surfaces_resolve_route_returns_matched_route_and_params() {
+    // Unit-level coverage for the new public helper that layout_broadcast
+    // calls. A plugin might also use this directly to prefetch.
+    let _lock = lock_env();
+    let lua = new_test_lua();
+
+    let (matched_id, root_match, unknown_match): (String, bool, bool) = lua
+        .load(
+            r#"
+            surfaces.register("kanban", {
+                routes = {
+                    { path = "/",          render = function() return { type = "panel", props = {} } end },
+                    { path = "/board/:id", render = function() return { type = "panel", props = {} } end },
+                },
+            })
+            local _c1, p1 = surfaces.resolve_route("kanban", "/board/13")
+            local c2, p2 = surfaces.resolve_route("kanban", "/")
+            local c3, _p3 = surfaces.resolve_route("kanban", "/totally/unknown")
+            return p1.id, (c2 ~= nil and p2 ~= nil), (c3 == nil)
+            "#,
+        )
+        .eval()
+        .expect("resolve_route");
+
+    assert_eq!(matched_id, "13");
+    assert!(root_match, "root subpath must match the / route");
+    assert!(unknown_match, "unknown subpath must return nil route");
+}


### PR DESCRIPTION
## Summary

Two related plugin-author ergonomics fixes shipped together.

### Part 1 — Error surfacing on render-time throws

**Before**: when a plugin's sub-route render fn throws, user sees "Layout error: hello / no layout surface registered for \`hello\`" — misleading. The surface IS registered, the render fn failed. Root cause: \`call_surfaces_registry_fallback\` collapsed "registered but raised" into the same \`None\` return as "not registered at all."

**Fix**: signature flip \`call_surfaces_registry_fallback: Option<Value>\` → \`Result<Option<Value>>\`. When \`surfaces.render_node\` raises, return \`Err(anyhow!("surface \`{name}\` raised: {err}"))\`. \`render_surface\` chains both sources via \`?\` — render-time errors propagate through \`error_fallback_json\` with the real Lua error message. The "no layout surface registered" text now fires only when the surface is truly missing from the registry.

**User-facing change**:
```
Before: Layout error: hello / no layout surface registered for \`hello\` (checked layout table + surfaces registry)
After:  Layout error: hello / surface \`hello\` raised: .../plugin.lua:42: ui.stack: unknown prop padding
```

### Part 2 — \`input_builder\` receives \`(client, sub_id, route_ctx)\`

**Before**: \`input_builder\` couldn't branch data-loading on subpath because \`build_frames\` threaded \`state.path\` AFTER \`input_builder\` returned. A kanban \`/board/:id\` had to stuff data fetching into \`render\` instead of the semantically correct \`input_builder\`.

**Fix**: \`build_frames\` hoists \`resolve_subpath\` + \`match_routes\` BEFORE \`input_builder\` invocation; passes third arg \`route_ctx = { path, params }\`. Backwards-compatible (existing 2-arg builders ignore extra positional). New public helper \`M.resolve_route(name, subpath)\` wraps the existing local \`match_routes\`.

**API shape**:
```lua
surfaces.register("kanban", {
  input_builder = function(client, sub_id, route_ctx)
    -- route_ctx = { path = "/board/42", params = { id = "42" } }
    if route_ctx and route_ctx.params and route_ctx.params.id then
      return { board = load_board(route_ctx.params.id) }
    end
    return { boards = list_all_boards() }
  end,
  routes = {
    { path = "/",          render = function(state, ctx) ... end },
    { path = "/board/:id", render = function(state, ctx) ... end },
  },
})
```

## Codex audit

**Verdict: APPROVED.** Key findings:
- Signature change correctly distinguishes missing / raised / rendered.
- Negative case preserved: \`missing_surface_still_emits_no_layout_surface_registered\` pins the existing behavior.
- Double-match (build_frames computes params for input_builder; dispatcher re-matches from \`state.path\`) is defense-in-depth, not a correctness hole.
- \`route_ctx\` shape \`{ path, params }\` is minimal; no leaked fields.
- \`M.resolve_route\` nil-safe via \`M.get\`.
- Hot-reload defensive guard \`type(surfaces_mod.resolve_route) == "function"\` is justified (mixed-version window during reload).
- 6 new integration tests, none tautological — each would fail against pre-fix code.

## Test plan

- [x] \`./test.sh\` — 42/42 ui_surface_registry (6 new integration tests) + full suite green
- [x] \`npx vitest --run\` — 172/172 unchanged
- [x] \`bin/rails test\` — 442/0/0
- [x] \`bin/rubocop\` — clean
- [x] Codex APPROVED on \`46767aaf\`
- [ ] System-test flakes in worktree confirmed env-related (TURN handshake sensitivity); CI should run clean

## Files (4 changed, +399 / −30)

- \`cli/src/lua/primitives/web_layout.rs\` (+55 / −22)
- \`cli/lua/lib/layout_broadcast.lua\` (+34 / −6)
- \`cli/lua/lib/surfaces.lua\` (+30 / −2)
- \`cli/tests/ui_surface_registry_test.rs\` (+310 / −0, 6 new tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)