### PR TITLE
feat(cli): vendor sqlite.lua + enable FFI for plugin persistence layer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y pkg-config
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y pkg-config libsqlite3-0
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,21 @@
+Botster — third-party notices
+=============================
+
+This project bundles third-party software. Each component below retains its
+original license; the full license text ships alongside the vendored files.
+
+-----------------------------------------------------------------------------
+sqlite.lua (vendored)
+-----------------------------------------------------------------------------
+Upstream: https://github.com/kkharji/sqlite.lua
+License: MIT
+Location: cli/lua/vendor/sqlite/
+License text: cli/lua/vendor/sqlite/LICENSE
+Modifications: cli/lua/vendor/sqlite/VENDOR_CHANGES.md
+
+-----------------------------------------------------------------------------
+ghostty (vendored submodule)
+-----------------------------------------------------------------------------
+Upstream: https://github.com/ghostty-org/ghostty (Tonksthebear/ghostty fork)
+License: MIT (see upstream LICENSE in the submodule)
+Location: cli/vendor/ghostty/

--- a/cli/lua/vendor/sqlite/LICENSE
+++ b/cli/lua/vendor/sqlite/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 kkharji
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/lua/vendor/sqlite/VENDOR_CHANGES.md
+++ b/cli/lua/vendor/sqlite/VENDOR_CHANGES.md
@@ -1,0 +1,79 @@
+# sqlite.lua vendor changes
+
+Upstream: https://github.com/kkharji/sqlite.lua
+Pinned at commit: `50092d60feb242602d7578398c6eb53b4a8ffe7b` (2024-ish, "Use HOMEBREW_PREFIX in defs.lua").
+Vendored into: `cli/lua/vendor/sqlite/`.
+
+All files were copied verbatim from `lua/sqlite/` in the upstream tree. The
+upstream `LICENSE` (MIT) is reproduced here alongside this file.
+
+The only diffs are the ones documented below — patches to break the `luv`
+(libuv binding) dependency and fix one upstream typo. `luv` is a `vim`/neovim
+runtime artifact and is not present in a bare LuaJIT host; our Lua runtime
+has LuaJIT's FFI enabled but no `luv` binding.
+
+## Patches
+
+### `defs.lua`
+
+Upstream: uses `require "luv"` to get the `LIBSQLITE` env var, `os_uname`, and
+`HOMEBREW_PREFIX`.
+
+- Line 3 (upstream): `local luv = require "luv"` — **removed.**
+- Lines 10–15 (upstream): `if vim then ... vim.g.sqlite_clib_path ... end`
+  block — **removed** (vim globals are not relevant outside neovim).
+- Line 18 (upstream): `path, _ = luv.os_getenv "LIBSQLITE"` — replaced with
+  `os.getenv("BOTSTER_LIBSQLITE") or os.getenv("LIBSQLITE")`. `BOTSTER_LIBSQLITE`
+  takes precedence so botster deployments can pin a specific library without
+  clobbering any caller's own `LIBSQLITE`.
+- Line 23 (upstream): `local os = luv.os_uname()` — replaced with `jit.os`
+  and `jit.arch`. The `if os.sysname == "Darwin"` branch is rewritten to
+  `if jit_os == "OSX"` because LuaJIT returns `"OSX"` whereas `uname` returns
+  `"Darwin"`. Added aarch64 paths to the Linux candidate list so ARM64 Linux
+  runners pick up `libsqlite3` without `BOTSTER_LIBSQLITE`.
+- Line 51 (upstream): `luv.os_getenv "HOMEBREW_PREFIX"` → `os.getenv("HOMEBREW_PREFIX")`.
+- Line 52 (upstream): `os.machine == "arm64"` → `jit_arch == "arm64"` (the
+  upstream variable name `os` was a local shadow of the global; our rewrite
+  uses separate `jit_os` and `jit_arch` names).
+
+### `helpers.lua`
+
+- Line 2 (upstream): `local luv = require "luv"` — **removed.**
+- Line 76 (upstream): `o.mtime = ... luv.fs_stat(o.db.uri) ... .mtime.sec ...`
+  — replaced with a defensive lookup against our `fs.stat` global primitive.
+  Our `fs.stat` currently returns `{exists, type, size}` without an `mtime`
+  field, so `o.mtime` will be `nil` in practice; that's acceptable because
+  the mtime is only used for cache invalidation in `tbl/cache.lua`, which
+  plugin.db() does not exercise today (single-writer per db).
+
+### `utils.lua`
+
+- Line 1 (upstream): `local luv = require "luv"` — **removed.**
+- Line 106 (upstream): `expanded = luv.fs_realpath(path)` — replaced with
+  `expanded = path`. Upstream used `realpath()` to canonicalize a leading-dot
+  relative path. plugin.db always passes absolute paths, so canonicalization
+  is cosmetic; returning the path unchanged is safe for our use case. If a
+  future caller needs canonicalization, add `fs.realpath` to
+  `cli/src/lua/primitives/fs.rs` and thread it through here.
+
+### `tbl/cache.lua`
+
+- Line 1 (upstream): `local u = require "sql.utils"` — **fixed to
+  `require "sqlite.utils"`.** This is a pre-existing upstream typo (the
+  module is `sqlite.utils`, not `sql.utils`). The file isn't on any current
+  happy path in botster, but the typo would trip any future caller; fixing
+  it inline avoids a confusing surprise later.
+- Line 2 (upstream): `local luv = require "luv"` — **removed.**
+- Line 65 (upstream): `local stat = luv.fs_stat(self.db.uri)` — same
+  `fs.stat`-based fallback as `helpers.lua`.
+
+## Upgrading upstream
+
+When bumping the pin:
+1. Fetch the new tag/commit from https://github.com/kkharji/sqlite.lua.
+2. Copy the 13 `.lua` files verbatim, plus `LICENSE`.
+3. Re-apply these patches. If upstream reshuffles `defs.lua` meaningfully,
+   read the diff carefully — the clib-loading block is the fragile bit.
+4. Update the pin at the top of this file.
+5. Run `cargo test -p botster -- sqlite_lua_smoke` to confirm the smoke
+   test still passes.

--- a/cli/lua/vendor/sqlite/assert.lua
+++ b/cli/lua/vendor/sqlite/assert.lua
@@ -1,0 +1,83 @@
+local M = {}
+local u = require "sqlite.utils"
+local clib = require "sqlite.defs"
+
+--- Functions for asseting and erroring out :D
+
+local errors = {
+  not_sqltbl = "can not execute %s, %s doesn't exists.",
+  close_fail = "database connection didn't get closed, ERRMSG: %s",
+  eval_fail = "eval has failed to execute statement, ERRMSG: %s",
+  failed_ops = "operation failed, ERRMSG: %s",
+  missing_req_key = "(insert) missing a required key: %s",
+  missing_db_object = "%s's db object is not set. set it with `%s:set_db(db)` and try again.",
+  outdated_schema = "`%s` does not exists in {`%s`}, schema is outdateset `self.db.tbl_schemas[table_name]` or reload",
+  auto_alter_more_less_keys = "schema defined ~= db schema. Please drop `%s` table first or set ensure to false.",
+}
+
+for key, value in pairs(errors) do
+  errors[key] = "sqlite.lua: " .. value
+end
+
+---Error out if sql table doesn't exists.
+---@param db table
+---@param tbl_name string
+---@param method any
+---@return boolean
+M.is_sqltbl = function(db, tbl_name, method)
+  assert(db:exists(tbl_name), errors.not_sqltbl:format(method, tbl_name))
+  return true
+end
+
+---Error out if connection didn't get closed.
+---This should never happen but is used just in case
+---@param conn_ptr sqlite_blob*
+---@return boolean
+M.should_close = function(conn_ptr, did_close)
+  assert(did_close, errors.close_fail:format(clib.last_errmsg(conn_ptr)))
+  return true
+end
+
+---Error out if statement evaluation/executation result in
+---last_errorcode ~= flags.ok
+---@param conn_ptr sqlite_blob*
+---@return boolean
+M.should_eval = function(conn_ptr)
+  local no_err = clib.last_errcode(conn_ptr) == clib.flags.ok
+  assert(no_err, errors.eval_fail:format(clib.last_errmsg(conn_ptr)))
+end
+
+---Check if a given ret table length is more then 0
+---This because in update we insert and expect some value
+---returned 'let me id or 'boolean.
+---When the ret values < 0 then the function didn't do anything.
+---@param status sqlite_db_status
+---@return boolean
+M.should_modify = function(status)
+  assert(status.code == 0, errors.failed_ops:format(status.msg))
+  return true
+end
+
+M.missing_req_key = function(val, key)
+  assert(val ~= nil, errors.missing_req_key:format(key))
+  return false
+end
+
+M.should_have_column_def = function(column_def, k, schema)
+  if not column_def then
+    error(errors.outdated_schema:format(k, u.join(u.keys(schema), ", ")))
+  end
+end
+
+M.should_have_db_object = function(db, name)
+  assert(db ~= nil, errors.missing_db_object:format(name, name))
+  return true
+end
+
+M.auto_alter_should_have_equal_len = function(len_new, len_old, tname)
+  if len_new - len_old ~= 0 then
+    error(errors.auto_alter_more_less_keys:format(tname))
+  end
+end
+
+return M

--- a/cli/lua/vendor/sqlite/db.lua
+++ b/cli/lua/vendor/sqlite/db.lua
@@ -1,0 +1,669 @@
+---@brief [[
+---Main sqlite.lua object and methods.
+---@brief ]]
+---@tag sqlite.db.lua
+
+local u = require "sqlite.utils"
+local require = u.require_on_index
+
+local sqlite = {}
+
+---@class sqlite_db @Main sqlite.lua object.
+---@field uri string: database uri. it can be an environment variable or an absolute path. default ":memory:"
+---@field opts sqlite_opts: see https://www.sqlite.org/pragma.html |sqlite_opts|
+---@field conn sqlite_blob: sqlite connection c object.
+---@field db sqlite_db: reference to fallback to when overwriting |sqlite_db| methods (extended only).
+sqlite.db = {}
+sqlite.db.__index = sqlite.db
+sqlite.db.__version = "v1.2.2"
+
+local clib = require "sqlite.defs"
+local s = require "sqlite.stmt"
+local h = require "sqlite.helpers"
+local a = require "sqlite.assert"
+local p = require "sqlite.parser"
+local tbl = require "sqlite.tbl"
+
+---Creates a new sqlite.lua object, without creating a connection to uri.
+---|sqlite.new| is identical to |sqlite.db:open| but it without opening sqlite db
+---connection (unless opts.keep_open). Its most suited for cases where the
+---database might be -acccess from multiple places. For neovim use cases, this
+---mean from different -neovim instances.
+---
+---<pre>
+---```lua
+--- local db = sqlite.new("path/to/db" or "$env_var", { ... } or nil)
+--- -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+--- -- for more customize behaviour, set opts.open_mode to a list of db.flags
+--- -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
+---```
+---</pre>
+---@param uri string: uri to db file.
+---@param opts sqlite_opts: (optional) see |sqlite_opts|
+---@return sqlite_db
+function sqlite.db.new(uri, opts)
+  opts = opts or {}
+  local keep_open = opts.keep_open
+  opts.keep_open = nil
+  uri = type(uri) == "string" and u.expand(uri) or ":memory:"
+
+  local o = setmetatable({
+    uri = uri,
+    conn = nil,
+    closed = true,
+    opts = opts,
+    modified = false,
+    created = nil,
+    tbl_schemas = {},
+  }, sqlite.db)
+
+  if keep_open then
+    o:open()
+  end
+
+  return o
+end
+
+---Extend |sqlite_db| object with extra sugar syntax and api. This is recommended
+---for all sqlite use case as it provide convenience. This method is super lazy.
+---it try its best to doing any ffi calls until the first operation done on a table.
+---
+---In the case you want to keep db connection open and not on invocation bases.
+---Run |sqlite.db:open()| right after creating the object or when you
+---intend to use it.
+---
+---Like |sqlite_tbl| original methods can be access through pre-appending "__"
+---when user overwrites it.
+---
+---if { conf.opts.lazy } then only return a logical object with self-dependent
+--tables, e.g. a table exists and other not because the one that
+---exists, it's method was called. (default false).
+---if { conf.opts.keep_open } then the sqlite extend db object will be returned
+---with an open connection (default false)
+
+---<pre>
+---```lua
+--- local db = sqlite { -- or sqlite_db:extend
+---   uri = "path/to/db", -- path to db file
+---   entries = require'entries',  -- a pre-made |sqlite_tbl| object.
+---   category = { title = { "text", unique = true, primary = true}  },
+---   opts = {} or nil -- custom sqlite3 options, see |sqlite_opts|
+---   --- if opts.keep_open, make connection and keep it open.
+---   --- if opts.lazy, then just provide logical object
+---   --- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+---   --- for more customize behaviour, set opts.open_mode to a list of db.flags
+---   --- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
+--- }
+--- --- Overwrite method and access it using through pre-appending "__"
+--- db.select = function(...) db:__select(...) end
+---```
+---</pre>
+---@param conf table: see 'Fields'
+---@field uri string: path to db file.
+---@field opts sqlite_opts: (optional) see |sqlite_opts| + lazy (default false), open (default false)
+---@field tname1 string: pointing to |sqlite_etbl| or |sqlite_schema_dict|
+---@field tnameN string: pointing to |sqlite_etbl| or |sqlite_schema_dict|
+---@see sqlite_tbl:extend
+---@return sqlite_db
+function sqlite.db:extend(conf)
+  conf.opts = conf.opts or {}
+  local lazy = conf.opts.lazy
+  conf.opts.lazy = nil
+
+  local db = self.new(conf.uri, conf.opts)
+  local cls = setmetatable({ db = db }, {
+    __index = function(_, key, ...)
+      if type(key) == "string" then
+        key = key:sub(1, 2) == "__" and key:sub(3, -1) or key
+        if db[key] then
+          return db[key]
+        end
+      end
+    end,
+  })
+
+  for tbl_name, schema in pairs(conf) do
+    if tbl_name ~= "uri" and tbl_name ~= "opts" and tbl_name ~= "lazy" and u.is_tbl(schema) then
+      local name = schema._name and schema._name or tbl_name
+      cls[tbl_name] = schema.set_db and schema or require("sqlite.tbl").new(name, schema, not lazy and db or nil)
+      if not cls[tbl_name].db then
+        (cls[tbl_name]):set_db(db)
+      end
+    end
+  end
+
+  return cls
+end
+
+---Creates and connect to new sqlite db object, either in memory or via a {uri}.
+---If it is called on pre-made |sqlite_db| object, than it should open it. otherwise ignore.
+---
+---<pre>
+---```lua
+--- -- Open db file at path or environment variable, otherwise open in memory.
+--- local db = sqlite.db:open("./pathto/dbfile" or "$ENV_VARABLE" or nil, {...})
+--- -- reopen connection if closed.
+--- db:open()
+--- -- configure open mode through opts.open_mode = "ro", "rw", "rwc", default "rwc"
+--- -- for more customize behaviour, set opts.open_mode to a list of db.flags
+--- -- see https://sqlite.org/c3ref/open.html#urifilenamesinsqlite3open
+---```
+---</pre>
+---@param uri string: (optional) {uri} == {nil} then in-memory db.
+---@param opts sqlite_opts|nil:  see |sqlite_opts|
+---@return sqlite_db
+function sqlite.db:open(uri, opts, noconn)
+  local d = self
+  if not d.uri then
+    d = sqlite.db.new(uri, opts)
+  end
+
+  if d.closed or d.closed == nil then
+    d.conn = clib.connect(d.uri, d.opts)
+    d.created = os.date "%Y-%m-%d %H:%M:%S"
+    d.closed = false
+  end
+
+  return d
+end
+
+---Close sqlite db connection. returns true if closed, error otherwise.
+---
+---<pre>
+---```lua
+--- local db = sqlite.db:open()
+--- db:close() -- close connection
+---```
+---</pre>
+---@return boolean
+function sqlite.db:close()
+  self.closed = self.closed or clib.close(self.conn) == 0
+  a.should_close(self.conn, self.closed)
+  return self.closed
+end
+
+---Same as |sqlite.db:open| but execute {func} then closes db connection.
+---If the function is called as a method to db object e.g. 'db:with_open', then
+---{args[1]} must be a function. Else {args[1]} need to be the uri and {args[2]} the function.
+---
+---<pre>
+---```lua
+--- -- as a function
+--- local entries = sqlite.with_open("path/to/db", function(db)
+---    return db:select("todos", { where = { status = "done" } })
+--- end)
+--- -- as a method
+--- local exists = db:with_open(function()
+---   return db:exists("projects")
+---  end)
+---```
+---</pre>
+---
+---@varargs If used as db method, then the {args[1]} should be a function, else
+---{args[1]} is uri and {args[2]} is function.
+---@see sqlite.db:open
+---@return any
+function sqlite.db:with_open(...)
+  local args = { ... }
+  if type(self) == "string" or not self then
+    self = sqlite.db:open(self)
+  end
+
+  local func = type(args[1]) == "function" and args[1] or args[2]
+
+  if self:isclose() then
+    self:open()
+  end
+
+  local success, result = pcall(function()
+    return func(self)
+  end)
+  self:close()
+  if not success then
+    error(result)
+  end
+  return result
+end
+
+---Predict returning true if db connection is active.
+---
+---<pre>
+---```lua
+--- if db:isopen() then
+---   db:close()
+--- end
+---```
+---</pre>
+---@return boolean
+function sqlite.db:isopen()
+  return not self.closed
+end
+
+---Predict returning true if db connection is indeed closed.
+---
+---<pre>
+---```lua
+--- if db:isclose() then
+---   error("db is closed")
+--- end
+---```
+---</pre>
+---@return boolean
+function sqlite.db:isclose()
+  return self.closed
+end
+
+---Returns current connection status
+---Get last error code
+---
+---<pre>
+---```lua
+--- print(db:status().msg) -- get last error msg
+--- print(db:status().code) -- get last error code.
+---```
+---</pre>
+---@return sqlite_db_status
+function sqlite.db:status()
+  return {
+    msg = clib.last_errmsg(self.conn),
+    code = clib.last_errcode(self.conn),
+  }
+end
+
+---Evaluates a sql {statement} and if there are results from evaluation it
+---returns list of rows. Otherwise it returns a boolean indecating
+---whether the evaluation was successful.
+---
+---<pre>
+---```lua
+--- -- evaluate without any extra arguments.
+--- db:eval("drop table if exists todos")
+--- --  evaluate with unamed value.
+--- db:eval("select * from todos where id = ?", 1)
+--- -- evaluate with named arguments.
+--- db:eval("insert into t(a, b) values(:a, :b)", {a = "1", b = 3})
+---```
+---</pre>
+---@param statement string: SQL statement.
+---@param params table|nil: params to be bind to {statement}
+---@return boolean|table
+function sqlite.db:eval(statement, params)
+  local res = {}
+  local stmt = s:parse(self.conn, statement)
+
+  -- when the user provide simple sql statements
+  if not params then
+    stmt:each(function()
+      table.insert(res, stmt:kv())
+    end)
+    stmt:reset()
+
+    -- when the user run eval("select * from ?", "tbl_name")
+  elseif type(params) ~= "table" and statement:match "%?" then
+    local value = p.sqlvalue(params)
+    stmt:bind { value }
+    stmt:each(function(stm)
+      table.insert(res, stm:kv())
+    end)
+    stmt:reset()
+    stmt:bind_clear()
+
+    -- when the user provided named keys
+  elseif params and type(params) == "table" then
+    params = type(params[1]) == "table" and params or { params }
+    for _, v in ipairs(params) do
+      stmt:bind(v)
+      stmt:each(function(stm)
+        table.insert(res, stm:kv())
+      end)
+      stmt:reset()
+      stmt:bind_clear()
+    end
+  end
+  -- clear out the parsed statement.
+  stmt:finalize()
+
+  -- if no rows is returned, then check return the result of errcode == flags.ok
+  res = rawequal(next(res), nil) and clib.last_errcode(self.conn) == clib.flags.ok or res
+
+  -- fix res of its table, so that select all doesn't return { [1] = {[1] = { row }} }
+  if type(res) == "table" and res[2] == nil and u.is_nested(res[1]) then
+    res = res[1]
+  end
+
+  a.should_eval(self.conn)
+
+  self.modified = true
+
+  return res
+end
+
+---Execute statement without any return
+---
+---<pre>
+---```lua
+--- db:execute("drop table if exists todos")
+--- db:execute("pragma foreign_keys=on")
+---```
+---</pre>
+---@param statement string: statement to be executed
+---@return boolean: true if successful, error out if not.
+function sqlite.db:execute(statement)
+  local succ = clib.exec_stmt(self.conn, statement) == 0
+  return succ and succ or error(clib.last_errmsg(self.conn))
+end
+
+---Check if a table with {tbl_name} exists in sqlite db
+---<pre>
+---```lua
+--- if not db:exists("todo_tbl") then
+---   error("Table doesn't exists!!!")
+--- end
+---```
+---</pre>
+---@param tbl_name string: the table name.
+---@return boolean
+function sqlite.db:exists(tbl_name)
+  local q = self:eval("select name from sqlite_master where name= ?", tbl_name)
+  return type(q) == "table" and true or false
+end
+
+---Create a new sqlite db table with {name} based on {schema}. if {schema.ensure} then
+---create only when it does not exists. similar to 'create if not exists'.
+---
+---<pre>
+---```lua
+--- db:create("todos", {
+---   id = {"int", "primary", "key"},
+---   title = "text",
+---   name = { type = "string", reference = "sometbl.id" },
+---   ensure = true -- create table if it doesn't already exists (THIS IS DEFUAULT)
+--- })
+---```
+---</pre>
+---@param tbl_name string: table name
+---@param schema sqlite_schema_dict
+---@return boolean
+function sqlite.db:create(tbl_name, schema)
+  local req = p.create(tbl_name, schema)
+  if req:match "reference" then
+    self:execute "pragma foreign_keys = ON"
+    self.opts.foreign_keys = true
+  end
+  return self:eval(req)
+end
+
+---Remove {tbl_name} from database
+---
+---<pre>
+---```lua
+--- if db:exists("todos") then
+---   db:drop("todos")
+--- end
+---```
+---</pre>
+---@param tbl_name string: table name
+---@return boolean
+function sqlite.db:drop(tbl_name)
+  self.tbl_schemas[tbl_name] = nil
+  return self:eval(p.drop(tbl_name))
+end
+
+---Get {name} table schema, if table does not exist then return an empty table.
+---
+---<pre>
+---```lua
+--- if db:exists("todos") then
+---   inspect(db:schema("todos").project)
+--- else
+---   print("create me")
+--- end
+---```
+---</pre>
+---@param tbl_name string: the table name.
+---@return sqlite_schema_dict
+function sqlite.db:schema(tbl_name)
+  local sch = self:eval(("pragma table_info(%s)"):format(tbl_name))
+  local schema = {}
+  for _, v in ipairs(type(sch) == "boolean" and {} or sch) do
+    schema[v.name] = {
+      cid = v.cid,
+      required = v.notnull == 1,
+      primary = v.pk == 1,
+      type = v.type,
+      default = v.dflt_value,
+    }
+  end
+  return schema
+end
+
+---Insert lua table into sqlite database table.
+---
+---<pre>
+---```lua
+--- --- single item.
+--- db:insert("todos", { title = "new todo" })
+--- --- insert multiple items.
+--- db:insert("items", {  { name = "a"}, { name = "b" }, { name = "c" } })
+---```
+---</pre>
+---@param tbl_name string: the table name
+---@param rows table: rows to insert to the table.
+---@return boolean|integer: boolean (true == success), and the last inserted row id.
+function sqlite.db:insert(tbl_name, rows, schema)
+  a.is_sqltbl(self, tbl_name, "insert")
+  local ret_vals = {}
+  schema = schema and schema or h.get_schema(tbl_name, self)
+  local items = p.pre_insert(rows, schema)
+  local last_rowid
+  clib.wrap_stmts(self.conn, function()
+    for _, v in ipairs(items) do
+      local stmt = s:parse(self.conn, p.insert(tbl_name, { values = v }))
+      stmt:bind(v)
+      stmt:step()
+      stmt:bind_clear()
+      table.insert(ret_vals, stmt:finalize())
+    end
+    last_rowid = tonumber(clib.last_insert_rowid(self.conn))
+  end)
+
+  local succ = u.all(ret_vals, function(_, v)
+    return v
+  end)
+  if succ then
+    self.modified = true
+  end
+  return succ, last_rowid
+end
+
+---Update table row with where closure and list of values
+---returns true incase the table was updated successfully.
+---
+---<pre>
+---```lua
+--- --- update todos status linked to project "lua-hello-world" or "rewrite-neoivm-in-rust"
+--- db:update("todos", {
+---   where = { project = {"lua-hello-world", "rewrite-neoivm-in-rust"} },
+---   set = { status = "later" }
+--- })
+---
+--- --- pass custom statement and boolean
+--- db:update("timestamps", {
+---   where = { id = "<" .. 4 }, -- mimcs WHERE id < 4
+---   set = { seen = true } -- will be converted to 0.
+--- })
+---```
+---</pre>
+---@param tbl_name string: sqlite table name.
+---@param specs sqlite_query_update | sqlite_query_update[]
+---@return boolean
+function sqlite.db:update(tbl_name, specs, schema)
+  a.is_sqltbl(self, tbl_name, "update")
+  if not specs then
+    return false
+  end
+
+  return clib.wrap_stmts(self.conn, function()
+    specs = u.is_nested(specs) and specs or { specs }
+    schema = schema and schema or h.get_schema(tbl_name, self)
+
+    local ret_val = nil
+    for _, v in ipairs(specs) do
+      v.set = v.set and v.set or v.values
+      if self:select(tbl_name, { where = v.where })[1] then
+        local stmt = s:parse(self.conn, p.update(tbl_name, { set = v.set, where = v.where }))
+        stmt:bind(p.pre_insert(v.set, schema)[1])
+        stmt:step()
+        stmt:reset()
+        stmt:bind_clear()
+        stmt:finalize()
+        a.should_modify(self:status())
+        ret_val = true
+      else
+        ret_val = self:insert(tbl_name, u.tbl_extend("keep", v.set, v.where))
+        a.should_modify(self:status())
+      end
+    end
+    self.modified = true
+    return ret_val
+  end)
+end
+
+---Delete a {tbl_name} row/rows based on the {where} closure. If {where == nil}
+---then all the {tbl_name} content will be deleted.
+---
+---<pre>
+---```lua
+--- --- delete todos table content
+--- db:delete("todos")
+--- --- delete row that has id as 1
+--- db:delete("todos", { id = 1 })
+--- --- delete all rows that has value of id 1 or 2 or 3
+--- db:delete("todos", { id = {1,2,3} })
+--- --- matching ids or greater than 5
+--- db:delete("todos", { id = {"<", 5} }) -- or {id = "<5"}
+---```
+---</pre>
+---@param tbl_name string: sqlite table name
+---@param where sqlite_query_delete: key value pair to where delete operation should effect.
+---@todo support querys with `and`
+---@return boolean: true if operation is successfully, false otherwise.
+function sqlite.db:delete(tbl_name, where)
+  a.is_sqltbl(self, tbl_name, "delete")
+
+  if not where then
+    return self:execute(p.delete(tbl_name))
+  end
+
+  where = u.is_nested(where) and where or { where }
+  clib.wrap_stmts(self.conn, function()
+    for _, spec in ipairs(where) do
+      local _where = spec.where and spec.where or spec
+      local stmt = s:parse(self.conn, p.delete(tbl_name, { where = _where }))
+      stmt:step()
+      stmt:reset()
+      stmt:finalize()
+      a.should_modify(self:status())
+    end
+  end)
+
+  self.modified = true
+
+  return true
+end
+
+---Query from a table with where and join options
+---
+---<pre>
+---```lua
+--- db:select("todos") get everything
+--- --- get row with id of 1
+--- db:select("todos", { where = { id = 1 })
+--- ---  get row with status value of later or paused
+--- db:select("todos", { where = { status = {"later", "paused"} })
+--- --- get 5 items from todos table
+--- db:select("todos", { limit = 5 })
+--- --- select a set of keys with computed one
+--- db:select("timestamps", {
+---   select = {
+---     age = (strftime("%s", "now") - strftime("%s", "timestamp")) * 24 * 60,
+---     "id",
+---     "timestamp",
+---     "entry",
+---     },
+---   })
+---```
+---</pre>
+---@param tbl_name string: the name of the db table to select on
+---@param spec sqlite_query_select
+---@return table[]
+function sqlite.db:select(tbl_name, spec, schema)
+  a.is_sqltbl(self, tbl_name, "select")
+  return clib.wrap_stmts(self.conn, function()
+    local ret = {}
+    schema = schema and schema or h.get_schema(tbl_name, self)
+
+    spec = spec or {}
+    spec.select = spec.keys and spec.keys or spec.select
+
+    local stmt = s:parse(self.conn, p.select(tbl_name, spec))
+    s.each(stmt, function()
+      table.insert(ret, s.kv(stmt))
+    end)
+    s.reset(stmt)
+    if s.finalize(stmt) then
+      self.modified = false
+    end
+    return p.post_select(ret, schema)
+  end)
+end
+
+---Create new sqlite_tbl object.
+---If {opts}.ensure = false, then on each run it will drop the table and recreate it.
+---NOTE: this might change someday to alter the table instead. For now
+---alteration is auto and limited to field schema edits and renames
+---
+---<pre>
+---```lua
+--- local tbl = db:tbl("todos", {
+---   id = true, -- same as { type = "integer", required = true, primary = true }
+---   title = "text",
+---   category = {
+---     type = "text",
+---     reference = "category.id",
+---     on_update = "cascade", -- means when category get updated update
+---     on_delete = "null", -- means when category get deleted, set to null
+---   },
+--- })
+--- --- or without db injected and use as wrapper for |sqlite.tbl.new|
+--- local tbl = db.tbl("name", ...)
+---```
+---</pre>
+---@param tbl_name string: the name of the table. can be new or existing one.
+---@param schema sqlite_schema_dict: {schema, ensure (defalut true)}
+---@see |sqlite.tbl.new|
+---@return sqlite_tbl
+function sqlite.db:tbl(tbl_name, schema)
+  if type(self) == "string" then
+    schema = tbl_name
+    return tbl.new(self, schema)
+  end
+  return tbl.new(tbl_name, schema, self)
+end
+
+---DEPRECATED
+function sqlite.db:table(tbl_name, opts)
+  print "sqlite.lua sqlite:table is deprecated use sqlite:tbl instead"
+  return self:tbl(tbl_name, opts)
+end
+
+---Sqlite functions sugar wrappers. See `sql/strfun`
+sqlite.db.lib = require "sqlite.strfun"
+
+sqlite.db = setmetatable(sqlite.db, {
+  __call = sqlite.db.extend,
+})
+
+sqlite.db.flags = clib.flags
+
+return sqlite.db

--- a/cli/lua/vendor/sqlite/defs.lua
+++ b/cli/lua/vendor/sqlite/defs.lua
@@ -1,0 +1,731 @@
+local ffi = require "ffi"
+local bit = require "bit"
+-- botster: `luv` (the libuv binding) is not available outside neovim; we rely on
+-- LuaJIT's `os.getenv` / `jit.os` / `jit.arch` instead. See VENDOR_CHANGES.md.
+local M = {}
+
+--- Load clib
+local clib = (function()
+  -- botster: BOTSTER_LIBSQLITE takes precedence so deployments can pin a
+  -- specific library without clobbering a caller's own LIBSQLITE.
+  local path = os.getenv("BOTSTER_LIBSQLITE") or os.getenv("LIBSQLITE")
+
+  local clib_path = path
+    or (function() --- try to find libsqlite.Linux and Macos support only.
+      -- botster: `jit.os` returns "Linux"|"OSX"|"Windows"|"BSD"|"Other";
+      -- `jit.arch` returns "x86"|"x64"|"arm"|"arm64"|... Upstream keyed on
+      -- `luv.os_uname().sysname` which has "Darwin" instead of LuaJIT's "OSX",
+      -- so the Darwin branch compares against "OSX" below.
+      local jit_os = jit and jit.os or "Other"
+      local jit_arch = jit and jit.arch or "x64"
+
+      local file_exists = function(file_path)
+        local f = io.open(file_path, "r")
+        if f ~= nil then
+          io.close(f)
+          return true
+        else
+          return false
+        end
+      end
+
+      if jit_os == "Linux" then
+        local linux_paths = {
+          "/usr/lib/x86_64-linux-gnu/libsqlite3.so",
+          "/usr/lib/x86_64-linux-gnu/libsqlite3.so.0",
+          "/usr/lib/aarch64-linux-gnu/libsqlite3.so",
+          "/usr/lib/aarch64-linux-gnu/libsqlite3.so.0",
+          "/usr/lib64/libsqlite3.so",
+          "/usr/lib64/libsqlite3.so.0",
+          "/usr/lib/libsqlite3.so",
+        }
+        for _, v in pairs(linux_paths) do
+          if file_exists(v) then
+            return v
+          end
+        end
+      end
+
+      if jit_os == "OSX" then
+        local homebrew_prefix = os.getenv("HOMEBREW_PREFIX") or "/opt/homebrew"
+        return jit_arch == "arm64" and homebrew_prefix .. "/opt/sqlite/lib/libsqlite3.dylib"
+          or "/usr/local/opt/sqlite3/lib/libsqlite3.dylib"
+      end
+    end)()
+
+  return ffi.load(clib_path or "libsqlite3")
+end)()
+
+---@type sqlite_flags
+M.flags = {
+  -- Result codes
+  ["ok"] = 0,
+  ["error"] = 1,
+  ["internal"] = 2,
+  ["perm"] = 3,
+  ["abort"] = 4,
+  ["busy"] = 5,
+  ["locked"] = 6,
+  ["nomem"] = 7,
+  ["readonly"] = 8,
+  ["interrupt"] = 9,
+  ["ioerr"] = 10,
+  ["corrupt"] = 11,
+  ["notfound"] = 12,
+  ["full"] = 13,
+  ["cantopen"] = 14,
+  ["protocol"] = 15,
+  ["empty"] = 16,
+  ["schema"] = 17,
+  ["toobig"] = 18,
+  ["constraint"] = 19,
+  ["mismatch"] = 20,
+  ["misuse"] = 21,
+  ["nolfs"] = 22,
+  ["auth"] = 23,
+  ["format"] = 24,
+  ["range"] = 25,
+  ["notadb"] = 26,
+  ["notice"] = 27,
+  ["warning"] = 28,
+  ["row"] = 100,
+  ["done"] = 101,
+}
+
+---@type sqlite_db.opts
+M.valid_pargma = {
+  ["analysis_limit"] = true,
+  ["application_id"] = true,
+  ["auto_vacuum"] = true,
+  ["automatic_index"] = true,
+  ["busy_timeout"] = true,
+
+  ["cache_size"] = true,
+  ["cache_spill"] = true,
+  ["case_sensitive_like"] = true,
+  ["cell_size_check"] = true,
+  ["checkpoint_fullfsync"] = true,
+
+  ["collation_list"] = true,
+  ["compile_options"] = true,
+  ["data_version"] = true,
+  ["database_list"] = true,
+  ["encoding"] = true,
+  ["foreign_key_check"] = true,
+
+  ["foreign_key_list"] = true,
+  ["foreign_keys"] = true,
+  ["freelist_count"] = true,
+  ["fullfsync"] = true,
+  ["function_list"] = true,
+
+  ["hard_heap_limit"] = true,
+  ["ignore_check_constraints"] = true,
+  ["incremental_vacuum"] = true,
+  ["index_info"] = true,
+  ["index_list"] = true,
+
+  ["index_xinfo"] = true,
+  ["integrity_check"] = true,
+  ["journal_mode"] = true,
+  ["journal_size_limit"] = true,
+  ["legacy_alter_table"] = true,
+
+  ["legacy_file_format"] = true,
+  ["locking_mode"] = true,
+  ["max_page_count"] = true,
+  ["mmap_size"] = true,
+  ["module_list"] = true,
+  ["optimize"] = true,
+
+  ["page_count"] = true,
+  ["page_size"] = true,
+  ["parser_trace"] = true,
+  ["pragma_list"] = true,
+  ["query_only"] = true,
+  ["quick_check"] = true,
+
+  ["read_uncommitted"] = true,
+  ["recursive_triggers"] = true,
+  ["reverse_unordered_selects"] = true,
+  ["schema_version"] = true,
+  ["secure_delete"] = true,
+
+  ["shrink_memory"] = true,
+  ["soft_heap_limit"] = true,
+  ["stats"] = true,
+  ["synchronous"] = true,
+  ["table_info"] = true,
+  ["table_xinfo"] = true,
+  ["temp_store"] = true,
+
+  ["vdbe_trace"] = true,
+  ["wal_autocheckpoint"] = true,
+  ["wal_checkpoint"] = true,
+  ["writable_schema"] = true,
+
+  ["threads"] = true,
+  ["trusted_schema"] = true,
+  ["user_version"] = true,
+  ["vdbe_addoptrace"] = true,
+  ["vdbe_debug"] = true,
+  ["vdbe_listing"] = true,
+}
+
+-- Extended Result Codes
+M.flags["error_missing_collseq"] = bit.bor(M.flags.error, bit.lshift(1, 8))
+M.flags["error_retry"] = bit.bor(M.flags.error, bit.lshift(2, 8))
+M.flags["error_snapshot"] = bit.bor(M.flags.error, bit.lshift(3, 8))
+M.flags["ioerr_read"] = bit.bor(M.flags.ioerr, bit.lshift(1, 8))
+M.flags["ioerr_short_read"] = bit.bor(M.flags.ioerr, bit.lshift(2, 8))
+M.flags["ioerr_write"] = bit.bor(M.flags.ioerr, bit.lshift(3, 8))
+M.flags["ioerr_fsync"] = bit.bor(M.flags.ioerr, bit.lshift(4, 8))
+M.flags["ioerr_dir_fsync"] = bit.bor(M.flags.ioerr, bit.lshift(5, 8))
+M.flags["ioerr_truncate"] = bit.bor(M.flags.ioerr, bit.lshift(6, 8))
+M.flags["ioerr_fstat"] = bit.bor(M.flags.ioerr, bit.lshift(7, 8))
+M.flags["ioerr_unlock"] = bit.bor(M.flags.ioerr, bit.lshift(8, 8))
+M.flags["ioerr_rdlock"] = bit.bor(M.flags.ioerr, bit.lshift(9, 8))
+M.flags["ioerr_delete"] = bit.bor(M.flags.ioerr, bit.lshift(10, 8))
+M.flags["ioerr_blocked"] = bit.bor(M.flags.ioerr, bit.lshift(11, 8))
+M.flags["ioerr_nomem"] = bit.bor(M.flags.ioerr, bit.lshift(12, 8))
+M.flags["ioerr_access"] = bit.bor(M.flags.ioerr, bit.lshift(13, 8))
+M.flags["ioerr_checkreservedlock"] = bit.bor(M.flags.ioerr, bit.lshift(14, 8))
+M.flags["ioerr_lock"] = bit.bor(M.flags.ioerr, bit.lshift(15, 8))
+M.flags["ioerr_close"] = bit.bor(M.flags.ioerr, bit.lshift(16, 8))
+M.flags["ioerr_dir_close"] = bit.bor(M.flags.ioerr, bit.lshift(17, 8))
+M.flags["ioerr_shmopen"] = bit.bor(M.flags.ioerr, bit.lshift(18, 8))
+M.flags["ioerr_shmsize"] = bit.bor(M.flags.ioerr, bit.lshift(19, 8))
+M.flags["ioerr_shmlock"] = bit.bor(M.flags.ioerr, bit.lshift(20, 8))
+M.flags["ioerr_shmmap"] = bit.bor(M.flags.ioerr, bit.lshift(21, 8))
+M.flags["ioerr_seek"] = bit.bor(M.flags.ioerr, bit.lshift(22, 8))
+M.flags["ioerr_delete_noent"] = bit.bor(M.flags.ioerr, bit.lshift(23, 8))
+M.flags["ioerr_mmap"] = bit.bor(M.flags.ioerr, bit.lshift(24, 8))
+M.flags["ioerr_gettemppath"] = bit.bor(M.flags.ioerr, bit.lshift(25, 8))
+M.flags["ioerr_convpath"] = bit.bor(M.flags.ioerr, bit.lshift(26, 8))
+M.flags["ioerr_vnode"] = bit.bor(M.flags.ioerr, bit.lshift(27, 8))
+M.flags["ioerr_auth"] = bit.bor(M.flags.ioerr, bit.lshift(28, 8))
+M.flags["ioerr_begin_atomic"] = bit.bor(M.flags.ioerr, bit.lshift(29, 8))
+M.flags["ioerr_commit_atomic"] = bit.bor(M.flags.ioerr, bit.lshift(30, 8))
+M.flags["ioerr_rollback_atomic"] = bit.bor(M.flags.ioerr, bit.lshift(31, 8))
+M.flags["ioerr_data"] = bit.bor(M.flags.ioerr, bit.lshift(32, 8))
+M.flags["ioerr_corruptfs"] = bit.bor(M.flags.ioerr, bit.lshift(33, 8))
+M.flags["locked_sharedcache"] = bit.bor(M.flags.locked, bit.lshift(1, 8))
+M.flags["locked_vtab"] = bit.bor(M.flags.locked, bit.lshift(2, 8))
+M.flags["busy_recovery"] = bit.bor(M.flags.busy, bit.lshift(1, 8))
+M.flags["busy_snapshot"] = bit.bor(M.flags.busy, bit.lshift(2, 8))
+M.flags["busy_timeout"] = bit.bor(M.flags.busy, bit.lshift(3, 8))
+M.flags["cantopen_notempdir"] = bit.bor(M.flags.cantopen, bit.lshift(1, 8))
+M.flags["cantopen_isdir"] = bit.bor(M.flags.cantopen, bit.lshift(2, 8))
+M.flags["cantopen_fullpath"] = bit.bor(M.flags.cantopen, bit.lshift(3, 8))
+M.flags["cantopen_convpath"] = bit.bor(M.flags.cantopen, bit.lshift(4, 8))
+M.flags["cantopen_dirtywal"] = bit.bor(M.flags.cantopen, bit.lshift(5, 8))
+M.flags["cantopen_symlink"] = bit.bor(M.flags.cantopen, bit.lshift(6, 8))
+M.flags["corrupt_vtab"] = bit.bor(M.flags.corrupt, bit.lshift(1, 8))
+M.flags["corrupt_sequence"] = bit.bor(M.flags.corrupt, bit.lshift(2, 8))
+M.flags["corrupt_index"] = bit.bor(M.flags.corrupt, bit.lshift(3, 8))
+M.flags["readonly_recovery"] = bit.bor(M.flags.readonly, bit.lshift(1, 8))
+M.flags["readonly_cantlock"] = bit.bor(M.flags.readonly, bit.lshift(2, 8))
+M.flags["readonly_rollback"] = bit.bor(M.flags.readonly, bit.lshift(3, 8))
+M.flags["readonly_dbmoved"] = bit.bor(M.flags.readonly, bit.lshift(4, 8))
+M.flags["readonly_cantinit"] = bit.bor(M.flags.readonly, bit.lshift(5, 8))
+M.flags["readonly_directory"] = bit.bor(M.flags.readonly, bit.lshift(6, 8))
+M.flags["abort_rollback"] = bit.bor(M.flags.abort, bit.lshift(2, 8))
+M.flags["constraint_check"] = bit.bor(M.flags.constraint, bit.lshift(1, 8))
+M.flags["constraint_commithook"] = bit.bor(M.flags.constraint, bit.lshift(2, 8))
+M.flags["constraint_foreignkey"] = bit.bor(M.flags.constraint, bit.lshift(3, 8))
+M.flags["constraint_function"] = bit.bor(M.flags.constraint, bit.lshift(4, 8))
+M.flags["constraint_notnull"] = bit.bor(M.flags.constraint, bit.lshift(5, 8))
+M.flags["constraint_primarykey"] = bit.bor(M.flags.constraint, bit.lshift(6, 8))
+M.flags["constraint_trigger"] = bit.bor(M.flags.constraint, bit.lshift(7, 8))
+M.flags["constraint_unique"] = bit.bor(M.flags.constraint, bit.lshift(8, 8))
+M.flags["constraint_vtab"] = bit.bor(M.flags.constraint, bit.lshift(9, 8))
+M.flags["constraint_rowid"] = bit.bor(M.flags.constraint, bit.lshift(10, 8))
+M.flags["constraint_pinned"] = bit.bor(M.flags.constraint, bit.lshift(11, 8))
+M.flags["notice_recover_wal"] = bit.bor(M.flags.notice, bit.lshift(1, 8))
+M.flags["notice_recover_rollback"] = bit.bor(M.flags.notice, bit.lshift(2, 8))
+M.flags["warning_autoindex"] = bit.bor(M.flags.warning, bit.lshift(1, 8))
+M.flags["auth_user"] = bit.bor(M.flags.auth, bit.lshift(1, 8))
+M.flags["ok_load_permanently"] = bit.bor(M.flags.ok, bit.lshift(1, 8))
+M.flags["ok_symlink"] = bit.bor(M.flags.ok, bit.lshift(2, 8))
+
+-- Flags for file open operations.
+M.flags["open_readonly"] = 0x00000001
+M.flags["open_readwrite"] = 0x00000002
+M.flags["open_create"] = 0x00000004
+M.flags["open_deleteonclose"] = 0x00000008
+M.flags["open_exclusive"] = 0x00000010
+M.flags["open_autoproxy"] = 0x00000020
+M.flags["open_uri"] = 0x00000040
+M.flags["open_memory"] = 0x00000080
+M.flags["open_main_db"] = 0x00000100
+M.flags["open_temp_db"] = 0x00000200
+M.flags["open_transient_db"] = 0x00000400
+M.flags["open_main_journal"] = 0x00000800
+M.flags["open_temp_journal"] = 0x00001000
+M.flags["open_subjournal"] = 0x00002000
+M.flags["open_super_journal"] = 0x00004000
+M.flags["open_nomutex"] = 0x00008000
+M.flags["open_fullmutex"] = 0x00010000
+M.flags["open_sharedcache"] = 0x00020000
+M.flags["open_privatecache"] = 0x00040000
+M.flags["open_wal"] = 0x00080000
+M.flags["open_nofollow"] = 0x01000000
+
+-- Fundamental Datatypes
+M.flags["integer"] = 1
+M.flags["float"] = 2
+M.flags["text"] = 3
+M.flags["blob"] = 4
+M.flags["null"] = 5
+
+-- Types
+ffi.cdef [[
+  typedef struct sqlite3 sqlite3;
+
+  typedef __int64 sqlite_int64;
+  typedef unsigned __int64 sqlite_uint64;
+
+  typedef sqlite_int64 sqlite3_int64;
+  typedef sqlite_uint64 sqlite3_uint64;
+
+  typedef struct sqlite3_file sqlite3_file;
+  typedef struct sqlite3_stmt sqlite3_stmt;
+
+  typedef struct sqlite3_value sqlite3_value;
+  typedef struct sqlite3_context sqlite3_context;
+
+  typedef struct sqlite3_vtab sqlite3_vtab;
+  typedef struct sqlite3_vtab_cursor sqlite3_vtab_cursor;
+
+  typedef struct sqlite3_blob sqlite3_blob;
+
+  typedef struct sqlite3_str sqlite3_str;
+  typedef struct sqlite3_backup sqlite3_backup;
+]]
+
+-- Functions
+ffi.cdef [[
+  const char *sqlite3_libversion(void);
+  const char *sqlite3_sourceid(void);
+  int sqlite3_libversion_number(void);
+
+  int sqlite3_threadsafe(void);
+
+  int sqlite3_close(sqlite3*);
+  int sqlite3_close_v2(sqlite3*);
+
+  int sqlite3_exec(sqlite3*, const char *sql, int (*callback)(void*,int,char**,char**), void *, char **errmsg);
+
+  int sqlite3_initialize(void);
+  int sqlite3_shutdown(void);
+  int sqlite3_os_init(void);
+  int sqlite3_os_end(void);
+
+  int sqlite3_config(int, ...);
+  int sqlite3_db_config(sqlite3*, int op, ...);
+
+  int sqlite3_extended_result_codes(sqlite3*, int onoff);
+
+  sqlite3_int64 sqlite3_last_insert_rowid(sqlite3*);
+  void sqlite3_set_last_insert_rowid(sqlite3*,sqlite3_int64);
+
+  int sqlite3_changes(sqlite3*);
+  int sqlite3_total_changes(sqlite3*);
+
+  void sqlite3_interrupt(sqlite3*);
+
+  int sqlite3_complete(const char *sql);
+  int sqlite3_complete16(const void *sql);
+
+  int sqlite3_busy_handler(sqlite3*,int(*)(void*,int),void*);
+  int sqlite3_busy_timeout(sqlite3*, int ms);
+
+  int sqlite3_get_table(sqlite3 *db, const char *zSql, char ***pazResult, int *pnRow, int *pnColumn, char **pzErrmsg);
+  void sqlite3_free_table(char **result);
+
+  sqlite3_int64 sqlite3_memory_used(void);
+  sqlite3_int64 sqlite3_memory_highwater(int resetFlag);
+
+  void sqlite3_randomness(int N, void *P);
+
+  int sqlite3_set_authorizer(sqlite3*, int (*xAuth)(void*,int,const char*,const char*,const char*,const char*),
+                  void *pUserData);
+
+  int sqlite3_trace_v2(sqlite3*, unsigned uMask, int(*xCallback)(unsigned,void*,void*,void*), void *pCtx);
+
+  void sqlite3_progress_handler(sqlite3*, int, int(*)(void*), void*);
+
+  int sqlite3_open(const char *filename, sqlite3 **ppDb);
+  int sqlite3_open16(const void *filename, sqlite3 **ppDb);
+  int sqlite3_open_v2(const char *filename, sqlite3 **ppDb, int flags, const char *zVfs);
+
+  const char *sqlite3_uri_parameter(const char *zFilename, const char *zParam);
+  int sqlite3_uri_boolean(const char *zFile, const char *zParam, int bDefault);
+  sqlite3_int64 sqlite3_uri_int64(const char*, const char*, sqlite3_int64);
+  const char *sqlite3_uri_key(const char *zFilename, int N);
+
+  const char *sqlite3_filename_database(const char*);
+  const char *sqlite3_filename_journal(const char*);
+  const char *sqlite3_filename_wal(const char*);
+
+  sqlite3_file *sqlite3_database_file_object(const char*);
+
+  char *sqlite3_create_filename(const char *zDatabase, const char *zJournal, const char *zWal, int nParam,
+                  const char **azParam);
+  void sqlite3_free_filename(char*);
+
+  int sqlite3_errcode(sqlite3 *db);
+  int sqlite3_extended_errcode(sqlite3 *db);
+  const char *sqlite3_errmsg(sqlite3*);
+  const void *sqlite3_errmsg16(sqlite3*);
+  const char *sqlite3_errstr(int);
+
+  int sqlite3_limit(sqlite3*, int id, int newVal);
+
+  int sqlite3_prepare(sqlite3 *db, const char *zSql, int nByte, sqlite3_stmt **ppStmt, const char **pzTail);
+  int sqlite3_prepare_v2(sqlite3 *db, const char *zSql, int nByte, sqlite3_stmt **ppStmt, const char **pzTail);
+  int sqlite3_prepare_v3(sqlite3 *db, const char *zSql, int nByte, unsigned int prepFlags, sqlite3_stmt **ppStmt,
+                  const char **pzTail);
+  int sqlite3_prepare16(sqlite3 *db, const void *zSql, int nByte, sqlite3_stmt **ppStmt, const void **pzTail);
+  int sqlite3_prepare16_v2(sqlite3 *db, const void *zSql, int nByte, sqlite3_stmt **ppStmt, const void **pzTail);
+  int sqlite3_prepare16_v3(sqlite3 *db, const void *zSql, int nByte, unsigned int prepFlags, sqlite3_stmt **ppStmt,
+                  const void **pzTail);
+
+  const char *sqlite3_sql(sqlite3_stmt *pStmt);
+  char *sqlite3_expanded_sql(sqlite3_stmt *pStmt);
+  const char *sqlite3_normalized_sql(sqlite3_stmt *pStmt);
+
+  int sqlite3_stmt_readonly(sqlite3_stmt *pStmt);
+  int sqlite3_stmt_isexplain(sqlite3_stmt *pStmt);
+  int sqlite3_stmt_busy(sqlite3_stmt*);
+
+  int sqlite3_bind_blob(sqlite3_stmt*, int, const void*, int n, void(*)(void*));
+  int sqlite3_bind_blob64(sqlite3_stmt*, int, const void*, sqlite3_uint64,
+                  void(*)(void*));
+  int sqlite3_bind_double(sqlite3_stmt*, int, double);
+  int sqlite3_bind_int(sqlite3_stmt*, int, int);
+  int sqlite3_bind_int64(sqlite3_stmt*, int, sqlite3_int64);
+  int sqlite3_bind_null(sqlite3_stmt*, int);
+  int sqlite3_bind_text(sqlite3_stmt*,int,const char*,int,void(*)(void*));
+  int sqlite3_bind_text16(sqlite3_stmt*, int, const void*, int, void(*)(void*));
+  int sqlite3_bind_text64(sqlite3_stmt*, int, const char*, sqlite3_uint64,
+                  void(*)(void*), unsigned char encoding);
+  int sqlite3_bind_value(sqlite3_stmt*, int, const sqlite3_value*);
+  int sqlite3_bind_pointer(sqlite3_stmt*, int, void*, const char*,void(*)(void*));
+  int sqlite3_bind_zeroblob(sqlite3_stmt*, int, int n);
+  int sqlite3_bind_zeroblob64(sqlite3_stmt*, int, sqlite3_uint64);
+
+  int sqlite3_bind_parameter_count(sqlite3_stmt*);
+  const char *sqlite3_bind_parameter_name(sqlite3_stmt*, int);
+  int sqlite3_bind_parameter_index(sqlite3_stmt*, const char *zName);
+  int sqlite3_clear_bindings(sqlite3_stmt*);
+  int sqlite3_column_count(sqlite3_stmt *pStmt);
+  const char *sqlite3_column_name(sqlite3_stmt*, int N);
+  const void *sqlite3_column_name16(sqlite3_stmt*, int N);
+
+  const char *sqlite3_column_database_name(sqlite3_stmt*,int);
+  const void *sqlite3_column_database_name16(sqlite3_stmt*,int);
+  const char *sqlite3_column_table_name(sqlite3_stmt*,int);
+  const void *sqlite3_column_table_name16(sqlite3_stmt*,int);
+  const char *sqlite3_column_origin_name(sqlite3_stmt*,int);
+  const void *sqlite3_column_origin_name16(sqlite3_stmt*,int);
+
+  const char *sqlite3_column_decltype(sqlite3_stmt*,int);
+  const void *sqlite3_column_decltype16(sqlite3_stmt*,int);
+
+  int sqlite3_step(sqlite3_stmt*);
+  int sqlite3_data_count(sqlite3_stmt *pStmt);
+
+  const void *sqlite3_column_blob(sqlite3_stmt*, int iCol);
+  double sqlite3_column_double(sqlite3_stmt*, int iCol);
+  int sqlite3_column_int(sqlite3_stmt*, int iCol);
+  sqlite3_int64 sqlite3_column_int64(sqlite3_stmt*, int iCol);
+  const unsigned char *sqlite3_column_text(sqlite3_stmt*, int iCol);
+  const void *sqlite3_column_text16(sqlite3_stmt*, int iCol);
+  sqlite3_value *sqlite3_column_value(sqlite3_stmt*, int iCol);
+  int sqlite3_column_bytes(sqlite3_stmt*, int iCol);
+  int sqlite3_column_bytes16(sqlite3_stmt*, int iCol);
+  int sqlite3_column_type(sqlite3_stmt*, int iCol);
+
+  int sqlite3_finalize(sqlite3_stmt *pStmt);
+  int sqlite3_reset(sqlite3_stmt *pStmt);
+
+  const void *sqlite3_value_blob(sqlite3_value*);
+  double sqlite3_value_double(sqlite3_value*);
+  int sqlite3_value_int(sqlite3_value*);
+  sqlite3_int64 sqlite3_value_int64(sqlite3_value*);
+  void *sqlite3_value_pointer(sqlite3_value*, const char*);
+  const unsigned char *sqlite3_value_text(sqlite3_value*);
+  const void *sqlite3_value_text16(sqlite3_value*);
+  const void *sqlite3_value_text16le(sqlite3_value*);
+  const void *sqlite3_value_text16be(sqlite3_value*);
+  int sqlite3_value_bytes(sqlite3_value*);
+  int sqlite3_value_bytes16(sqlite3_value*);
+  int sqlite3_value_type(sqlite3_value*);
+  int sqlite3_value_numeric_type(sqlite3_value*);
+  int sqlite3_value_nochange(sqlite3_value*);
+  int sqlite3_value_frombind(sqlite3_value*);
+
+  unsigned int sqlite3_value_subtype(sqlite3_value*);
+
+  sqlite3_value *sqlite3_value_dup(const sqlite3_value*);
+  void sqlite3_value_free(sqlite3_value*);
+
+  void *sqlite3_aggregate_context(sqlite3_context*, int nBytes);
+
+  void *sqlite3_user_data(sqlite3_context*);
+
+  sqlite3 *sqlite3_context_db_handle(sqlite3_context*);
+
+  void *sqlite3_get_auxdata(sqlite3_context*, int N);
+  void sqlite3_set_auxdata(sqlite3_context*, int N, void*, void (*)(void*));
+
+  void sqlite3_result_blob(sqlite3_context*, const void*, int, void(*)(void*));
+  void sqlite3_result_blob64(sqlite3_context*,const void*,
+                  sqlite3_uint64,void(*)(void*));
+  void sqlite3_result_double(sqlite3_context*, double);
+  void sqlite3_result_error(sqlite3_context*, const char*, int);
+  void sqlite3_result_error16(sqlite3_context*, const void*, int);
+  void sqlite3_result_error_toobig(sqlite3_context*);
+  void sqlite3_result_error_nomem(sqlite3_context*);
+  void sqlite3_result_error_code(sqlite3_context*, int);
+  void sqlite3_result_int(sqlite3_context*, int);
+  void sqlite3_result_int64(sqlite3_context*, sqlite3_int64);
+  void sqlite3_result_null(sqlite3_context*);
+  void sqlite3_result_text(sqlite3_context*, const char*, int, void(*)(void*));
+  void sqlite3_result_text64(sqlite3_context*, const char*,sqlite3_uint64,
+                  void(*)(void*), unsigned char encoding);
+  void sqlite3_result_text16(sqlite3_context*, const void*, int, void(*)(void*));
+  void sqlite3_result_text16le(sqlite3_context*, const void*, int,void(*)(void*));
+  void sqlite3_result_text16be(sqlite3_context*, const void*, int,void(*)(void*));
+  void sqlite3_result_value(sqlite3_context*, sqlite3_value*);
+  void sqlite3_result_pointer(sqlite3_context*, void*,const char*,void(*)(void*));
+  void sqlite3_result_zeroblob(sqlite3_context*, int n);
+  int sqlite3_result_zeroblob64(sqlite3_context*, sqlite3_uint64 n);
+
+  void sqlite3_result_subtype(sqlite3_context*,unsigned int);
+
+  int sqlite3_sleep(int);
+
+  int sqlite3_get_autocommit(sqlite3*);
+  sqlite3 *sqlite3_db_handle(sqlite3_stmt*);
+  const char *sqlite3_db_filename(sqlite3 *db, const char *zDbName);
+  int sqlite3_db_readonly(sqlite3 *db, const char *zDbName);
+  int sqlite3_txn_state(sqlite3*,const char *zSchema);
+
+  sqlite3_stmt *sqlite3_next_stmt(sqlite3 *pDb, sqlite3_stmt *pStmt);
+
+  void *sqlite3_commit_hook(sqlite3*, int(*)(void*), void*);
+  void *sqlite3_rollback_hook(sqlite3*, void(*)(void *), void*);
+
+  void *sqlite3_update_hook(sqlite3*, void(*)(void *,int ,char const *,char const *,sqlite3_int64), void*);
+
+  int sqlite3_enable_shared_cache(int);
+  int sqlite3_release_memory(int);
+  int sqlite3_db_release_memory(sqlite3*);
+
+  sqlite3_int64 sqlite3_soft_heap_limit64(sqlite3_int64 N);
+  sqlite3_int64 sqlite3_hard_heap_limit64(sqlite3_int64 N);
+
+  int sqlite3_table_column_metadata(sqlite3 *db, const char *zDbName, const char *zTableName, const char *zColumnName,
+                  char const **pzDataType, char const **pzCollSeq, int *pNotNull, int *pPrimaryKey, int *pAutoinc);
+
+  int sqlite3_load_extension(sqlite3 *db, const char *zFile, const char *zProc, char **pzErrMsg);
+
+  int sqlite3_enable_load_extension(sqlite3 *db, int onoff);
+  int sqlite3_auto_extension(void(*xEntryPoint)(void));
+  int sqlite3_cancel_auto_extension(void(*xEntryPoint)(void));
+  void sqlite3_reset_auto_extension(void);
+
+  int sqlite3_declare_vtab(sqlite3*, const char *zSQL);
+  int sqlite3_overload_function(sqlite3*, const char *zFuncName, int nArg);
+
+  int sqlite3_blob_open(sqlite3*, const char *zDb, const char *zTable, const char *zColumn, sqlite3_int64 iRow,
+                  int flags, sqlite3_blob **ppBlob);
+  int sqlite3_blob_reopen(sqlite3_blob *, sqlite3_int64);
+  int sqlite3_blob_close(sqlite3_blob *);
+  int sqlite3_blob_bytes(sqlite3_blob *);
+  int sqlite3_blob_read(sqlite3_blob *, void *Z, int N, int iOffset);
+  int sqlite3_blob_write(sqlite3_blob *, const void *z, int n, int iOffset);
+
+  int sqlite3_file_control(sqlite3*, const char *zDbName, int op, void*);
+  int sqlite3_test_control(int op, ...);
+
+  int sqlite3_keyword_count(void);
+  int sqlite3_keyword_name(int,const char**,int*);
+  int sqlite3_keyword_check(const char*,int);
+
+  sqlite3_str *sqlite3_str_new(sqlite3*);
+  char *sqlite3_str_finish(sqlite3_str*);
+
+  void sqlite3_str_appendf(sqlite3_str*, const char *zFormat, ...);
+  void sqlite3_str_vappendf(sqlite3_str*, const char *zFormat, va_list);
+  void sqlite3_str_append(sqlite3_str*, const char *zIn, int N);
+  void sqlite3_str_appendall(sqlite3_str*, const char *zIn);
+  void sqlite3_str_appendchar(sqlite3_str*, int N, char C);
+  void sqlite3_str_reset(sqlite3_str*);
+
+  int sqlite3_str_errcode(sqlite3_str*);
+  int sqlite3_str_length(sqlite3_str*);
+  char *sqlite3_str_value(sqlite3_str*);
+
+  int sqlite3_status(int op, int *pCurrent, int *pHighwater, int resetFlag);
+  int sqlite3_status64(int op, sqlite3_int64 *pCurrent, sqlite3_int64 *pHighwater, int resetFlag);
+
+  int sqlite3_db_status(sqlite3*, int op, int *pCur, int *pHiwtr, int resetFlg);
+  int sqlite3_stmt_status(sqlite3_stmt*, int op,int resetFlg);
+
+  sqlite3_backup *sqlite3_backup_init(sqlite3 *pDest, const char *zDestName, sqlite3 *pSource, const char *zSourceName);
+  int sqlite3_backup_step(sqlite3_backup *p, int nPage);
+  int sqlite3_backup_finish(sqlite3_backup *p);
+  int sqlite3_backup_remaining(sqlite3_backup *p);
+  int sqlite3_backup_pagecount(sqlite3_backup *p);
+
+  int sqlite3_unlock_notify(sqlite3 *pBlocked, void (*xNotify)(void **apArg, int nArg), void *pNotifyArg);
+
+  int sqlite3_stricmp(const char *, const char *);
+  int sqlite3_strnicmp(const char *, const char *, int);
+
+  int sqlite3_strglob(const char *zGlob, const char *zStr);
+
+  int sqlite3_strlike(const char *zGlob, const char *zStr, unsigned int cEsc);
+
+  void sqlite3_log(int iErrCode, const char *zFormat, ...);
+
+  void *sqlite3_wal_hook(sqlite3*, int(*)(void *,sqlite3*,const char*,int), void*);
+
+  int sqlite3_wal_autocheckpoint(sqlite3 *db, int N);
+  int sqlite3_wal_checkpoint(sqlite3 *db, const char *zDb);
+
+  int sqlite3_wal_checkpoint_v2(sqlite3 *db, const char *zDb, int eMode, int *pnLog, int *pnCkpt);
+
+  int sqlite3_vtab_config(sqlite3*, int op, ...);
+
+  int sqlite3_vtab_on_conflict(sqlite3 *);
+  int sqlite3_vtab_nochange(sqlite3_context*);
+
+  int sqlite3_stmt_scanstatus(sqlite3_stmt *pStmt, int idx, int iScanStatusOp, void *pOut);
+
+  void sqlite3_stmt_scanstatus_reset(sqlite3_stmt*);
+  int sqlite3_db_cacheflush(sqlite3*);
+  int sqlite3_system_errno(sqlite3*);
+
+  unsigned char *sqlite3_serialize(sqlite3 *db, const char *zSchema, sqlite3_int64 *piSize, unsigned int mFlags);
+  int sqlite3_deserialize(sqlite3 *db, const char *zSchema, unsigned char *pData, sqlite3_int64 szDb,
+                  sqlite3_int64 szBuf, unsigned mFlags);
+]]
+
+---@class sqlite3 @sqlite3 db object
+---@class sqlite_blob @sqlite3 blob object
+
+M.to_str = function(ptr, len)
+  if ptr == nil then
+    return
+  end
+  return ffi.string(ptr, len)
+end
+
+M.type_of = function(ptr)
+  if ptr == nil then
+    return
+  end
+  return ffi.typeof(ptr)
+end
+
+M.get_new_db_ptr = function()
+  return ffi.new "sqlite3*[1]"
+end
+
+M.get_new_stmt_ptr = function()
+  return ffi.new "sqlite3_stmt*[1]"
+end
+
+M.get_new_blob_ptr = function()
+  return ffi.new "sqlite3_blob*[1]"
+end
+
+M.type_of_db_ptr = ffi.typeof "sqlite3*"
+M.type_of_stmt_ptr = ffi.typeof "sqlite3_stmt*"
+M.type_of_exec_ptr = ffi.typeof "int (*)(void*,int,char**,char**)"
+M.type_of_blob_ptr = ffi.typeof "sqlite3_blob*"
+
+--- Wrapper around clib.exec for convenience.
+---@param conn_ptr sqlite connction ptr
+---@param statement string: statement to be executed.
+---@return table: stmt object
+M.exec_stmt = function(conn_ptr, statement)
+  return clib.sqlite3_exec(conn_ptr, statement, nil, nil, nil)
+end
+
+--- Execute a manipulation sql statement within begin and commit block
+---@param conn_ptr sqlite connction ptr
+---@param fn func()
+M.wrap_stmts = function(conn_ptr, fn)
+  M.exec_stmt(conn_ptr, "BEGIN")
+  local res = fn()
+  M.exec_stmt(conn_ptr, "COMMIT")
+  return res
+end
+
+---Get last error msg
+---@param conn_ptr sqlite connction ptr
+---@return string: sqlite error msg
+M.last_errmsg = function(conn_ptr)
+  return M.to_str(clib.sqlite3_errmsg(conn_ptr))
+end
+
+---Get last error code
+---@param conn_ptr sqlite connction ptr
+---@return number: sqlite error number
+M.last_errcode = function(conn_ptr)
+  return clib.sqlite3_errcode(conn_ptr)
+end
+
+-- Open Modes
+M.open_modes = {
+  ["ro"] = bit.bor(M.flags.open_readonly, M.flags.open_uri),
+  ["rw"] = bit.bor(M.flags.open_readwrite, M.flags.open_uri),
+  ["rwc"] = bit.bor(M.flags.open_readwrite, M.flags.open_create, M.flags.open_uri),
+}
+
+---Create new connection and modify `sqlite_db` object
+---@param uri string
+---@param opts sqlite_db.opts
+---@return sqlite_blob*
+M.connect = function(uri, opts)
+  opts = opts or {}
+  local conn = M.get_new_db_ptr()
+  local open_mode = opts.open_mode
+  opts.open_mode = nil
+  if type(open_mode) == "table" then
+    open_mode = bit.bor(unpack(open_mode))
+  else
+    open_mode = M.open_modes[open_mode or "rwc"]
+  end
+
+  local code = clib.sqlite3_open_v2(uri, conn, open_mode, nil)
+
+  if code ~= M.flags.ok then
+    error(("sqlite.lua: couldn't connect to sql database, ERR: %s"):format(M.last_errmsg(conn[0])))
+  end
+
+  for k, v in pairs(opts) do
+    if not M.valid_pargma[k] then
+      error("sqlite.lua: " .. k .. " is not a valid pragma")
+    end
+    if type(k) == "boolean" then
+      k = "ON"
+    end
+    M.exec_stmt(conn[0], ("pragma %s = %s"):format(k, v))
+  end
+
+  return conn[0]
+end
+
+M = setmetatable(M, {
+  __index = function(_, k)
+    return clib["sqlite3_" .. k]
+  end,
+})
+
+return M

--- a/cli/lua/vendor/sqlite/helpers.lua
+++ b/cli/lua/vendor/sqlite/helpers.lua
@@ -1,0 +1,117 @@
+local M = {}
+-- botster: `luv` is not available; the single touchpoint was a stat() for
+-- cache-invalidation mtime. We fall back to the `fs.stat` global primitive
+-- when present (it returns {exists, type, size}), or nil otherwise. See
+-- VENDOR_CHANGES.md for the rationale.
+local a = require "sqlite.assert"
+local u = require "sqlite.utils"
+local fmt = string.format
+local P = require "sqlite.parser"
+
+---Get a table schema, or execute a given function to get it
+---@param tbl_name string
+---@param db sqlite_db
+M.get_schema = function(tbl_name, db)
+  local schema = db.tbl_schemas[tbl_name]
+  if schema then
+    return schema
+  end
+  db.tbl_schemas[tbl_name] = db:schema(tbl_name)
+  return db.tbl_schemas[tbl_name]
+end
+
+---Check and alter table schema, limited to simple renames and alteration of key schema
+---@param o sqlite_tbl
+---@param valid_schema any
+M.check_for_auto_alter = function(o, valid_schema)
+  local with_foregin_key = false
+
+  if not valid_schema then
+    return
+  end
+
+  for _, def in pairs(o.tbl_schema) do
+    if type(def) == "table" and def.reference then
+      with_foregin_key = true
+      break
+    end
+  end
+
+  local get = fmt("select * from sqlite_master where name = '%s'", o.name)
+
+  local stmt = o.tbl_exists and o.db:eval(get) or nil
+  if type(stmt) ~= "table" then
+    return
+  end
+
+  local origin, parsed = stmt[1].sql, P.create(o.name, o.tbl_schema, true)
+  if origin == parsed then
+    return
+  end
+
+  local ok, cmd = pcall(P.table_alter_key_defs, o.name, o.tbl_schema, o.db:schema(o.name))
+  if not ok then
+    print(cmd)
+    return
+  end
+
+  o.db:execute(cmd)
+  o.db_schema = o.db:schema(o.name)
+
+  if with_foregin_key then
+    o.db:execute "PRAGMA foreign_keys = ON;"
+    o.db.opts.foreign_keys = true
+  end
+end
+
+---Run tbl functions
+---@param func function: wrapped function to run
+---@param o sqlite_tbl
+---@return any
+M.run = function(func, o)
+  a.should_have_db_object(o.db, o.name)
+  local exec = function()
+    local valid_schema = o.tbl_schema and next(o.tbl_schema) ~= nil
+
+    --- Run once pre-init
+    if o.tbl_exists == nil then
+      o.tbl_exists = o.db:exists(o.name)
+      -- botster: upstream used luv.fs_stat(...).mtime.sec. Our fs.stat primitive
+      -- returns {exists, type, size} and has no mtime field, so the cached
+      -- mtime stays nil — the cache invalidation tied to it becomes a no-op,
+      -- which is acceptable for the current plugin.db() use case (single
+      -- writer per db).
+      local stat = type(fs) == "table" and fs.stat and fs.stat(o.db.uri) or nil
+      o.mtime = (type(stat) == "table" and stat.mtime) or nil
+      rawset(
+        o,
+        "has_content",
+        o.tbl_exists and o.db:eval(fmt("select count(*) from %s", o.name))[1]["count(*)"] ~= 0 or 0
+      )
+      -- o.has_content =
+      M.check_for_auto_alter(o, valid_schema)
+    end
+
+    --- Run when tbl doesn't exists anymore
+    if o.tbl_exists == false and valid_schema then
+      o.tbl_schema.ensure = u.if_nil(o.tbl_schema.ensure, true)
+      o.db:create(o.name, o.tbl_schema)
+      o.db_schema = o.db:schema(o.name)
+    end
+
+    --- Run once when we don't have schema
+    if not o.db_schema then
+      o.db_schema = o.db:schema(o.name)
+    end
+
+    --- Run wrapped function
+    return func()
+  end
+
+  if o.db.closed then
+    return o.db:with_open(exec)
+  end
+  return exec()
+end
+
+return M

--- a/cli/lua/vendor/sqlite/init.lua
+++ b/cli/lua/vendor/sqlite/init.lua
@@ -1,0 +1,74 @@
+---@brief [[
+---SQLite/LuaJIT binding and highly opinionated wrapper for storing,
+---retrieving, caching, persisting, querying, and connecting to SQLite databases.
+---
+--- To find out more
+--- visit https://github.com/kkharji/sqlite.lua
+---<pre>
+---
+--- Help usage in neovim: ignore ||
+---   :h |sqlite.readme|         | open help readme
+---   :h |sqlite_schema_key|     | open a class or type
+---   :h |sqlite.tbl|            | show help for sqlite_tbl.
+---   :h |sqlite.db|             | show help for sqlite_db.
+---   :h sqlite.db:...           | show help for a sqlite_db method.
+---   :h sqlite.tbl:...          | show help for a sqlite_tbl method.
+---
+---</pre>
+--- sqlite.lua types:
+---@brief ]]
+---@tag sqlite.readme
+
+---@class sqlite_schema_key @Sqlite schema key fileds. {name} is the only required field.
+---@field cid number: column index.
+---@field name string: column key.
+---@field type string: column type.
+---@field required boolean: whether it's required.
+---@field primary boolean: whether it's a primary key.
+---@field default string: default value when null.
+---@field reference string: "table_name.column_key"
+---@field on_delete sqlite_trigger: trigger on row delete.
+---@field on_update sqlite_trigger: trigger on row updated.
+
+---@alias sqlite_schema_dict table<string, sqlite_schema_key>
+---@alias sqlite_query_delete table<string, string>
+
+---@class sqlite_opts @Sqlite3 Options (TODO: add sqlite option fields and description)
+
+---@class sqlite_query_update @Query fileds used when calling |sqlite:update| or |sqlite_tbl:update|
+---@field where table: filter down values using key values.
+---@field set table: key and value to updated.
+
+---@class sqlite_query_select @Query fileds used when calling |sqlite:select| or |sqlite_tbl:get|
+---@field where table: filter down values using key values.
+---@field keys table: keys to include. (default all)
+---@field join table: (TODO: support)
+---@field order_by table: { asc = "key", dsc = {"key", "another_key"} }
+---@field limit number: the number of result to limit by
+---@field contains table: for sqlite glob ex. { title = "fix*" }
+
+---@class sqlite_flags @Sqlite3 Error Flags (TODO: add sqlite error flags value and description)
+
+---@class sqlite_db_status @Status returned from |sqlite:status()|
+---@field msg string
+---@field code sqlite_flags
+
+---@alias sqlite_trigger
+---| '"no action"' : when a parent key is modified or deleted from the database, no special action is taken.
+---| '"restrict"' : prohibites from deleting/modifying a parent key when a child key is mapped to it.
+---| '"null"' : when a parent key is deleted/modified, the child key that mapped to the parent key gets set to null.
+---| '"default"' : similar to "null", except that sets to the column's default value instead of NULL.
+---| '"cascade"' : propagates the delete or update operation on the parent key to each dependent child key.
+
+---@type sqlite_db
+return setmetatable({}, {
+  __index = function(_, key)
+    return require("sqlite.db")[key]
+  end,
+  __newindex = function(_)
+    error "sqlite.lua: this shouldn't happen. Mutating sqlite base object is prohibited."
+  end,
+  __call = function(_, ...)
+    return require "sqlite.db"(...)
+  end,
+})

--- a/cli/lua/vendor/sqlite/json.lua
+++ b/cli/lua/vendor/sqlite/json.lua
@@ -1,0 +1,372 @@
+--
+-- json.lua
+--
+-- Copyright (c) 2020 rxi
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy of
+-- this software and associated documentation files (the "Software"), to deal in
+-- the Software without restriction, including without limitation the rights to
+-- use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+-- of the Software, and to permit persons to whom the Software is furnished to do
+-- so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+--
+
+local json = { _version = "0.1.2" }
+
+-------------------------------------------------------------------------------
+-- Encode
+-------------------------------------------------------------------------------
+
+local encode
+
+local escape_char_map = {
+  ["\\"] = "\\",
+  ['"'] = '"',
+  ["\b"] = "b",
+  ["\f"] = "f",
+  ["\n"] = "n",
+  ["\r"] = "r",
+  ["\t"] = "t",
+}
+
+local escape_char_map_inv = { ["/"] = "/" }
+for k, v in pairs(escape_char_map) do
+  escape_char_map_inv[v] = k
+end
+
+local function escape_char(c)
+  return "\\" .. (escape_char_map[c] or string.format("u%04x", c:byte()))
+end
+
+local function encode_nil(val)
+  return val == nil and "null"
+end
+
+local function encode_table(val, stack)
+  local res = {}
+  stack = stack or {}
+
+  -- Circular reference?
+  if stack[val] then
+    error "circular reference"
+  end
+
+  stack[val] = true
+
+  if rawget(val, 1) ~= nil or next(val) == nil then
+    -- Treat as array -- check keys are valid and it is not sparse
+    local n = 0
+    for k in pairs(val) do
+      if type(k) ~= "number" then
+        error "invalid table: mixed or invalid key types"
+      end
+      n = n + 1
+    end
+    if n ~= #val then
+      error "invalid table: sparse array"
+    end
+    -- Encode
+    for _, v in ipairs(val) do
+      table.insert(res, encode(v, stack))
+    end
+    stack[val] = nil
+    return "[" .. table.concat(res, ",") .. "]"
+  else
+    -- Treat as an object
+    for k, v in pairs(val) do
+      if type(k) ~= "string" then
+        error "invalid table: mixed or invalid key types"
+      end
+      table.insert(res, encode(k, stack) .. ":" .. encode(v, stack))
+    end
+    stack[val] = nil
+    return "{" .. table.concat(res, ",") .. "}"
+  end
+end
+
+local function encode_string(val)
+  return '"' .. val:gsub('[%z\1-\31\\"]', escape_char) .. '"'
+end
+
+local function encode_number(val)
+  -- Check for NaN, -inf and inf
+  if val ~= val or val <= -math.huge or val >= math.huge then
+    error("unexpected number value '" .. tostring(val) .. "'")
+  end
+  return string.format("%.14g", val)
+end
+
+local type_func_map = {
+  ["nil"] = encode_nil,
+  ["table"] = encode_table,
+  ["string"] = encode_string,
+  ["number"] = encode_number,
+  ["boolean"] = tostring,
+}
+
+encode = function(val, stack)
+  local t = type(val)
+  local f = type_func_map[t]
+  if f then
+    return f(val, stack)
+  end
+  error("unexpected type '" .. t .. "'")
+end
+
+function json.encode(val)
+  return (encode(val))
+end
+
+-------------------------------------------------------------------------------
+-- Decode
+-------------------------------------------------------------------------------
+
+local parse
+
+local function create_set(...)
+  local res = {}
+  for i = 1, select("#", ...) do
+    res[select(i, ...)] = true
+  end
+  return res
+end
+
+local space_chars = create_set(" ", "\t", "\r", "\n")
+local delim_chars = create_set(" ", "\t", "\r", "\n", "]", "}", ",")
+local escape_chars = create_set("\\", "/", '"', "b", "f", "n", "r", "t", "u")
+local literals = create_set("true", "false", "null")
+
+local literal_map = {
+  ["true"] = true,
+  ["false"] = false,
+  ["null"] = nil,
+}
+
+local function next_char(str, idx, set, negate)
+  for i = idx, #str do
+    if set[str:sub(i, i)] ~= negate then
+      return i
+    end
+  end
+  return #str + 1
+end
+
+local function decode_error(str, idx, msg)
+  local line_count = 1
+  local col_count = 1
+  for i = 1, idx - 1 do
+    col_count = col_count + 1
+    if str:sub(i, i) == "\n" then
+      line_count = line_count + 1
+      col_count = 1
+    end
+  end
+  error(string.format("%s at line %d col %d", msg, line_count, col_count))
+end
+
+local function codepoint_to_utf8(n)
+  -- http://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=iws-appendixa
+  local f = math.floor
+  if n <= 0x7f then
+    return string.char(n)
+  elseif n <= 0x7ff then
+    return string.char(f(n / 64) + 192, n % 64 + 128)
+  elseif n <= 0xffff then
+    return string.char(f(n / 4096) + 224, f(n % 4096 / 64) + 128, n % 64 + 128)
+  elseif n <= 0x10ffff then
+    return string.char(f(n / 262144) + 240, f(n % 262144 / 4096) + 128, f(n % 4096 / 64) + 128, n % 64 + 128)
+  end
+  error(string.format("invalid unicode codepoint '%x'", n))
+end
+
+local function parse_unicode_escape(s)
+  local n1 = tonumber(s:sub(1, 4), 16)
+  local n2 = tonumber(s:sub(7, 10), 16)
+  -- Surrogate pair?
+  if n2 then
+    return codepoint_to_utf8((n1 - 0xd800) * 0x400 + (n2 - 0xdc00) + 0x10000)
+  else
+    return codepoint_to_utf8(n1)
+  end
+end
+
+local function parse_string(str, i)
+  local res = ""
+  local j = i + 1
+  local k = j
+
+  while j <= #str do
+    local x = str:byte(j)
+
+    if x < 32 then
+      decode_error(str, j, "control character in string")
+    elseif x == 92 then -- `\`: Escape
+      res = res .. str:sub(k, j - 1)
+      j = j + 1
+      local c = str:sub(j, j)
+      if c == "u" then
+        local hex = str:match("^[dD][89aAbB]%x%x\\u%x%x%x%x", j + 1)
+          or str:match("^%x%x%x%x", j + 1)
+          or decode_error(str, j - 1, "invalid unicode escape in string")
+        res = res .. parse_unicode_escape(hex)
+        j = j + #hex
+      else
+        if not escape_chars[c] then
+          decode_error(str, j - 1, "invalid escape char '" .. c .. "' in string")
+        end
+        res = res .. escape_char_map_inv[c]
+      end
+      k = j + 1
+    elseif x == 34 then -- `"`: End of string
+      res = res .. str:sub(k, j - 1)
+      return res, j + 1
+    end
+
+    j = j + 1
+  end
+
+  decode_error(str, i, "expected closing quote for string")
+end
+
+local function parse_number(str, i)
+  local x = next_char(str, i, delim_chars)
+  local s = str:sub(i, x - 1)
+  local n = tonumber(s)
+  if not n then
+    decode_error(str, i, "invalid number '" .. s .. "'")
+  end
+  return n, x
+end
+
+local function parse_literal(str, i)
+  local x = next_char(str, i, delim_chars)
+  local word = str:sub(i, x - 1)
+  if not literals[word] then
+    decode_error(str, i, "invalid literal '" .. word .. "'")
+  end
+  return literal_map[word], x
+end
+
+local function parse_array(str, i)
+  local res = {}
+  local n = 1
+  i = i + 1
+  while 1 do
+    local x
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of array?
+    if str:sub(i, i) == "]" then
+      i = i + 1
+      break
+    end
+    -- Read token
+    x, i = parse(str, i)
+    res[n] = x
+    n = n + 1
+    -- Next token
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "]" then
+      break
+    end
+    if chr ~= "," then
+      decode_error(str, i, "expected ']' or ','")
+    end
+  end
+  return res, i
+end
+
+local function parse_object(str, i)
+  local res = {}
+  i = i + 1
+  while 1 do
+    local key, val
+    i = next_char(str, i, space_chars, true)
+    -- Empty / end of object?
+    if str:sub(i, i) == "}" then
+      i = i + 1
+      break
+    end
+    -- Read key
+    if str:sub(i, i) ~= '"' then
+      decode_error(str, i, "expected string for key")
+    end
+    key, i = parse(str, i)
+    -- Read ':' delimiter
+    i = next_char(str, i, space_chars, true)
+    if str:sub(i, i) ~= ":" then
+      decode_error(str, i, "expected ':' after key")
+    end
+    i = next_char(str, i + 1, space_chars, true)
+    -- Read value
+    val, i = parse(str, i)
+    -- Set
+    res[key] = val
+    -- Next token
+    i = next_char(str, i, space_chars, true)
+    local chr = str:sub(i, i)
+    i = i + 1
+    if chr == "}" then
+      break
+    end
+    if chr ~= "," then
+      decode_error(str, i, "expected '}' or ','")
+    end
+  end
+  return res, i
+end
+
+local char_func_map = {
+  ['"'] = parse_string,
+  ["0"] = parse_number,
+  ["1"] = parse_number,
+  ["2"] = parse_number,
+  ["3"] = parse_number,
+  ["4"] = parse_number,
+  ["5"] = parse_number,
+  ["6"] = parse_number,
+  ["7"] = parse_number,
+  ["8"] = parse_number,
+  ["9"] = parse_number,
+  ["-"] = parse_number,
+  ["t"] = parse_literal,
+  ["f"] = parse_literal,
+  ["n"] = parse_literal,
+  ["["] = parse_array,
+  ["{"] = parse_object,
+}
+
+parse = function(str, idx)
+  local chr = str:sub(idx, idx)
+  local f = char_func_map[chr]
+  if f then
+    return f(str, idx)
+  end
+  decode_error(str, idx, "unexpected character '" .. chr .. "'")
+end
+
+function json.decode(str)
+  if type(str) ~= "string" then
+    error("expected argument of type string, got " .. type(str))
+  end
+  local res, idx = parse(str, next_char(str, 1, space_chars, true))
+  idx = next_char(str, idx, space_chars, true)
+  if idx <= #str then
+    decode_error(str, idx, "trailing garbage")
+  end
+  return res
+end
+
+return json

--- a/cli/lua/vendor/sqlite/parser.lua
+++ b/cli/lua/vendor/sqlite/parser.lua
@@ -1,0 +1,573 @@
+local u = require "sqlite.utils"
+local json = require "sqlite.json"
+local tinsert = table.insert
+local tconcat = table.concat
+local a = require "sqlite.assert"
+local M = {}
+
+---@brief [[
+---Internal functions for parsing sql statement from lua table.
+---methods = { select, update, delete, insert, create, alter, drop }
+---accepts tbl name and options.
+---options = {join, keys, values, set, where, select}
+---hopfully returning valid sql statement :D
+---@brief ]]
+---@tag parser.lua
+
+---handle sqlite datatype interop
+M.sqlvalue = function(v)
+  return type(v) == "boolean" and (v == true and 1 or 0) or (v == nil and "null" or v)
+end
+
+M.luavalue = function(v, key_type)
+  if key_type == "luatable" or key_type == "json" then
+    return json.decode(v)
+  elseif key_type == "boolean" then
+    if v == 0 then
+      return false
+    else
+      return true
+    end
+    -- return v == 0 and false or true
+  end
+
+  return v
+end
+
+---string.format specifier based on value type
+---@param v any: the value
+---@param nonbind boolean?: whether to return the specifier or just return the value.
+---@return string
+local specifier = function(v, nonbind)
+  local type = type(v)
+  if type == "number" then
+    local _, b = math.modf(v)
+    return b == 0 and "%d" or "%f"
+  elseif type == "string" and not nonbind then
+    return v:find "'" and [["%s"]] or "'%s'"
+  elseif nonbind then
+    return v
+  else
+    return ""
+  end
+end
+
+local bind = function(o)
+  o = o or {}
+  o.s = o.s or ", "
+  if not o.kv then
+    o.v = o.v ~= nil and M.sqlvalue(o.v) or "?"
+    return ("%s = " .. specifier(o.v)):format(o.k, o.v)
+  else
+    local res = {}
+    for k, v in u.opairs(o.kv) do
+      k = o.k ~= nil and o.k or k
+      v = M.sqlvalue(v)
+      v = o.nonbind and ":" .. k or v
+      tinsert(res, ("%s" .. (o.nonbind and nil or " = ") .. specifier(v, o.nonbind)):format(k, v))
+    end
+    return tconcat(res, o.s)
+  end
+end
+
+---format glob pattern as part of where clause
+local pcontains = function(defs)
+  if not defs then
+    return {}
+  end
+  local items = {}
+  for k, v in u.opairs(defs) do
+    local head = "%s glob " .. specifier(k)
+
+    if type(v) == "table" then
+      local val = u.map(v, function(value)
+        return head:format(k, M.sqlvalue(value))
+      end)
+      tinsert(items, tconcat(val, " or "))
+    else
+      tinsert(items, head:format(k, v))
+    end
+  end
+
+  return tconcat(items, " ")
+end
+
+---Format values part of sql statement
+---@params defs table: key/value pairs defining sqlite table keys.
+---@params defs kv: whether to bind by named keys.
+local pkeys = function(defs, kv)
+  kv = kv == nil and true or kv
+
+  if not defs or not kv then
+    return {}
+  end
+
+  defs = u.is_nested(defs) and defs[1] or defs
+
+  local keys = {}
+  for k, _ in u.opairs(defs) do
+    tinsert(keys, k)
+  end
+
+  return ("(%s)"):format(tconcat(keys, ", "))
+end
+
+---Format values part of sql statement, usually used with select method.
+---@params defs table: key/value pairs defining sqlite table keys.
+---@params defs kv: whether to bind by named keys.
+local pvalues = function(defs, kv)
+  kv = kv == nil and true or kv -- TODO: check if defs is key value pairs instead
+  if not defs or not kv then
+    return {}
+  end
+
+  defs = u.is_nested(defs) and defs[1] or defs
+
+  local keys = {}
+  for k, v in u.opairs(defs) do
+    if type(v) == "string" and v:match "^[%S]+%(.*%)$" then
+      tinsert(keys, v)
+    else
+      tinsert(keys, ":" .. k)
+    end
+  end
+
+  return ("values(%s)"):format(tconcat(keys, ", "))
+end
+
+---Format where part of a sql statement.
+---@params defs table: key/value pairs defining sqlite table keys.
+---@params name string: the name of the sqlite table
+---@params join table: used as boolean, controling whether to use name.key or just key.
+local pwhere = function(defs, name, join, contains)
+  if not defs and not contains then
+    return {}
+  end
+
+  local where = {}
+  if defs then
+    for k, v in u.opairs(defs) do
+      k = join and name .. "." .. k or k
+
+      if type(v) ~= "table" then
+        if type(v) == "string" and (v:sub(1, 1) == "<" or v:sub(1, 1) == ">") then
+          tinsert(where, k .. " " .. v)
+        else
+          tinsert(where, bind { v = v, k = k, s = " and " })
+        end
+      else
+        if type(k) == "number" then
+          tinsert(where, table.concat(v, " "))
+        else
+          tinsert(where, "(" .. bind { kv = v, k = k, s = " or " } .. ")")
+        end
+      end
+    end
+  end
+
+  if contains then
+    tinsert(where, pcontains(contains))
+  end
+  return ("where %s"):format(tconcat(where, " and "))
+end
+
+local plimit = function(defs)
+  if not defs then
+    return {}
+  end
+
+  local type = type(defs)
+  local istbl = (type == "table" and defs[2])
+  local offset = "limit %s offset %s"
+  local limit = "limit %s"
+
+  return istbl and offset:format(defs[1], defs[2]) or limit:format(type == "number" and defs or defs[1])
+end
+
+---Format set part of sql statement, usually used with update method.
+---@params defs table: key/value pairs defining sqlite table keys.
+local pset = function(defs)
+  if not defs then
+    return {}
+  end
+
+  return "set " .. bind { kv = defs, nonbind = true }
+end
+
+---Format join part of a sql statement.
+---@params defs table: key/value pairs defining sqlite table keys.
+---@params name string: the name of the sqlite table
+local pjoin = function(defs, name)
+  if not defs or not name then
+    return {}
+  end
+  local target
+
+  local on = (function()
+    for k, v in pairs(defs) do
+      if k ~= name then
+        target = k
+        return ("%s.%s ="):format(k, v)
+      end
+    end
+  end)()
+
+  local select = (function()
+    for k, v in pairs(defs) do
+      if k == name then
+        return ("%s.%s"):format(k, v)
+      end
+    end
+  end)()
+
+  return ("inner join %s on %s %s"):format(target, on, select)
+end
+
+local porder_by = function(defs)
+  -- TODO: what if nulls? should append "nulls last"
+  if not defs then
+    return {}
+  end
+
+  local fmt = "%s %s"
+  local items = {}
+
+  for v, k in u.opairs(defs) do
+    if type(k) == "table" then
+      for _, _k in u.opairs(k) do
+        tinsert(items, fmt:format(_k, v))
+      end
+    else
+      tinsert(items, fmt:format(k, v))
+    end
+  end
+
+  return ("order by %s"):format(tconcat(items, ", "))
+end
+
+local partial = function(method, tbl, opts)
+  opts = opts or {}
+  return tconcat(
+    u.flatten {
+      method,
+      pkeys(opts.values),
+      pvalues(opts.values, opts.named),
+      pset(opts.set),
+      pwhere(opts.where, tbl, opts.join, opts.contains),
+      porder_by(opts.order_by),
+      plimit(opts.limit),
+    },
+    " "
+  )
+end
+
+local pselect = function(select)
+  local t = type(select)
+
+  if t == "table" and next(select) ~= nil then
+    local items = {}
+    for k, v in pairs(select) do
+      if type(k) == "number" then
+        tinsert(items, v)
+      else
+        tinsert(items, ("%s as %s"):format(v, k))
+      end
+    end
+
+    return tconcat(items, ", ")
+  end
+
+  return t == "string" and select or "*"
+end
+
+---Parse select statement to extracts data from a database
+---@param tbl string: table name
+---@param opts table: lists of options: valid{ select, join, order_by, limit, where }
+---@return string: the select sql statement.
+M.select = function(tbl, opts)
+  opts = opts or {}
+  local cmd = opts.unique and "select distinct %s" or "select %s"
+  local select = pselect(opts.select)
+  local stmt = (cmd .. " from %s"):format(select, tbl)
+  local method = opts.join and stmt .. " " .. pjoin(opts.join, tbl) or stmt
+  return partial(method, tbl, opts)
+end
+
+---Parse select statement to update data in the database
+---@param tbl string: table name
+---@param opts table: lists of options: valid{ set, where }
+---@return string: the update sql statement.
+M.update = function(tbl, opts)
+  local method = ("update %s"):format(tbl)
+  return partial(method, tbl, opts)
+end
+
+---Parse insert statement to insert data into a database
+---@param tbl string: table name
+---@param opts table: lists of options: valid{ where }
+---@return string: the insert sql statement.
+M.insert = function(tbl, opts)
+  local method = ("insert into %s"):format(tbl)
+  return partial(method, tbl, opts)
+end
+
+---Parse delete statement to deletes data from a database
+---@param tbl string: table name
+---@param opts table: lists of options: valid{ where }
+---@return string: the delete sql statement.
+M.delete = function(tbl, opts)
+  opts = opts or {}
+  local method = ("delete from %s"):format(tbl)
+  local where = pwhere(opts.where)
+  return type(where) == "string" and method .. " " .. where or method
+end
+
+local format_action = function(value, update)
+  local stmt = update and "on update" or "on delete"
+  local preappend = (value:match "default" or value:match "null") and " set " or " "
+
+  return stmt .. preappend .. value
+end
+
+local opts_to_str = function(tbl)
+  local f = {
+    pk = function()
+      return "primary key"
+    end,
+    type = function(v)
+      return v
+    end,
+    unique = function()
+      return "unique"
+    end,
+    required = function(v)
+      if v then
+        return "not null"
+      end
+    end,
+    default = function(v)
+      v = (type(v) == "string" and v:match "^[%S]+%(.*%)$") and "(" .. tostring(v) .. ")" or v
+      local str = "default "
+      if tbl["required"] then
+        return "on conflict replace " .. str .. v
+      else
+        return str .. v
+      end
+    end,
+    reference = function(v)
+      return ("references %s"):format(v:gsub("%.", "(") .. ")")
+    end,
+    on_update = function(v)
+      return format_action(v, true)
+    end,
+    on_delete = function(v)
+      return format_action(v)
+    end,
+  }
+
+  f.primary = f.pk
+
+  local res = {}
+
+  if type(tbl[1]) == "string" then
+    res[1] = tbl[1]
+  end
+
+  local check = function(type)
+    local v = tbl[type]
+    if v then
+      res[#res + 1] = f[type](v)
+    end
+  end
+
+  check "type"
+  check "unique"
+  check "required"
+  check "pk"
+  check "primary"
+  check "default"
+  check "reference"
+  check "on_update"
+  check "on_delete"
+
+  return tconcat(res, " ")
+end
+
+---Parse table create statement
+---@param tbl string: table name
+---@param defs table: keys and type pairs
+---@return string: the create sql statement.
+M.create = function(tbl, defs, ignore_ensure)
+  if not defs then
+    return
+  end
+  local items = {}
+
+  tbl = (defs.ensure and not ignore_ensure) and "if not exists " .. tbl or tbl
+
+  for k, v in u.opairs(defs) do
+    if k ~= "ensure" then
+      local t = type(v)
+      if t == "boolean" then
+        tinsert(items, k .. " integer not null primary key")
+      elseif t ~= "table" then
+        tinsert(items, string.format("%s %s", k, v))
+      else
+        if u.is_list(v) then
+          tinsert(items, ("%s %s"):format(k, tconcat(v, " ")))
+        else
+          tinsert(items, ("%s %s"):format(k, opts_to_str(v)))
+        end
+      end
+    end
+  end
+  return ("CREATE TABLE %s(%s)"):format(tbl, tconcat(items, ", "))
+end
+
+---Parse table drop statement
+---@param tbl string: table name
+---@return string: the drop sql statement.
+M.drop = function(tbl)
+  return "drop table " .. tbl
+end
+
+-- local same_type = function(new, old)
+--   if not new or not old then
+--     return false
+--   end
+
+--   local tnew, told = type(new), type(old)
+
+--   if tnew == told then
+--     if tnew == "string" then
+--       return new == old
+--     elseif tnew == "table" then
+--       if new[1] and old[1] then
+--         return (new[1] == old[1])
+--       elseif new.type and old.type then
+--         return (new.type == old.type)
+--       elseif new.type and old[1] then
+--         return (new.type == old[1])
+--       elseif new[1] and old.type then
+--         return (new[1] == old.type)
+--       end
+--     end
+--   else
+--     if tnew == "table" and told == "string" then
+--       if new.type == old then
+--         return true
+--       elseif new[1] == old then
+--         return true
+--       end
+--     elseif tnew == "string" and told == "table" then
+--       return old.type == new or old[1] == new
+--     end
+--   end
+--   -- return false
+-- end
+
+---Alter a given table, only support changing key definition
+---@param tname string
+---@param new sqlite_schema_dict
+---@param old sqlite_schema_dict
+M.table_alter_key_defs = function(tname, new, old, dry)
+  local tmpname = tname .. "_new"
+  local create = M.create(tmpname, new, true)
+  local drop = M.drop(tname)
+  local move = "INSERT INTO %s(%s) SELECT %s FROM %s"
+  local rename = ("ALTER TABLE %s RENAME TO %s"):format(tmpname, tname)
+  local with_foregin_key = false
+
+  for _, def in pairs(new) do
+    if type(def) == "table" and def.reference then
+      with_foregin_key = true
+    end
+  end
+
+  local stmt = "PRAGMA foreign_keys=off; BEGIN TRANSACTION; %s; COMMIT;"
+  if not with_foregin_key then
+    stmt = stmt .. " PRAGMA foreign_keys=on"
+  end
+
+  local keys = { new = u.okeys(new), old = u.okeys(old) }
+  local idx = { new = {}, old = {} }
+  local len = { new = #keys.new, old = #keys.old }
+  -- local facts = { extra_key = len.new > len.old, drop_key = len.old > len.new }
+
+  a.auto_alter_should_have_equal_len(len.new, len.old, tname)
+
+  for _, varient in ipairs { "new", "old" } do
+    for k, v in pairs(keys[varient]) do
+      idx[varient][v] = k
+    end
+  end
+
+  for i, v in ipairs(keys.new) do
+    if idx.old[v] and idx.old[v] ~= i then
+      local tmp = keys.old[i]
+      keys.old[i] = v
+      keys.old[idx.old[v]] = tmp
+    end
+  end
+
+  local update_null_vals = {}
+  local update_null_stmt = "UPDATE %s SET %s=%s where %s IS NULL"
+  for key, def in pairs(new) do
+    if type(def) == "table" and def.default and not def.required then
+      tinsert(update_null_vals, update_null_stmt:format(tmpname, key, def.default, key))
+    end
+  end
+  update_null_vals = #update_null_vals == 0 and "" or tconcat(update_null_vals, "; ")
+
+  local new_keys, old_keys = tconcat(keys.new, ", "), tconcat(keys.old, ", ")
+  local insert = move:format(tmpname, new_keys, old_keys, tname)
+  stmt = stmt:format(tconcat({ create, insert, update_null_vals, drop, rename }, "; "))
+
+  return not dry and stmt or insert
+end
+
+---Pre-process data insert to sql db.
+---for now it's mainly used to for parsing lua tables and boolean values.
+---It throws when a schema key is required and doesn't exists.
+---@param rows tinserted row.
+---@param schema table tbl schema with extra info
+---@return table pre processed rows
+M.pre_insert = function(rows, schema)
+  local res = {}
+  rows = u.is_nested(rows) and rows or { rows }
+  for i, row in ipairs(rows) do
+    res[i] = u.map(row, function(v, k)
+      local column_def = schema[k]
+      a.should_have_column_def(column_def, k, schema)
+      a.missing_req_key(v, column_def)
+      local is_json = column_def.type == "luatable" or column_def.type == "json"
+      return is_json and json.encode(v) or M.sqlvalue(v)
+    end)
+  end
+  return res
+end
+
+---Postprocess data queried from a sql db. for now it is mainly used
+---to for parsing json values to lua table.
+---@param rows tinserted row.
+---@param schema table tbl schema
+---@return table pre processed rows
+---@TODO support boolean values.
+M.post_select = function(rows, schema)
+  local is_nested = u.is_nested(rows)
+  rows = is_nested and rows or { rows }
+  for _, row in ipairs(rows) do
+    for k, v in pairs(row) do
+      local info = schema[k]
+      if info then
+        row[k] = M.luavalue(v, info.type)
+      else
+        row[k] = v
+      end
+    end
+  end
+
+  return is_nested and rows or rows[1]
+end
+
+return M

--- a/cli/lua/vendor/sqlite/stmt.lua
+++ b/cli/lua/vendor/sqlite/stmt.lua
@@ -1,0 +1,413 @@
+---@brief [[
+--- sqlstmt is a collection of methods to deal with sqlite statements.
+---@brief ]]
+---@tag sqlstmt
+local clib = require "sqlite.defs"
+local flags = clib.flags
+
+---@class sqlstmt @Object to deal with sqlite statements
+---@field pstmt sqlite_blob sqlite_pstmt
+---@field conn sqlite_blob sqlite3 object
+---@field str string original statement
+local sqlstmt = {}
+sqlstmt.__index = sqlstmt
+
+--- TODO: refactor and make parser.lua required here only.
+
+---Parse a statement
+---@param conn sqlite3: the database connection.
+---@param str string: the sqlite statement to be parsed.
+---@return sqlstmt: collection of methods, applicable to the parsed statement.
+---@see sqlstmt:__parse
+---@usage local sqlstmt = sqlstmt:parse(db, "insert into todos (title,desc) values(:title, :desc)")
+function sqlstmt:parse(conn, str)
+  assert(clib.type_of(conn) == clib.type_of_db_ptr, "Invalid connection passed to sqlstmt:parse")
+  assert(type(str) == "string", "Invalid second argument passed to sqlstmt:parse")
+  local o = setmetatable({
+    str = str,
+    conn = conn,
+    finalized = false,
+  }, sqlstmt)
+
+  local pstmt = clib.get_new_stmt_ptr()
+  local code = clib.prepare_v2(o.conn, o.str, #o.str, pstmt, nil)
+
+  assert(
+    code == flags.ok,
+    ("sqlite.lua: sql statement parse, , stmt: `%s`, err: `(`%s`)`"):format(o.str, clib.last_errmsg(o.conn))
+  )
+  o.pstmt = pstmt[0]
+  return o
+end
+
+---Resets the parsed statement. required for parsed statements to be re-executed.
+---NOTE: Any statement variables that had values bound to them using the
+---sqlstmt:bind functions retain their values.
+---@return number: falgs.ok or errcode
+---@TODO should we error out when errcode?
+function sqlstmt:reset()
+  return clib.reset(self.pstmt)
+end
+
+---Frees the prepared statement
+---@return boolean: if no error true.
+function sqlstmt:finalize()
+  self.errcode = clib.finalize(self.pstmt)
+  self.finalized = self.errcode == flags.ok
+  assert(
+    self.finalized,
+    string.format(
+      "sqlite.lua: couldn't finalize statement, ERRMSG: %s stmt = (%s)",
+      clib.to_str(clib.errmsg(self.conn)),
+      self.str
+    )
+  )
+  return self.finalized
+end
+
+---Called before evaluating the (next iteration) of the prepared statement.
+---@return sqlite_flags: Possible Flags: { flags.busy, flags.done, flags.row, flags.error, flags.misuse }
+function sqlstmt:step()
+  local step_code = clib.step(self.pstmt)
+  assert(
+    step_code ~= flags.error or step_code ~= flags.misuse,
+    string.format("sqlite.lua: error in step(), ERRMSG: %s. Please report issue.", clib.to_str(clib.errmsg(self.conn)))
+  )
+  return step_code
+end
+
+---Number of keys/columns in results
+---@return number: column count in the results.
+function sqlstmt:nkeys()
+  return clib.column_count(self.pstmt)
+end
+
+---Number of rows/items in results.
+---@return number: rows count in the results.
+function sqlstmt:nrows()
+  local count = 0
+  self:each(function()
+    count = count + 1
+  end)
+  return count
+end
+
+---key-name/column-name at {idx} in results.
+---@param idx number: (0-index)
+---@return string: keyname/column name at {idx}
+---@TODO should accept 1-index
+function sqlstmt:key(idx)
+  return clib.to_str(clib.column_name(self.pstmt, idx))
+end
+
+---key-names/column-names in results.
+---@return table: key-names/column-names.
+---@see sqlstmt:nkeys
+---@see sqlstmt:key
+function sqlstmt:keys()
+  local keys = {}
+  for i = 0, self:nkeys() - 1 do
+    table.insert(keys, i + 1, self:key(i))
+  end
+  return keys
+end
+
+local sqlite_datatypes = {
+  [1] = "int", -- bind_double
+  [2] = "double", -- bind_text
+  [3] = "text", -- bind_null
+  [4] = "blob", -- bind_null
+  [5] = "null", -- bind_null
+}
+
+---Key/Column lua datatype at {idx}
+---@param idx number: (0-index)
+---@return string: key/column type at {idx}
+---@TODO should accept 1-index
+function sqlstmt:convert_type(idx)
+  local convert_dt = {
+    ["INTEGER"] = "number",
+    ["FLOAT"] = "number",
+    ["DOUBLE"] = "number",
+    ["TEXT"] = "string",
+    ["BLOB"] = "binary",
+    ["NULL"] = nil,
+  }
+  return convert_dt[clib.to_str(clib.column_decltype(self.pstmt, idx))]
+end
+
+---Keys/Columns types visible in current result.
+---@return table: list of types, ordered by key location.
+---@see sqlstmt:type
+---@see sqlstmt:nkeys
+function sqlstmt:types()
+  local types = {}
+  for i = 0, self:nkeys() - 1 do
+    table.insert(types, i + 1, self:convert_type(i))
+  end
+  return types
+end
+
+---Value at {idx}
+---@param idx number: (0-index)
+---@return string: value at {idx}
+---@TODO should accept 1-index
+function sqlstmt:val(idx)
+  local ktype = clib.column_type(self.pstmt, idx)
+  if ktype == 5 then
+    return
+  end
+  local val = clib["column_" .. sqlite_datatypes[ktype]](self.pstmt, idx)
+  return ktype == 3 and clib.to_str(val) or val
+end
+
+---Ordered list of current result values.
+---@return table: list of values, ordered by key location.
+---@see sqlstmt:val
+---@see sqlstmt:nkeys
+function sqlstmt:vals()
+  local vals = {}
+  for i = 0, self:nkeys() - 1 do
+    table.insert(vals, i + 1, self:val(i))
+  end
+  return vals
+end
+
+---Key/value pair in current result.
+---@return table: key/value pair of a row.
+---@see sqlstmt:key
+---@see sqlstmt:val
+---@see sqlstmt:nkeys
+function sqlstmt:kv()
+  local ret = {}
+  for i = 0, self:nkeys() - 1 do
+    ret[self:key(i)] = self:val(i)
+  end
+  return ret
+end
+
+---Key/type pair in current result.
+---@return table: key/type pair of a row.
+---@see sqlstmt:key
+---@see sqlstmt:val
+---@see sqlstmt:nkeys
+function sqlstmt:kt()
+  local ret = {}
+  for i = 0, self:nkeys() - 1 do
+    ret[self:key(i)] = self:convert_type(i)
+  end
+  return ret
+end
+
+---sqlstmt:next:
+---If code == flags.row it returns
+---If code == flags.done it reset the parsed statement
+function sqlstmt:next()
+  local code = self:step()
+  if code == flags.row then
+    return self
+  elseif code == flags.done then
+    self:reset()
+  else
+    return nil, code
+  end
+end
+
+---sqlstmt:iter
+---@see sqlstmt:next
+function sqlstmt:iter()
+  return self:next(), self.pstmt
+end
+
+---Loops through results with {callback} until there is no row left.
+---@param callback function: a function to be called on each number of row.
+---@usage sqlstmt:each(function(s)  print(s:val(1))  end)
+---@see sqlstmt:step
+function sqlstmt:each(callback)
+  assert(type(callback) == "function", "sqlstmt:each expected a function, got something else.")
+  while self:step() == flags.row do
+    callback(self)
+  end
+end
+
+---Loops through the results and if {callback} pass to it row, else return nested kv pairs.
+---@param callback function: a function to be called with each row.
+---@return table: if no callback then nested key-value pairs
+---@see sqlstmt:kv
+---@see sqlstmt:each
+function sqlstmt:kvrows(callback)
+  local kv = {}
+  self:each(function()
+    local row = self:kv()
+    if callback then
+      return callback(row)
+    else
+      table.insert(kv, row)
+    end
+  end)
+  if not callback then
+    return kv
+  end
+end
+
+---Like sqlstmt:kvrows but passed list of values instead of kv pairs.
+---@param callback function: a function to be called with each row.
+---@return table: if no callback then nested lists of values in each row.
+---@see sqlstmt:vals
+---@see sqlstmt:each
+function sqlstmt:vrows(callback)
+  local vals = {}
+  self:each(function(s)
+    local row = s:vals()
+    if callback then
+      return callback(row)
+    else
+      table.insert(vals, row)
+    end
+  end)
+  if not callback then
+    return vals
+  end
+end
+
+local bind_type_to_func = {
+  ["number"] = "double", -- bind_double
+  ["string"] = "text", -- bind_text
+  ["nil"] = "null", -- bind_null
+}
+
+---Bind {args[2]} at {args[1]} or kv pairs {args[1]}.
+---If {args[1]} is a number and {args[2]} is a value then it binds by index.
+---Else first argument is a table, then it binds the table to indicies, and it
+---works with named and unnamed.
+---@varargs if {args[1]} number and {args[2]} or {args[1]} table
+---@see sqlstmt:nparam
+---@see sqlstmt:param
+---@see sqlstmt:bind
+function sqlstmt:bind(...)
+  local args = { ... }
+  -- bind by table
+  if type(args[1]) == "table" then
+    local names = args[1]
+    local parameter_index_cache = {}
+    local anon_indices = {}
+    for i = 1, self:nparam() do
+      local name = self:param(i)
+      if name == "?" then
+        table.insert(anon_indices, i)
+      else
+        parameter_index_cache[name:sub(2, -1)] = i
+      end
+    end
+
+    for k, v in pairs(names) do
+      local index = parameter_index_cache[k] or table.remove(anon_indices, 1)
+      if ((type(v) == "string" and v:match "^[%S]+%(.*%)$") and flags.ok or self:bind(index, v)) ~= flags.ok then
+        error("sqlite.lua error at stmt:bind(), failed to bind a given value '%s'. Please report issue."):format(v)
+      end
+    end
+    return flags.ok
+  end
+
+  -- bind by index
+  if type(args[1]) == "number" and args[2] then
+    local idx, value = args[1], args[2]
+    local func = bind_type_to_func[type(value)]
+    local len = func == "text" and #value or nil
+
+    if not func then
+      return error [[
+        sqlite.lua error at stmt:bind(): Unrecognized or unsupported type.
+        Please report issue.
+      ]]
+    end
+
+    if len then
+      return clib["bind_" .. func](self.pstmt, idx, value, len, nil)
+    else
+      if value then
+        return clib["bind_" .. func](self.pstmt, idx, value)
+      else
+        return clib["bind_" .. func](self.pstmt, idx)
+      end
+    end
+  end
+end
+
+---Binds a blob at {idx} with {size}
+---@param idx number: index starting at 1
+---@param pointer sqlite_blob: blob to bind
+---@param size number: pointer size
+---@return sqlite_flags
+function sqlstmt:bind_blob(idx, pointer, size)
+  return clib.bind_blob64(self.pstmt, idx, pointer, size, nil) -- Always 64? or two functions
+end
+
+---Binds zeroblob at {idx} with {size}
+---@param idx number: index starting at 1
+---@param size number: zeroblob size
+---@return sqlite_flags
+function sqlstmt:bind_zeroblob(idx, size)
+  return clib.bind_zeroblob64(self.pstmt, idx, size)
+end
+
+---The number of parameter to bind.
+---@return number: number of params in {sqlstmt.pstmt}
+function sqlstmt:nparam()
+  if not self.parm_count then
+    self.parm_count = clib.bind_parameter_count(self.pstmt)
+  end
+
+  return self.parm_count
+end
+
+---The parameter key/name at {idx}
+---@param idx number: index starting at 1
+---@return string: param key ":key" at {idx}
+function sqlstmt:param(idx)
+  return clib.to_str(clib.bind_parameter_name(self.pstmt, idx)) or "?"
+end
+
+---Parameters keys/names
+---@return table: paramters key/names in {sqlstmt.pstmt}
+---@see sqlstmt:nparam
+---@see sqlstmt:param
+function sqlstmt:params()
+  local res = {}
+  for i = 1, self:nparam() do
+    table.insert(res, self:param(i))
+  end
+  return res
+end
+
+---Clear the current bindings.
+---@return sqlite_flags
+function sqlstmt:bind_clear()
+  self.current_bind_index = nil
+  return clib.clear_bindings(self.pstmt)
+end
+
+---Bind the value at the next index until all values are bound
+---@param value any: value to bind
+---@return sqlite_flags
+---@TODO does it return sqlite_flag in all cases? @conni
+function sqlstmt:bind_next(value)
+  if not self.current_bind_index then
+    self.current_bind_index = 1
+  end
+
+  if self.current_bind_index <= self:nparam() then
+    local ret = self:bind(self.current_bind_index, value)
+    self.current_bind_index = self.current_bind_index + 1
+    return ret
+  end
+  return flags.error -- TODO(conni): should error out?
+end
+
+---Expand the resulting statement after binding, used for debugging purpose.
+---@return string: the resulting statement that can be finalized.
+function sqlstmt:expand()
+  return clib.to_str(clib.expanded_sql(self.pstmt))
+end
+
+return sqlstmt

--- a/cli/lua/vendor/sqlite/strfun.lua
+++ b/cli/lua/vendor/sqlite/strfun.lua
@@ -1,0 +1,135 @@
+local M = {}
+local u = require "sqlite.utils"
+
+local customstr
+customstr = function(str)
+  local mt = getmetatable(str)
+
+  local wrap = function(a_, b_, sign)
+    local _str = ("%s %s %s"):format(a_, sign, b_)
+    if u.is_str(b_) and b_:match "^%a+%(.+%)$" then
+      _str = "(" .. _str .. ")"
+    end
+    return _str
+  end
+
+  mt._a_dd = function(a_, b_)
+    return wrap(a_, b_, "+")
+  end
+  mt.__sub = function(a_, b_)
+    return wrap(a_, b_, "-")
+  end
+  mt.__mul = function(a_, b_)
+    return wrap(a_, b_, "*")
+  end
+  mt.__div = function(a_, b_)
+    return wrap(a_, b_, "/")
+  end
+  mt.__pow = function(a_, b_)
+    return wrap(a_, b_, "^")
+  end
+  mt.__mod = function(a_, b_)
+    return wrap(a_, b_, "%")
+  end
+
+  return str
+end
+
+local ts = function(ts)
+  local str
+  if ts ~= "now" and (type(ts) == "string" and not ts:match "%d") then
+    str = "%s"
+  else
+    str = "'%s'"
+  end
+  return str:format(ts or "now")
+end
+
+---Format date according {format}
+---@param format string the format
+---     %d 	day of month: 00
+---     %f 	fractional seconds: SS.SSS
+---     %H 	hour: 00-24
+---     %j 	day of year: 001-366
+---     %J 	Julian day number
+---     %m 	month: 01-12
+---     %M 	minute: 00-59
+---     %s 	seconds since 1970-01-01
+---     %S 	seconds: 00-59
+---     %w 	day of week 0-6 with Sunday==0
+---     %W 	week of year: 00-53
+---     %Y 	year: 0000-9999
+---     %% 	%
+---@param timestring string timestamp to format 'deafult now'
+---@return string: string representation or TEXT when evaluated.
+---@usage `sqlstrftime('%Y %m %d','now')` -> 2021 8 11
+---@usage `sqlstrftime('%H %M %S %s','now')` -> 12 40 18 1414759218
+---@usage `sqlstrftime('%s','now') - strftime('%s','2014-10-07 02:34:56')` -> 2110042
+M.strftime = function(format, timestring)
+  local str = [[strftime('%s', %s)]]
+  return customstr(str:format(format, ts(timestring)))
+end
+
+---Return the number of days since noon in Greenwich on November 24, 4714 B.C.
+---@param timestring string timestamp to format 'deafult now'
+---@return string: string representation or REAL when evaluated.
+---@usage `sqljulianday('now')` -> ...
+---@usage `sqljulianday('now') - julianday('1947-08-15')` -> 24549.5019360879
+M.julianday = function(timestring)
+  local str = "julianday(%s)"
+  return customstr(str:format(ts(timestring)))
+end
+
+---Returns date as "YYYY-MM-DD HH:MM:SS"
+---@param timestring string timestamp to format 'deafult now'
+---@return string: string representation or  "YYYY-MM-DD HH:MM:SS"
+---@usage `sqldatetime('now')` -> 2021-8-11 11:31:52
+M.datetime = function(timestring)
+  local str = [[datetime('%s')]]
+  return customstr(str:format(timestring or "now"))
+end
+
+---Returns time as HH:MM:SS.
+---@param timestring string timestamp to format 'deafult now'
+---@param modifier string: e.g. +60 seconds, +15 minutes
+---@return string: string representation or "HH:MM:SS"
+---@usage `sqltime()` -> "12:50:01"
+---@usage `sqltime('2014-10-07 15:45:57.005678')` -> 15:45:57
+---@usage `sqltime('now','+60 seconds')` 15:45:57 + 60 seconds
+M.time = function(timestring, modifier)
+  local str = [[time('%s')]]
+  if modifier then
+    str = [[time('%s', '%s')]]
+    return customstr(str:format(timestring or "now", modifier))
+  end
+
+  return customstr(str:format(timestring or "now"))
+end
+
+---Returns date as YYYY-MM-DD
+---@param timestring string timestamp to format 'deafult now'
+---@param modifier string: e.g. +2 month, +1 year
+---@return string: string representation or "HH:MM:SS"
+---@usage `sqldate()` -> 2021-08-31
+---@usage `sqldate('2021-08-07')` -> 2021-08-07
+---@usage `sqldate('now','+2 month')` -> 2021-10-07
+M.date = function(timestring, modifier)
+  local str = [[date('%s')]]
+  if modifier then
+    str = [[date('%s', '%s')]]
+    return customstr(str:format(timestring or "now", modifier))
+  end
+
+  return customstr(str:format(timestring or "now"))
+end
+
+---Cast a value as something
+---@param source string: the value.
+---@param as string: the type.
+---@usage `cast((julianday() - julianday "timestamp") * 24 * 60, "integer")`
+---@return string
+M.cast = function(source, as)
+  return string.format("cast(%s as %s)", source, as)
+end
+
+return M

--- a/cli/lua/vendor/sqlite/tbl.lua
+++ b/cli/lua/vendor/sqlite/tbl.lua
@@ -1,0 +1,477 @@
+---@brief [[
+---Abstraction to produce more readable code.
+---<pre>
+--- ```lua
+--- local tbl = require'sqlite.tbl'
+--- ```
+---</pre>
+---@brief ]]
+---@tag sqlite.tbl.lua
+
+local u = require "sqlite.utils"
+local h = require "sqlite.helpers"
+
+local sqlite = {}
+
+---@class sqlite_tbl @Main sql table class
+---@field db sqlite_db: sqlite.lua database object.
+---@field name string: table name.
+---@field mtime number: db last modified time.
+sqlite.tbl = {}
+sqlite.tbl.__index = sqlite.tbl
+
+---Create new |sqlite_tbl| object. This object encouraged to be extend and
+---modified by the user. overwritten method can be still accessed via
+---pre-appending `__`  e.g. redefining |sqlite_tbl:get|, result in
+---`sqlite_tbl:__get` available as a backup. This object can be instantiated
+---without a {db}, in which case, it requires 'sqlite.tbl:set_db' is called.
+---
+---Common use case might be to define tables in separate files and then require them in
+---file that export db object (TODO: support tbl reuse in different dbs).
+---
+---<pre>
+---```lua
+--- local t = tbl("todos", { --- or tbl.new
+---   id = true, -- same as { "integer", required = true, primary = true }
+---   title = "text",
+---   since = { "date", default = sqlite.lib.strftime("%s", "now") },
+---   category = {
+---     type = "text",
+---     reference = "category.id",
+---     on_update = "cascade", -- means when category get updated update
+---     on_delete = "null", -- means when category get deleted, set to null
+---   },
+--- }, db)
+--- --- overwrite
+--- t.get = function() return t:__get({ where = {...}, select = {...} })[1] end
+---```
+---</pre>
+---@param name string: table name
+---@param schema sqlite_schema_dict
+---@param db sqlite_db|nil : if nil, then for it to work, it needs setting with sqlite.tbl:set_db().
+---@return sqlite_tbl
+function sqlite.tbl.new(name, schema, db)
+  schema = schema or {}
+
+  local t = setmetatable({
+    db = db,
+    name = name,
+    tbl_schema = u.if_nil(schema.schema, schema),
+  }, sqlite.tbl)
+
+  if db then
+    h.run(function() end, t)
+  end
+
+  return setmetatable({}, {
+    __index = function(_, key, ...)
+      if type(key) == "string" then
+        key = key:sub(1, 2) == "__" and key:sub(3, -1) or key
+        if t[key] then
+          return t[key]
+        end
+      end
+    end,
+  })
+end
+
+---Create or change table schema. If no {schema} is given,
+---then it return current the used schema if it exists or empty table otherwise.
+---On change schema it returns boolean indecting success.
+---
+---<pre>
+---```lua
+--- local projects = sqlite.tbl:new("", {...})
+--- --- get project table schema.
+--- projects:schema()
+--- --- mutate project table schema with droping content if not schema.ensure
+--- projects:schema {...}
+---```
+---</pre>
+---@param schema sqlite_schema_dict
+---@return sqlite_schema_dict | boolean
+function sqlite.tbl:schema(schema)
+  return h.run(function()
+    local exists = self.db:exists(self.name)
+    if not schema then -- TODO: or table is empty
+      return exists and self.db:schema(self.name) or {}
+    end
+    if not exists or schema.ensure then
+      self.tbl_exists = self.db:create(self.name, schema)
+      return self.tbl_exists
+    end
+    if not schema.ensure then -- TODO: use alter
+      local res = exists and self.db:drop(self.name) or true
+      res = res and self.db:create(self.name, schema) or false
+      self.tbl_schema = schema
+      return res
+    end
+  end, self)
+end
+
+---Remove table from database, if the table is already drooped then it returns false.
+---
+---<pre>
+---```lua
+--- --- drop todos table content.
+--- todos:drop()
+---```
+---</pre>
+---@see sqlite.db:drop
+---@return boolean
+function sqlite.tbl:drop()
+  return h.run(function()
+    if not self.db:exists(self.name) then
+      return false
+    end
+
+    local res = self.db:drop(self.name)
+    if res then
+      self.tbl_exists = false
+      self.tbl_schema = nil
+    end
+    return res
+  end, self)
+end
+
+---Predicate that returns true if the table is empty.
+---
+---<pre>
+---```lua
+--- if todos:empty() then
+---   print "no more todos, we are free :D"
+--- end
+---```
+---</pre>
+---@return boolean
+function sqlite.tbl:empty()
+  return h.run(function()
+    if self.db:exists(self.name) then
+      return self.db:eval("select count(*) from " .. self.name)[1]["count(*)"] == 0
+    end
+  end, self)
+end
+
+---Predicate that returns true if the table exists.
+---
+---<pre>
+---```lua
+--- if goals:exists() then
+---   error("I'm disappointed in you :D")
+--- end
+---```
+---</pre>
+---@return boolean
+function sqlite.tbl:exists()
+  return h.run(function()
+    return self.db:exists(self.name)
+  end, self)
+end
+
+---Get the current number of rows in the table
+---
+---<pre>
+---```lua
+--- if notes:count() == 0 then
+---   print("no more notes")
+--- end
+---```
+---@return number
+function sqlite.tbl:count()
+  return h.run(function()
+    if not self.db:exists(self.name) then
+      return 0
+    end
+    local res = self.db:eval("select count(*) from " .. self.name)
+    return res[1]["count(*)"]
+  end, self)
+end
+
+---Query the table and return results.
+---
+---<pre>
+---```lua
+--- --- get everything
+--- todos:get()
+--- --- get row with id of 1
+--- todos:get { where = { id = 1 } }
+--- --- select a set of keys with computed one
+--- timestamps:get {
+---   select = {
+---     age = (strftime("%s", "now") - strftime("%s", "timestamp")) * 24 * 60,
+---     "id",
+---     "timestamp",
+---     "entry",
+---     },
+---   }
+---```
+---</pre>
+---@param query sqlite_query_select
+---@return table
+---@see sqlite.db:select
+function sqlite.tbl:get(query)
+  -- query = query or { query = { all = 1 } }
+
+  return h.run(function()
+    local res = self.db:select(self.name, query or { query = { all = 1 } }, self.db_schema)
+    return res
+  end, self)
+end
+
+---Get first match.
+---
+---<pre>
+---```lua
+--- --- get single entry. notice that we don't pass where key.
+--- tbl:where{ id = 1 }
+--- --- get row with id of 1 or 'todos.where { id = 1 }'
+---```
+---</pre>
+---@param where table: where key values
+---@return nil or row
+---@usage ``
+---@see sqlite.db:select
+function sqlite.tbl:where(where)
+  return where and self:get({ where = where })[1] or nil
+end
+
+---Iterate over table rows and execute {func}.
+---Returns false if no row is returned.
+---
+---<pre>
+---```lua
+--- --- Execute a function on each returned row
+--- todos:each(function(row)
+---   print(row.title)
+--- end, {
+---   where = { status = "pending" },
+---   contains = { title = "fix*" }
+--- })
+---
+--- todos:each({ where = { ... }}, function(row)
+---   print(row.title)
+--- end)
+---```
+---</pre>
+---@param func function: func(row)
+---@param query sqlite_query_select|nil
+---@return boolean
+function sqlite.tbl:each(func, query)
+  if type(func) == "table" then
+    func, query = query, func
+  end
+
+  return h.run(function()
+    local rows = self.db:select(self.name, query or {}, self.db_schema)
+    if not rows then
+      return false
+    end
+
+    for _, row in ipairs(rows) do
+      func(row)
+    end
+
+    return rows ~= {} or type(rows) ~= "boolean"
+  end, self)
+end
+
+---Create a new table from iterating over a tbl rows with {func}.
+---
+---<pre>
+---```lua
+--- --- transform rows.
+--- local rows = todos:map(function(row)
+---   row.somekey = ""
+---   row.f = callfunction(row)
+---   return row
+--- end, {
+---   where = { status = "pending" },
+---   contains = { title = "fix*" }
+--- })
+--- --- This works too.
+--- local titles = todos:map({ where = { ... }}, function(row)
+---   return row.title
+--- end)
+--- --- no query, no problem :D
+--- local all = todos:map(function(row) return row.title end)
+---```
+---</pre>
+---@param func function: func(row)
+---@param query sqlite_query_select
+---@return table[]
+function sqlite.tbl:map(func, query)
+  if type(func) == "table" then
+    func, query = query, func
+  end
+
+  return h.run(function()
+    local res = {}
+    local rows = self.db:select(self.name, query or {}, self.db_schema)
+    if not rows then
+      return {}
+    end
+    for _, row in ipairs(rows) do
+      local ret = func(row)
+      if ret then
+        table.insert(res, func(row))
+      end
+    end
+
+    return res
+  end, self)
+end
+
+---Sorts a table in-place using a transform. Values are ranked in a custom order of the results of
+---running `transform (v)` on all values. `transform` may also be a string name property  sort by.
+---`comp` is a comparison function. Adopted from Moses.lua
+---
+---<pre>
+---```lua
+--- --- return rows sort by id.
+--- local res = t1:sort({ where = {id = {32,12,35}}})
+--- --- return rows sort by age
+--- local res = t1:sort({ where = {id = {32,12,35}}}, "age")`
+--- --- return with custom sort function (recommended)
+--- local res = t1:sort({where = { ... }}, "age", function(a, b) return a > b end)`
+---```
+---</pre>
+---@param query sqlite_query_select|nil
+---@param transform function: a `transform` function to sort elements. Defaults to @{identity}
+---@param comp function: a comparison function, defaults to the `<` operator
+---@return table[]
+function sqlite.tbl:sort(query, transform, comp)
+  return h.run(function()
+    local res = self.db:select(self.name, query or { query = { all = 1 } }, self.db_schema)
+    local f = transform or function(r)
+      return r[u.keys(query.where)[1]]
+    end
+    if type(transform) == "string" then
+      f = function(r)
+        return r[transform]
+      end
+    end
+    comp = comp or function(a_, b_)
+      return a_ < b_
+    end
+    table.sort(res, function(a_, b_)
+      return comp(f(a_), f(b_))
+    end)
+    return res
+  end, self)
+end
+
+---Insert rows into a table.
+---
+---<pre>
+---```lua
+--- --- single item.
+--- todos:insert { title = "new todo" }
+--- --- insert multiple items, using todos table as first param
+--- tbl.insert(todos, "items", {  { name = "a"}, { name = "b" }, { name = "c" } })
+---```
+---</pre>
+---@param rows table: a row or a group of rows
+---@see sqlite.db:insert
+---@usage `todos:insert { title = "stop writing examples :D" }` insert single item.
+---@usage `todos:insert { { ... }, { ... } }` insert multiple items
+---@return integer: last inserted id
+function sqlite.tbl:insert(rows)
+  return h.run(function()
+    local succ, last_rowid = self.db:insert(self.name, rows, self.db_schema)
+    if succ then
+      self.has_content = self:count() ~= 0 or false
+    end
+    return last_rowid
+  end, self)
+end
+
+---Delete a rows/row or table content based on {where} closure. If {where == nil}
+---then clear table content.
+---
+---<pre>
+---```lua
+--- --- delete todos table content
+--- todos:remove()
+--- --- delete row that has id as 1
+--- todos:remove { id = 1 }
+--- --- delete all rows that has value of id 1 or 2 or 3
+--- todos:remove { id = {1,2,3} }
+--- --- matching ids or greater than 5
+--- todos:remove { id = {"<", 5} } -- or {id = "<5"}
+---```
+---</pre>
+---@param where sqlite_query_delete
+---@see sqlite.db:delete
+---@return boolean
+function sqlite.tbl:remove(where)
+  return h.run(function()
+    return self.db:delete(self.name, where)
+  end, self)
+end
+
+---Update table row with where closure and list of values
+---returns true incase the table was updated successfully.
+---
+---<pre>
+---```lua
+--- --- update todos status linked to project "lua-hello-world" or "rewrite-neoivm-in-rust"
+--- todos:update {
+---   where = { project = {"lua-hello-world", "rewrite-neoivm-in-rust"} },
+---   set = { status = "later" }
+--- }
+--- --- pass custom statement and boolean
+--- ts:update {
+---   where = { id = "<" .. 4 }, -- mimcs WHERE id < 4
+---   set = { seen = true } -- will be converted to 0.
+--- }
+---```
+---</pre>
+---@param specs sqlite_query_update
+---@see sqlite.db:update
+---@see sqlite_query_update
+---@return boolean
+function sqlite.tbl:update(specs)
+  return h.run(function()
+    local succ = self.db:update(self.name, specs, self.db_schema)
+    return succ
+  end, self)
+end
+
+---Replaces table content with a given set of {rows}.
+---
+---<pre>
+---```lua
+--- --- replace project table content with a single call
+--- todos:replace { { ... }, { ... }, { ... },  }
+---
+--- --- replace everything with a single row
+--- ts:replace { key = "val" }
+---```
+---</pre>
+---@param rows table[]|table
+---@see sqlite.db:delete
+---@see sqlite.db:insert
+---@return boolean
+function sqlite.tbl:replace(rows)
+  return h.run(function()
+    self.db:delete(self.name)
+    local succ = self.db:insert(self.name, rows, self.db_schema)
+    return succ
+  end, self)
+end
+
+---Changes the db object to which the sqlite_tbl correspond to. If the object is
+---going to be passed to |sqlite.new|, then it will be set automatically at
+---definition.
+---@param db sqlite_db
+function sqlite.tbl:set_db(db)
+  self.db = db
+end
+
+sqlite.tbl = setmetatable(sqlite.tbl, {
+  __call = function(_, ...)
+    return sqlite.tbl.new(...)
+  end,
+})
+
+return sqlite.tbl

--- a/cli/lua/vendor/sqlite/tbl/cache.lua
+++ b/cli/lua/vendor/sqlite/tbl/cache.lua
@@ -1,0 +1,89 @@
+-- botster: upstream had `require "sql.utils"` (typo — the module is
+-- `sqlite.utils`). The file currently isn't exercised by any smoke/test
+-- path, but the typo would trip any future caller. Also drop the `luv`
+-- require; see VENDOR_CHANGES.md.
+local u = require "sqlite.utils"
+
+local Cache = {}
+
+Cache.__index = Cache
+
+local parse_query = (function()
+  local concat = function(v)
+    if not u.is_list(v) and type(v) ~= "string" then
+      local tmp = {}
+      for _k, _v in u.opairs(v) do
+        if type(_v) == "table" then
+          table.insert(tmp, string.format("%s=%s", _k, table.concat(_v, ",")))
+        else
+          table.insert(tmp, string.format("%s=%s", _k, _v))
+        end
+      end
+      return table.concat(tmp, "")
+    else
+      return table.concat(v, "")
+    end
+  end
+
+  return function(query)
+    local items = {}
+    for k, v in u.opairs(query) do
+      if type(v) == "table" then
+        table.insert(items, string.format("%s=%s", k, concat(v)))
+      else
+        table.insert(items, k .. "=" .. v)
+      end
+    end
+    return table.concat(items, ",")
+  end
+end)()
+
+-- assert(parse_query { where = { a = { 12, 99, 32 } } } == "where=a=12,99,32")
+-- assert(parse_query { where = { a = 32 } } == "where=a=32")
+-- print(vim.inspect(parse_query { keys = { "b", "c" }, where = { a = 1 } }))
+-- "keys=bc,select=bc,where=a=1"
+---Insert to cache using query definition.
+---@param query table
+---@param result table
+function Cache:insert(query, result)
+  self.store[parse_query(query)] = result
+end
+
+---Clear cache when succ is true, else skip.
+function Cache:clear(succ)
+  if succ then
+    self.store = {}
+    self.db.modified = false
+  end
+end
+
+function Cache:is_empty()
+  return next(self.store) == nil
+end
+
+---Get results from cache.
+---@param query sqlite_query_select
+---@return table
+function Cache:get(query)
+  -- botster: see helpers.lua for mtime-via-fs.stat rationale. With no mtime
+  -- available, the `mtime ~= self.mtime` comparison collapses to nil-vs-nil
+  -- (equal), so cache invalidation falls back to the `self.db.modified` flag
+  -- alone — sufficient for single-writer dbs.
+  local stat = type(fs) == "table" and fs.stat and fs.stat(self.db.uri) or nil
+  local mtime = (type(stat) == "table" and stat.mtime) or nil
+
+  if self.db.modified or mtime ~= self.mtime then
+    self:clear(true)
+    return
+  end
+
+  return self.store[parse_query(query)]
+end
+
+setmetatable(Cache, {
+  __call = function(self, db)
+    return setmetatable({ db = db, store = {} }, self)
+  end,
+})
+
+return Cache

--- a/cli/lua/vendor/sqlite/tbl/extend.lua
+++ b/cli/lua/vendor/sqlite/tbl/extend.lua
@@ -1,0 +1,113 @@
+---@type sqlite_tblext
+local tbl = {}
+
+---Create or change table schema. If no {schema} is given,
+---then it return current the used schema if it exists or empty table otherwise.
+---On change schema it returns boolean indecting success.
+---@param schema table: table schema definition
+---@return table table | boolean
+---@usage `tbl.schema()` get project table schema.
+---@usage `tbl.schema({...})` mutate project table schema
+---@todo do alter when updating the schema instead of droping it completely
+tbl.schema = function(schema) end
+
+---Remove table from database, if the table is already drooped then it returns false.
+---@usage `todos:drop()` drop todos table content.
+---@see DB:drop
+---@return boolean
+tbl.drop = function() end
+
+---Predicate that returns true if the table is empty.
+---@usage `if todos:empty() then echo "no more todos, you are free :D" end`
+---@return boolean
+tbl.empty = function() end
+
+---Predicate that returns true if the table exists.
+---@usage `if not goals:exists() then error("I'm disappointed in you ") end`
+---@return boolean
+tbl.exists = function() end
+
+---Query the table and return results.
+---@param query sqlite_query_select
+---@return table
+---@usage `tbl.get()` get a list of all rows in project table.
+---@usage `tbl.get({ where = { status = "pending", client = "neovim" }})`
+---@usage `tbl.get({ where = { status = "done" }, limit = 5})` get the last 5 done projects
+---@see DB:select
+tbl.get = function(query) end
+
+---Get the current number of rows in the table
+---@return number
+tbl.count = function() end
+
+---Get first match.
+---@param where table: where key values
+---@return nil or row
+---@usage `tbl.where{id = 1}`
+---@see DB:select
+tbl.where = function(where) end
+
+---Iterate over table rows and execute {func}.
+---Returns true only when rows is not emtpy.
+---@param func function: func(row)
+---@param query sqlite_query_select
+---@usage `let query = { where = { status = "pending"}, contains = { title = "fix*" } }`
+---@usage `tbl.each(function(row) print(row.title) end, query)`
+---@return boolean
+tbl.each = function(func, query) end
+
+---Create a new table from iterating over {self.name} rows with {func}.
+---@param func function: func(row)
+---@param query sqlite_query_select
+---@usage `let query = { where = { status = "pending"}, contains = { title = "fix*" } }`
+---@usage `local t = todos.map(function(row) return row.title end, query)`
+---@return table[]
+tbl.map = function(func, query) end
+
+---Sorts a table in-place using a transform. Values are ranked in a custom order of the results of
+---running `transform (v)` on all values. `transform` may also be a string name property  sort by.
+---`comp` is a comparison function. Adopted from Moses.lua
+---@param query sqlite_query_select
+---@param transform function: a `transform` function to sort elements. Defaults to @{identity}
+---@param comp function: a comparison function, defaults to the `<` operator
+---@return table[]
+---@usage `local res = tbl.sort({ where = {id = {32,12,35}}})` return rows sort by id
+---@usage `local res = tbl.sort({ where = {id = {32,12,35}}}, "age")` return rows sort by age
+---@usage `local res = tbl.sort({where = { ... }}, "age", function(a, b) return a > b end)` with custom function
+tbl.sort = function(query, transform, comp) end
+
+---Same functionalities as |DB:insert()|
+---@param rows table: a row or a group of rows
+---@see DB:insert
+---@usage `tbl.insert { title = "stop writing examples :D" }` insert single item.
+---@usage `tbl.insert { { ... }, { ... } }` insert multiple items
+---@return integer: last inserted id
+tbl.insert = function(rows) end
+
+---Same functionalities as |DB:delete()|
+---@param where sqlite_query_delete: key value pairs to filter rows to delete
+---@see DB:delete
+---@return boolean
+---@usage `todos.remove()` remove todos table content.
+---@usage `todos.remove{ project = "neovim" }` remove all todos where project == "neovim".
+---@usage `todos.remove{{project = "neovim"}, {id = 1}}` remove all todos where project == "neovim" or id =1
+tbl.remove = function(where) end
+
+---Same functionalities as |DB:update()|
+---@param specs sqlite_query_update
+---@see DB:update
+---@return boolean
+tbl.update = function(specs) end
+
+---replaces table content with {rows}
+---@param rows table: a row or a group of rows
+---@see DB:delete
+---@see DB:insert
+---@return boolean
+tbl.replace = function(rows) end
+
+---Set db object for the table.
+---@param db sqlite_db
+tbl.set_db = function(db) end
+
+return tbl

--- a/cli/lua/vendor/sqlite/utils.lua
+++ b/cli/lua/vendor/sqlite/utils.lua
@@ -1,0 +1,263 @@
+-- botster: `luv` not available. The single touchpoint was a realpath() call
+-- used by expand() for relative paths starting with "." — we short-circuit
+-- that branch to return the path as-is, because plugin.db always passes
+-- absolute paths. See VENDOR_CHANGES.md.
+local M = {}
+
+M.if_nil = function(a, b)
+  if a == nil then
+    return b
+  end
+  return a
+end
+
+M.is_str = function(s)
+  return type(s) == "string"
+end
+
+M.is_tbl = function(t)
+  return type(t) == "table"
+end
+
+M.is_boolean = function(t)
+  return type(t) == "boolean"
+end
+
+M.is_userdata = function(t)
+  return type(t) == "userdata"
+end
+
+M.is_nested = function(t)
+  return t and type(t[1]) == "table" or false
+end
+
+-- taken from: https://github.com/neovim/neovim/blob/master/runtime/lua/vim/shared.lua
+M.is_list = function(t)
+  if type(t) ~= "table" then
+    return false
+  end
+
+  local count = 0
+
+  for k, _ in pairs(t) do
+    if type(k) == "number" then
+      count = count + 1
+    else
+      return false
+    end
+  end
+
+  if count > 0 then
+    return true
+  else
+    return getmetatable(t) ~= {}
+  end
+end
+
+M.okeys = function(t)
+  local r = {}
+  for k in M.opairs(t) do
+    r[#r + 1] = k
+  end
+  return r
+end
+
+M.opairs = (function()
+  local __gen_order_index = function(t)
+    local orderedIndex = {}
+    for key in pairs(t) do
+      table.insert(orderedIndex, key)
+    end
+    table.sort(orderedIndex)
+    return orderedIndex
+  end
+
+  local nextpair = function(t, state)
+    local key
+    if state == nil then
+      -- the first time, generate the index
+      t.__orderedIndex = __gen_order_index(t)
+      key = t.__orderedIndex[1]
+    else
+      -- fetch the next value
+      for i = 1, table.getn(t.__orderedIndex) do
+        if t.__orderedIndex[i] == state then
+          key = t.__orderedIndex[i + 1]
+        end
+      end
+    end
+
+    if key then
+      return key, t[key]
+    end
+
+    -- no more value to return, cleanup
+    t.__orderedIndex = nil
+    return
+  end
+
+  return function(t)
+    return nextpair, t, nil
+  end
+end)()
+
+M.expand = function(path)
+  local expanded
+  if string.find(path, "^~") then
+    expanded = string.gsub(path, "^~", os.getenv "HOME")
+  elseif string.find(path, "^%.") then
+    -- botster: upstream used luv.fs_realpath() to canonicalize relative paths.
+    -- plugin.db always passes absolute paths so canonicalization is cosmetic
+    -- at best; returning the path unchanged is safe for our use case.
+    expanded = path
+  elseif string.find(path, "%$") then
+    local rep = string.match(path, "([^%$][^/]*)")
+    local val = os.getenv(string.upper(rep))
+    if val then
+      expanded = string.gsub(string.gsub(path, rep, val), "%$", "")
+    else
+      expanded = nil
+    end
+  else
+    expanded = path
+  end
+
+  return expanded and expanded or error "Path not valid"
+end
+
+M.all = function(iterable, fn)
+  for k, v in pairs(iterable) do
+    if not fn(k, v) then
+      return false
+    end
+  end
+
+  return true
+end
+
+M.keys = function(t)
+  local r = {}
+  for k in pairs(t) do
+    r[#r + 1] = k
+  end
+  return r
+end
+
+M.values = function(t)
+  local r = {}
+  for _, v in pairs(t) do
+    r[#r + 1] = v
+  end
+  return r
+end
+
+M.map = function(t, f)
+  local _t = {}
+  for i, value in pairs(t) do
+    local k, kv, v = i, f(value, i)
+    _t[v and kv or k] = v or kv
+  end
+  return _t
+end
+
+M.foreachv = function(t, f)
+  for i, v in M.opairs(t) do
+    f(i, v)
+  end
+end
+
+M.foreach = function(t, f)
+  for k, v in pairs(t) do
+    f(k, v)
+  end
+end
+
+M.mapv = function(t, f)
+  local _t = {}
+  for i, value in M.opairs(t) do
+    local _, kv, v = i, f(value, i)
+    table.insert(_t, v or kv)
+  end
+  return _t
+end
+
+M.join = function(l, s)
+  return table.concat(M.map(l, tostring), s, 1)
+end
+
+M.tbl_extend = (function()
+  local run_behavior = setmetatable({
+    ["error"] = function(_, k, _)
+      error("Key already exists: ", k)
+    end,
+    ["keep"] = function() end,
+    ["force"] = function(t, k, v)
+      t[k] = v
+    end,
+  }, {
+    __index = function(_, k)
+      error(k .. " is not a valid behavior")
+    end,
+  })
+
+  return function(behavior, ...)
+    local new_table = {}
+    local tables = { ... }
+    for i = 1, #tables do
+      local b = tables[i]
+      for k, v in pairs(b) do
+        if v then
+          if new_table[k] then
+            run_behavior[behavior](new_table, k, v)
+          else
+            new_table[k] = v
+          end
+        end
+      end
+    end
+    return new_table
+  end
+end)()
+
+-- Flatten taken from: https://github.com/premake/premake-core/blob/master/src/base/table.lua
+M.flatten = function(tbl)
+  local result = {}
+  local function flatten(arr)
+    local n = #arr
+    for i = 1, n do
+      local v = arr[i]
+      if type(v) == "table" then
+        flatten(v)
+      elseif v then
+        table.insert(result, v)
+      end
+    end
+  end
+  flatten(tbl)
+
+  return result
+end
+
+--- taken from https://github.com/tjdevries/lazy.nvim/blob/master/lua/lazy.lua
+M.require_on_exported_call = function(require_path)
+  return setmetatable({}, {
+    __index = function(_, k)
+      return function(...)
+        return require(require_path)[k](...)
+      end
+    end,
+  })
+end
+
+M.require_on_index = function(require_path)
+  return setmetatable({}, {
+    __index = function(_, key)
+      return require(require_path)[key]
+    end,
+
+    __newindex = function(_, key, value)
+      require(require_path)[key] = value
+    end,
+  })
+end
+return M

--- a/cli/src/lua/runtime.rs
+++ b/cli/src/lua/runtime.rs
@@ -140,7 +140,24 @@ impl LuaRuntime {
     /// - Lua state creation fails
     /// - Primitive registration fails
     pub fn new() -> Result<Self> {
-        let lua = Lua::new();
+        // Plugins run in the user trust tier (full pty/fs/process/http/webrtc/secrets access).
+        // FFI is consistent with that posture — a malicious plugin can already shell out or
+        // exfiltrate via existing primitives. FFI is enabled explicitly so the trust-model
+        // decision is visible at code-review time and so plugins can use
+        // `require('vendor.sqlite')` for persistence.
+        //
+        // SAFETY: `Lua::new()` creates a VM in "safe" mode which rejects loading FFI even
+        // via `load_std_libs(StdLib::FFI)`. `Lua::unsafe_new_with(ALL_SAFE | FFI, ...)`
+        // marks the VM unsafe and loads the normal safe stdlibs plus FFI — deliberately
+        // excluding `StdLib::DEBUG`, which would permit hook/upvalue manipulation we
+        // don't need. The trust decision is made here; downstream code treats the VM
+        // identically.
+        let lua = unsafe {
+            Lua::unsafe_new_with(
+                mlua::StdLib::ALL_SAFE | mlua::StdLib::FFI,
+                mlua::LuaOptions::default(),
+            )
+        };
 
         // Determine base path for Lua scripts
         let base_path = Self::resolve_base_path();
@@ -302,8 +319,11 @@ impl LuaRuntime {
         // - {base}/hub/?.lua - hub modules (state, hooks, loader)
         // - {base}/plugins/?.lua - user plugins
         // - {base}/plugins/?/init.lua - user plugin packages
+        // `{base}/vendor/?.lua` + `{base}/vendor/?/init.lua` let vendored modules
+        // (e.g. `vendor/sqlite/`) use their upstream-native internal requires
+        // (`require "sqlite.utils"`) without rewriting every call site.
         let new_path = format!(
-            "{path}/?.lua;{path}/?/init.lua;{path}/lib/?.lua;{path}/handlers/?.lua;{path}/hub/?.lua;{path}/plugins/?.lua;{path}/plugins/?/init.lua;{current}",
+            "{path}/?.lua;{path}/?/init.lua;{path}/lib/?.lua;{path}/handlers/?.lua;{path}/hub/?.lua;{path}/plugins/?.lua;{path}/plugins/?/init.lua;{path}/vendor/?.lua;{path}/vendor/?/init.lua;{current}",
             path = base_path.display(),
             current = current_path
         );
@@ -343,9 +363,11 @@ impl LuaRuntime {
             .get("path")
             .map_err(|e| anyhow!("Failed to get package.path: {e}"))?;
 
-        // Prepend so this path takes priority over paths already in package.path
+        // Prepend so this path takes priority over paths already in package.path.
+        // Vendor paths mirror those in `setup_package_path` so overlay layers
+        // can shadow vendored modules the same way they shadow first-party ones.
         let new_path = format!(
-            "{path}/?.lua;{path}/?/init.lua;{path}/lib/?.lua;{path}/handlers/?.lua;{path}/hub/?.lua;{path}/plugins/?.lua;{path}/plugins/?/init.lua;{current}",
+            "{path}/?.lua;{path}/?/init.lua;{path}/lib/?.lua;{path}/handlers/?.lua;{path}/hub/?.lua;{path}/plugins/?.lua;{path}/plugins/?/init.lua;{path}/vendor/?.lua;{path}/vendor/?/init.lua;{current}",
             path = additional_path.display(),
             current = current_path
         );
@@ -4314,7 +4336,14 @@ mod tests {
     /// hanging the caller — the previous value flows through unchanged.
     #[test]
     fn hook_call_enforces_timeout_on_runaway_interceptor() {
-        let lua = mlua::Lua::new();
+        // SAFETY: mirrors `LuaRuntime::new()` — unsafe-marked VM with safe
+        // stdlibs + FFI (no DEBUG) so tests exercise the production configuration.
+        let lua = unsafe {
+            mlua::Lua::unsafe_new_with(
+                mlua::StdLib::ALL_SAFE | mlua::StdLib::FFI,
+                mlua::LuaOptions::default(),
+            )
+        };
         load_hooks_module(&lua);
 
         // Register an interceptor that spins forever. Use a small timeout so
@@ -4353,7 +4382,14 @@ mod tests {
     /// data — the timeout must not interfere with the fast path.
     #[test]
     fn hook_call_fast_interceptor_is_unaffected() {
-        let lua = mlua::Lua::new();
+        // SAFETY: mirrors `LuaRuntime::new()` — unsafe-marked VM with safe
+        // stdlibs + FFI (no DEBUG) so tests exercise the production configuration.
+        let lua = unsafe {
+            mlua::Lua::unsafe_new_with(
+                mlua::StdLib::ALL_SAFE | mlua::StdLib::FFI,
+                mlua::LuaOptions::default(),
+            )
+        };
         load_hooks_module(&lua);
 
         lua.load(
@@ -4379,7 +4415,14 @@ mod tests {
     /// later interceptors still run on it.
     #[test]
     fn hook_call_chain_continues_after_timeout() {
-        let lua = mlua::Lua::new();
+        // SAFETY: mirrors `LuaRuntime::new()` — unsafe-marked VM with safe
+        // stdlibs + FFI (no DEBUG) so tests exercise the production configuration.
+        let lua = unsafe {
+            mlua::Lua::unsafe_new_with(
+                mlua::StdLib::ALL_SAFE | mlua::StdLib::FFI,
+                mlua::LuaOptions::default(),
+            )
+        };
         load_hooks_module(&lua);
 
         // Priority ordering: higher priority runs first. The spinner runs

--- a/cli/tests/sqlite_lua_smoke_test.rs
+++ b/cli/tests/sqlite_lua_smoke_test.rs
@@ -1,0 +1,97 @@
+//! End-to-end smoke test for the vendored `sqlite.lua` binding.
+//!
+//! Verifies the PR B.1 acceptance criteria:
+//!   1. LuaJIT FFI is loadable on the main Lua state.
+//!   2. `require("vendor.sqlite")` resolves to our vendored `init.lua`.
+//!   3. The luv-removal patches compile cleanly.
+//!   4. An in-memory sqlite database round-trips basic CRUD.
+//!
+//! This test does NOT exercise the `plugin.db{}` wrapper — that's PR B.2.
+//! It deliberately bypasses `LuaRuntime::new()` so the test stays focused on
+//! the vendored library and doesn't drag in every hub primitive.
+
+#![expect(
+    clippy::unwrap_used,
+    reason = "test-code brevity"
+)]
+
+use std::path::PathBuf;
+
+use mlua::{Lua, LuaOptions, StdLib};
+
+/// Build a bare LuaJIT VM with FFI loaded and `package.path` configured so
+/// `require("vendor.sqlite")` resolves against `cli/lua/`.
+///
+/// This mirrors what `LuaRuntime::new()` does for the vendor search paths
+/// (see `setup_package_path`), minus all the primitive registrations the
+/// smoke test doesn't need.
+///
+/// SAFETY: `Lua::new()` marks the VM safe-mode and rejects `StdLib::FFI`.
+/// Production uses `Lua::unsafe_new_with(ALL_SAFE | FFI, ...)` — unsafe-marked
+/// VM with safe stdlibs plus FFI, excluding DEBUG. This test mirrors that
+/// configuration exactly so the vendored FFI path is exercised as-in-prod.
+fn new_vendor_lua() -> Lua {
+    let lua = unsafe { Lua::unsafe_new_with(StdLib::ALL_SAFE | StdLib::FFI, LuaOptions::default()) };
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let lua_base = manifest_dir.join("lua");
+    let base = lua_base.to_string_lossy();
+
+    // Mirror `LuaRuntime::setup_package_path`: vendor paths let
+    // `require("sqlite.defs")` (upstream internal) and
+    // `require("vendor.sqlite")` (public entry) both resolve against
+    // `cli/lua/vendor/sqlite/`.
+    let package: mlua::Table = lua.globals().get("package").unwrap();
+    let current_path: String = package.get("path").unwrap();
+    let new_path = format!(
+        "{base}/?.lua;{base}/?/init.lua;{base}/vendor/?.lua;{base}/vendor/?/init.lua;{current_path}"
+    );
+    package.set("path", new_path).unwrap();
+
+    lua
+}
+
+#[test]
+fn ffi_stdlib_is_loaded() {
+    let lua = new_vendor_lua();
+    let loaded: bool = lua
+        .load(r#"local ffi = require('ffi'); return ffi ~= nil and type(ffi.load) == 'function'"#)
+        .eval()
+        .expect("ffi should be requireable");
+    assert!(loaded, "FFI stdlib should expose ffi.load");
+}
+
+#[test]
+fn vendor_sqlite_module_resolves() {
+    let lua = new_vendor_lua();
+    let resolves: bool = lua
+        .load(r#"local m = require('vendor.sqlite'); return type(m) == 'table'"#)
+        .eval()
+        .expect("vendor.sqlite should load");
+    assert!(resolves, "require('vendor.sqlite') must return a table");
+}
+
+#[test]
+fn vendored_sqlite_lua_round_trips_in_memory_db() {
+    let lua = new_vendor_lua();
+    let ok: bool = lua
+        .load(
+            r#"
+            local sqlite = require('vendor.sqlite')
+            local db = sqlite.new(':memory:')
+            db:open()
+            db:eval('CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT)')
+            db:eval("INSERT INTO t (name) VALUES ('alice'), ('bob')")
+            local rows = db:eval('SELECT * FROM t ORDER BY id')
+            assert(type(rows) == 'table', 'eval should return a table for SELECT')
+            assert(#rows == 2, 'expected 2 rows, got ' .. tostring(#rows))
+            assert(rows[1].name == 'alice', 'row 1 name mismatch: ' .. tostring(rows[1].name))
+            assert(rows[2].name == 'bob', 'row 2 name mismatch: ' .. tostring(rows[2].name))
+            db:close()
+            return true
+            "#,
+        )
+        .eval()
+        .expect("in-memory sqlite round-trip");
+    assert!(ok);
+}


### PR DESCRIPTION
## Summary

**PR B.1**: mechanical low-risk split of the plugin persistence story. Vendors [sqlite.lua](https://github.com/kkharji/sqlite.lua) into `cli/lua/vendor/sqlite/`, enables LuaJIT FFI on the Lua VM, and adds a smoke test proving end-to-end load + CRUD. **No `plugin.db{}` public API yet** — that lands in PR B.2.

Rationale: per the design doc reviewed by the user, we're leaning into Neovim ecosystem alignment. sqlite.lua is the battle-tested Lua-native SQLite layer from Neovim-land. Vendoring locks against upstream drift; we don't take PRs from upstream, we bump the pin deliberately.

## What ships

### Vendored sqlite.lua (13 files, ~4091 LOC)

Pinned at commit [`50092d60`](https://github.com/kkharji/sqlite.lua/commit/50092d60feb242602d7578398c6eb53b4a8ffe7b) (master tip, 2025-03-14). Files live at `cli/lua/vendor/sqlite/`, mirroring upstream `lua/sqlite/` layout. MIT license preserved in `cli/lua/vendor/sqlite/LICENSE`.

### Patches documented in `cli/lua/vendor/sqlite/VENDOR_CHANGES.md`

4 files differ from upstream, all docs'd with upstream line numbers + reasons:
- `defs.lua` — remove `luv` require + Neovim `vim` check; replace `os_getenv`/`os_uname`/`HOMEBREW_PREFIX` with Lua built-ins (`os.getenv`, `jit.os`, `jit.arch`). Adds `BOTSTER_LIBSQLITE` env-var override (falls back to stock `LIBSQLITE`).
- `helpers.lua`, `tbl/cache.lua` — replace `luv.fs_stat` with our `fs.stat` primitive. `mtime` field absent so cache invalidation collapses to `db.modified` flag; sufficient for single-writer DBs.
- `utils.lua` — replace `luv.fs_realpath` with absolute-path passthrough (design doc option a). Latent gap for leading-dot relative paths; `plugin.db` always passes absolute so non-issue on current path.
- **Upstream typo fix** in `tbl/cache.lua`: `require "sql.utils"` → `require "sqlite.utils"`. `sql.utils` doesn't resolve anywhere; documented.

### FFI enable (trust expansion)

`cli/src/lua/runtime.rs`: `Lua::new()` → `Lua::unsafe_new_with(ALL_SAFE | FFI, ...)`. **Narrower than `unsafe_new()`** — excludes `StdLib::DEBUG` explicitly. Mirrored to 3 test-only constructors. Code comment documents the trust rationale: plugins already have `pty`/`fs`/`process`/`http`/`webrtc`/`secrets`; FFI doesn't meaningfully widen the attack surface.

### Smoke test

`cli/tests/sqlite_lua_smoke_test.rs` — 3 tests:
1. `ffi` global loads
2. `require('vendor.sqlite')` resolves
3. In-memory DB CREATE / INSERT / SELECT round-trip

### CI

Added explicit `libsqlite3-0` to `.github/workflows/ci.yml` `cli-test` Ubuntu job. Transitively present via Rails deps today, but making the dep visible is better.

### Attribution

New `NOTICES` at repo root crediting sqlite.lua (MIT) and ghostty (already used elsewhere, finally attributed).

## Codex audit

**Verdict: APPROVED**, zero findings.

Key verifications:
- FFI bitmask correctness: `ALL_SAFE | FFI` = `(1<<30)-1 | 1<<30` = includes FFI, excludes DEBUG. Verified against mlua 0.10.5 source.
- Vendored drift: codex fetched upstream at the pinned commit and did a file-by-file byte comparison. ONLY the 4 documented patch files + the typo fix differ. Everything else is verbatim.
- `VENDOR_CHANGES.md` matches the real diffs (spot-checked against `defs.lua`, `helpers.lua`, `tbl/cache.lua`).
- FFI disable would cause test 1 to fail. `require('vendor.sqlite')` regression would cause test 2 to fail. luv patch regression would cause test 3 to fail.

**Non-blocking note from codex**: `release.yml`'s `ci-gate` job also runs `cli/test.sh` on Ubuntu but doesn't explicitly install `libsqlite3-0`. Not a current-path failure (transitively present), but worth a follow-up one-liner for parity.

## Test plan

- [x] `./test.sh` (CLI) — 1312 pass (+3 smoke), 1 ignored
- [x] `npx vitest --run` — 172/172 unchanged
- [x] `bin/rails test` — 442/0/0
- [x] `bin/rails test:system` — 37/37 pass
- [x] `bin/rubocop` — clean
- [x] Codex APPROVED on `62c1b5ad`
- [ ] If CI flags `release.yml ci-gate` without libsqlite3, add the package install there too (one-line)

## Files (18 changed, new vendor tree + minor wiring)

- `cli/lua/vendor/sqlite/*` — 13 vendored files + LICENSE + VENDOR_CHANGES.md (new)
- `cli/src/lua/runtime.rs` — FFI enable + package.path addition
- `cli/tests/sqlite_lua_smoke_test.rs` — new
- `.github/workflows/ci.yml` — libsqlite3-0 install
- `NOTICES` — new

## Next up: PR B.2

Will ship `plugin.db{}` public API, migration runner, 14+ integration tests, and `plugin_unloading` hook. Design doc complete; dispatch after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)