### PR TITLE
feat(cli): plugin.db{} persistence API with declarative schema + migrations

### DIFF
--- a/cli/lua/hub/init.lua
+++ b/cli/lua/hub/init.lua
@@ -50,6 +50,14 @@ safe_require("lib.accessory")
 safe_require("lib.commands")
 _G.mcp = safe_require("lib.mcp")
 
+-- Install plugin.db{} BEFORE any plugin loads. This wires `_G.plugin.db`
+-- and subscribes to `plugin_unloading` + `shutdown` so cached sqlite
+-- connections close cleanly on reload and on hub exit.
+local plugin_db_mod = safe_require("lib.plugin_db")
+if plugin_db_mod and type(plugin_db_mod.install) == "function" then
+    plugin_db_mod.install()
+end
+
 -- Phase 2b UI DSL transport libs. `lib.action` is the registry for
 -- browser-emitted UI action envelopes; `lib.layout_broadcast` wraps
 -- `web_layout.render(...)` with per-surface hash dedup. Exposing them as

--- a/cli/lua/hub/loader.lua
+++ b/cli/lua/hub/loader.lua
@@ -444,6 +444,11 @@ function M.unload_plugin(name)
     local module_key = "plugin." .. name
     local mod = package.loaded[module_key]
 
+    -- Notify subscribers (e.g. lib.plugin_db) that the plugin is about to be
+    -- torn down so they can release resources keyed by plugin name. Fires
+    -- BEFORE the plugin's own `_before_unload` so shared infra runs first.
+    hooks.notify("plugin_unloading", { name = name })
+
     -- Lifecycle: let the plugin clean up before being removed
     if mod and type(mod) == "table" and mod._before_unload then
         local ok, err = pcall(mod._before_unload)

--- a/cli/lua/lib/plugin_db.lua
+++ b/cli/lua/lib/plugin_db.lua
@@ -1,0 +1,679 @@
+-- cli/lua/lib/plugin_db.lua
+--
+-- plugin.db() — public persistence API for Lua plugins.
+--
+-- Plugin authors call `plugin.db{...}` once during plugin load. The module:
+--   1. Resolves the db path: {config.data_dir()}/plugins/<plugin_name>/db.sqlite
+--      (or ":memory:" if `memory = true` was declared).
+--   2. Opens a sqlite connection via vendored `sqlite.lua` and applies default
+--      PRAGMAs (WAL, synchronous=NORMAL, foreign_keys=ON, busy_timeout=5000).
+--   3. Runs the declared schema + migrations by comparing `PRAGMA user_version`
+--      to `spec.version`. Upgrade path applies additive changes + the author's
+--      `migrations[N]` step function, per step, inside a single transaction.
+--      Steady-state (current == target) reconciles additive changes only and
+--      errors on non-additive drift (removed/retyped/nullability-changed cols).
+--   4. Attaches per-model `sqlite.tbl` wrappers to the db instance so plugin
+--      code writes `db.messages:insert{...}` / `db.messages:get{...}`.
+--   5. Caches the db handle keyed by plugin name so hot-reloading a plugin
+--      reuses the connection instead of leaking fds.
+--
+-- See `docs/plugin-authoring.md` for the author-facing guide.
+
+local M = {}
+
+local sqlite = require("vendor.sqlite")
+-- Require the tbl constructor directly — `sqlite.tbl` (through the base
+-- module's __index) resolves to `db:tbl`, a method closure, not the class.
+local sqlite_tbl = require("sqlite.tbl")
+local sqlite_db_class = require("sqlite.db")
+local sqlite_defs = require("sqlite.defs")
+
+-- Patch `sqlite.defs.wrap_stmts` once at module load. Upstream's implementation
+-- wraps its callback in bare BEGIN/COMMIT; when the user calls
+-- `db:execute(fn)` and `fn` invokes `db.t:insert{...}` (which internally calls
+-- `wrap_stmts`) the inner BEGIN errors quietly and the inner COMMIT then
+-- closes the user's outer transaction — silently defeating rollback. We swap
+-- in a shim that skips its own BEGIN/COMMIT when a connection is already
+-- inside a plugin-db user transaction, so the outer tx controls commit/rollback.
+-- `sqlite.defs` installs a metatable __index that falls through to FFI
+-- symbols (`sqlite3_<k>`) for any missing key; use rawget to probe for our
+-- patch sentinel without accidentally triggering a bogus symbol lookup.
+if not rawget(sqlite_defs, "__plugin_db_wrap_patched") then
+    local original_wrap_stmts = rawget(sqlite_defs, "wrap_stmts")
+    -- Set of connection pointers currently inside `db:execute(fn)`.
+    -- Keyed by `tostring(conn_ptr)` so the FFI cdata comparison works.
+    local in_user_tx = {}
+    rawset(sqlite_defs, "__plugin_db_user_tx_set", in_user_tx)
+    rawset(sqlite_defs, "wrap_stmts", function(conn_ptr, fn)
+        if in_user_tx[tostring(conn_ptr)] then
+            return fn()
+        end
+        return original_wrap_stmts(conn_ptr, fn)
+    end)
+    rawset(sqlite_defs, "__plugin_db_wrap_patched", true)
+end
+local USER_TX_SET = rawget(sqlite_defs, "__plugin_db_user_tx_set")
+
+-- ============================================================================
+-- Module state
+-- ============================================================================
+
+-- Cache: plugin_name -> { wrapper = raw_db, memory = bool, uri = string }.
+-- Survives hot-reload so the sqlite fd + FFI state is reused instead of leaked.
+local db_handles = {}
+
+-- Guard against re-subscribing to hooks/events on module reload.
+local subscribed = false
+
+-- Default PRAGMAs applied after open. Applied in declaration order.
+-- (journal_mode must come first so subsequent pragmas take effect in WAL.)
+local DEFAULT_PRAGMAS = {
+    { "journal_mode",  "WAL" },
+    { "synchronous",   "NORMAL" },
+    { "foreign_keys",  "ON" },
+    { "busy_timeout",  "5000" },
+}
+
+-- Model names that would collide with sqlite.db methods. `wrap_db` rawsets
+-- each model as an instance field; if a plugin declared `models.close`, the
+-- rawset would shadow `sqlite.db:close` and break the shutdown/close path
+-- (FFI fd leak). Reserved set keeps the wrapper's own surface predictable too.
+local RESERVED_MODEL_NAMES = {
+    close = true, open = true, with_open = true, isopen = true, isclose = true,
+    status = true, eval = true, execute = true, exists = true, create = true,
+    drop = true, schema = true, insert = true, update = true, delete = true,
+    select = true, tbl = true, table = true, extend = true, new = true,
+    lib = true, flags = true,
+    uri = true, conn = true, closed = true, opts = true, modified = true,
+    created = true, tbl_schemas = true, db = true,
+}
+
+-- ============================================================================
+-- Schema DSL normalization
+-- ============================================================================
+
+--- Normalize a column declaration into a full table form.
+--
+-- Accepts:
+--   true                             -> { type = "integer", required = true, primary = true }
+--   "text"                           -> { type = "text" }
+--   { "text", required = true, ... } -> { type = "text", required = true, ... }
+--   { type = "text", ... }           -> { type = "text", ... }
+--
+-- @param decl any Column declaration from spec.models.<tbl>.<col>
+-- @return table Normalized declaration
+local function normalize_col(decl)
+    if decl == true then
+        return { type = "integer", required = true, primary = true }
+    elseif type(decl) == "string" then
+        return { type = decl }
+    elseif type(decl) ~= "table" then
+        error(string.format("plugin.db: invalid column declaration type=%s", type(decl)), 2)
+    end
+
+    local n = {}
+    for k, v in pairs(decl) do
+        if k == 1 and n.type == nil then
+            n.type = v
+        else
+            n[k] = v
+        end
+    end
+    -- "pk" alias for "primary"
+    if n.pk and n.primary == nil then n.primary = n.pk end
+    return n
+end
+
+--- Build a single column definition string for CREATE TABLE / ADD COLUMN.
+-- Mirrors sqlite.lua's `opts_to_str` subset, scoped to what our DSL supports.
+-- @param col_name string
+-- @param decl any Raw column declaration
+-- @return string e.g. "body text not null default ''"
+local function column_def(col_name, decl)
+    local n = normalize_col(decl)
+    local parts = { col_name }
+    if n.type and n.type ~= "" then
+        table.insert(parts, n.type)
+    end
+    if n.unique then table.insert(parts, "unique") end
+    if n.required then table.insert(parts, "not null") end
+    if n.primary then table.insert(parts, "primary key") end
+    if n.default ~= nil then
+        local v = n.default
+        local rendered
+        if type(v) == "string" then
+            -- Wrap in single quotes, doubling any internal single quotes.
+            rendered = "'" .. v:gsub("'", "''") .. "'"
+        elseif type(v) == "boolean" then
+            rendered = v and "1" or "0"
+        else
+            rendered = tostring(v)
+        end
+        table.insert(parts, "default " .. rendered)
+    end
+    if n.reference then
+        table.insert(parts, ("references %s"):format(n.reference:gsub("%.", "(") .. ")"))
+    end
+    if n.on_delete then
+        table.insert(parts, "on delete " .. n.on_delete)
+    end
+    if n.on_update then
+        table.insert(parts, "on update " .. n.on_update)
+    end
+    return table.concat(parts, " ")
+end
+
+--- Build a CREATE TABLE statement for a model schema.
+-- @param tbl_name string
+-- @param schema table { col_name = decl, ... }
+-- @return string SQL
+local function create_table_sql(tbl_name, schema)
+    local cols = {}
+    for col_name, col_decl in pairs(schema) do
+        table.insert(cols, column_def(col_name, col_decl))
+    end
+    return string.format(
+        "CREATE TABLE IF NOT EXISTS %s (%s)",
+        tbl_name, table.concat(cols, ", ")
+    )
+end
+
+-- ============================================================================
+-- Schema introspection
+-- ============================================================================
+
+--- Does a table with this name exist in sqlite_master?
+local function table_exists(db, tbl_name)
+    local rows = db:eval(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        tbl_name
+    )
+    return type(rows) == "table" and #rows > 0
+end
+
+--- Return the columns of a table keyed by name:
+-- { [col_name] = { name, type, required, primary, default } }.
+local function existing_cols(db, tbl_name)
+    local rows = db:eval(string.format("PRAGMA table_info(%s)", tbl_name))
+    local cols = {}
+    if type(rows) == "table" then
+        for _, r in ipairs(rows) do
+            cols[r.name] = {
+                name = r.name,
+                type = (r.type or ""):lower(),
+                required = r.notnull == 1,
+                primary = (r.pk or 0) > 0,
+                default = r.dflt_value,
+            }
+        end
+    end
+    return cols
+end
+
+-- ============================================================================
+-- Additive schema reconciliation
+-- ============================================================================
+
+--- Reconcile declared `models` against the live schema.
+--
+-- In `strict=true` mode (steady-state, current_version == target_version) any
+-- non-additive drift raises a Lua error with a printable diff. In `strict=false`
+-- mode (inside an upgrade step, BEFORE the author's migration fn runs) only
+-- additive changes are applied — non-additive mismatches are silently tolerated
+-- because the migration fn about to run is expected to resolve them.
+--
+-- Additive changes: new tables (CREATE TABLE IF NOT EXISTS), new columns
+-- (ALTER TABLE ADD COLUMN). Adding a NOT NULL column without a default is
+-- rejected regardless of strict flag since sqlite itself cannot apply it.
+local function reconcile_additive(db, plugin_name, models, strict)
+    models = models or {}
+    local mismatches = {}
+    local add_col_issues = {}
+    local changes = {}
+
+    for tbl_name, schema_in in pairs(models) do
+        if not table_exists(db, tbl_name) then
+            table.insert(changes, {
+                kind = "create_table",
+                tbl = tbl_name,
+                sql = create_table_sql(tbl_name, schema_in),
+            })
+        else
+            local existing = existing_cols(db, tbl_name)
+            local declared = {}
+            for col_name, col_decl in pairs(schema_in) do
+                declared[col_name] = normalize_col(col_decl)
+            end
+
+            -- Shared cols: check type + nullability
+            for col_name, decl in pairs(declared) do
+                local ex = existing[col_name]
+                if ex then
+                    local decl_type = (decl.type or ""):lower()
+                    if decl_type ~= "" and decl_type ~= ex.type then
+                        table.insert(mismatches, string.format(
+                            "  %s.%s: type changed (%s -> %s)",
+                            tbl_name, col_name, ex.type, decl_type
+                        ))
+                    end
+                    local decl_req = decl.required == true
+                    if decl_req ~= ex.required then
+                        table.insert(mismatches, string.format(
+                            "  %s.%s: nullability changed (%s -> %s)",
+                            tbl_name, col_name,
+                            ex.required and "required" or "nullable",
+                            decl_req and "required" or "nullable"
+                        ))
+                    end
+                end
+            end
+
+            -- Removed cols: existing but not declared
+            for col_name, _ in pairs(existing) do
+                if not declared[col_name] then
+                    table.insert(mismatches, string.format(
+                        "  %s.%s: column was removed",
+                        tbl_name, col_name
+                    ))
+                end
+            end
+
+            -- Added cols: declared but not existing
+            for col_name, decl in pairs(declared) do
+                if not existing[col_name] then
+                    if decl.required and decl.default == nil then
+                        table.insert(add_col_issues, string.format(
+                            "  %s.%s: required column with no default (sqlite refuses ADD COLUMN NOT NULL without DEFAULT)",
+                            tbl_name, col_name
+                        ))
+                    else
+                        table.insert(changes, {
+                            kind = "add_column",
+                            tbl = tbl_name,
+                            col = col_name,
+                            sql = string.format(
+                                "ALTER TABLE %s ADD COLUMN %s",
+                                tbl_name, column_def(col_name, schema_in[col_name])
+                            ),
+                        })
+                    end
+                end
+            end
+        end
+    end
+
+    if strict and #mismatches > 0 then
+        error(string.format(
+            "plugin.db: plugin '%s' schema mismatch.\nNon-additive changes detected:\n%s\nTo apply these changes, bump version and provide migrations[new_version] = function(db) ... end.",
+            plugin_name, table.concat(mismatches, "\n")
+        ), 0)
+    end
+
+    if #add_col_issues > 0 then
+        error(string.format(
+            "plugin.db: plugin '%s' cannot add required column(s) without a default value:\n%s\nOptions:\n  - Add a default: col = { 'text', required = true, default = '' }\n  - Make it optional: col = { 'text' }\n  - Bump version and backfill via migrations[next] = function(db) ... end",
+            plugin_name, table.concat(add_col_issues, "\n")
+        ), 0)
+    end
+
+    for _, change in ipairs(changes) do
+        db:eval(change.sql)
+        if change.kind == "create_table" then
+            log.info(string.format(
+                "db.additive_change plugin=%s table=%s kind=new_table",
+                plugin_name, change.tbl
+            ))
+        elseif change.kind == "add_column" then
+            log.info(string.format(
+                "db.additive_change plugin=%s table=%s col=%s kind=new_column",
+                plugin_name, change.tbl, change.col
+            ))
+        end
+    end
+end
+
+-- ============================================================================
+-- Migration runner
+-- ============================================================================
+
+--- Read the current `user_version` PRAGMA for the db. 0 when unset (fresh db).
+local function read_user_version(db)
+    local rows = db:eval("PRAGMA user_version")
+    if type(rows) == "table" and rows[1] and rows[1].user_version then
+        return rows[1].user_version
+    end
+    return 0
+end
+
+--- Run migration steps `current+1 .. target`, one transaction per step.
+-- Each step: non-strict additive reconcile -> author's migrations[i] (if any)
+-- -> PRAGMA user_version = i. On Lua error inside the step, ROLLBACK and
+-- propagate with step diagnostics; the db stays at the previous version.
+--
+-- Marks the connection as "in user tx" via USER_TX_SET for the duration of
+-- each step. This tells the patched `wrap_stmts` to skip its own BEGIN/COMMIT
+-- if the migration fn happens to call `db:insert/update/delete` (which would
+-- otherwise commit the outer tx early and break rollback-on-error).
+local function run_migrations(db, plugin_name, spec, current, target)
+    local ptr_key = tostring(db.conn)
+    for i = current + 1, target do
+        local step_start_ms = (os.clock() * 1000)
+        db:eval("BEGIN")
+        USER_TX_SET[ptr_key] = true
+        local ok, err = pcall(function()
+            -- Apply additive changes for version i (non-strict: the migration fn
+            -- about to run may legitimately DROP/rename columns; let it run
+            -- without the steady-state strictness check).
+            reconcile_additive(db, plugin_name, spec.models or {}, false)
+
+            -- Invoke the author's migration function for this step.
+            local mig_fn = spec.migrations and spec.migrations[i]
+            if mig_fn then
+                if type(mig_fn) ~= "function" then
+                    error(string.format(
+                        "migrations[%d] must be a function, got %s",
+                        i, type(mig_fn)
+                    ), 0)
+                end
+                mig_fn(db)
+            end
+
+            -- Record the new version. PRAGMA user_version is a valid pragma in
+            -- sqlite.lua's whitelist; it persists to the db header.
+            db:eval(string.format("PRAGMA user_version = %d", i))
+        end)
+        USER_TX_SET[ptr_key] = nil
+
+        if not ok then
+            pcall(function() db:eval("ROLLBACK") end)
+            error(string.format(
+                "plugin.db: plugin '%s' migration %d (v%d -> v%d) failed: %s\nTransaction rolled back. Database remains at v%d.\nFix the migration function and reload the plugin.",
+                plugin_name, i, i - 1, i, tostring(err), i - 1
+            ), 0)
+        end
+        db:eval("COMMIT")
+
+        local dur_ms = math.floor((os.clock() * 1000) - step_start_ms + 0.5)
+        log.info(string.format(
+            "db.migration plugin=%s applied=%d->%d duration_ms=%d",
+            plugin_name, i - 1, i, dur_ms
+        ))
+    end
+end
+
+--- Apply the declared version target to a freshly opened (or cached) db.
+-- Dispatches between downgrade error / upgrade migrations / steady-state
+-- reconcile based on the current user_version.
+--
+-- After a successful upgrade, runs the STRICT reconcile one more time against
+-- the final `spec.models`. This catches the case where a plugin declared a
+-- new table/column in `models` but forgot to create it in `migrations[N]` —
+-- without this pass the first load silently succeeds with a broken schema and
+-- the error only surfaces on the next load.
+local function apply_schema(db, plugin_name, spec, uri)
+    local target = spec.version or 1
+    local current = read_user_version(db)
+
+    if target < current then
+        error(string.format(
+            "plugin.db: plugin '%s' declares version=%d but database is at version %d.\nDowngrades are not supported.\nOptions:\n  - Bump the declared version to %d or higher.\n  - Delete %s to reset and start fresh.",
+            plugin_name, target, current, current, uri
+        ), 0)
+    elseif target > current then
+        run_migrations(db, plugin_name, spec, current, target)
+        -- Final validation pass against the declared models: strict.
+        reconcile_additive(db, plugin_name, spec.models or {}, true)
+    else
+        -- current == target: steady-state reconcile is strict.
+        reconcile_additive(db, plugin_name, spec.models or {}, true)
+    end
+end
+
+-- ============================================================================
+-- Wrapper: attach tbl proxies + override execute for transaction-fn semantics.
+-- ============================================================================
+
+--- Attach per-model `sqlite.tbl` wrappers as instance fields on the raw db so
+--- plugin code writes `db.messages:insert{...}` etc. Also override `execute`
+--- to accept a function arg (BEGIN / pcall / COMMIT-or-ROLLBACK). Idempotent:
+--- safe to call multiple times on the same db (e.g. on hot-reload after the
+--- plugin's models set changed).
+local function wrap_db(raw_db, spec)
+    -- Attach tbl proxies for every declared model. rawset bypasses the
+    -- sqlite_db class metatable's __index, so instance reads of `db.messages`
+    -- resolve to our tbl before falling back to sqlite.db methods.
+    local models = spec.models or {}
+    for tbl_name, _ in pairs(models) do
+        if rawget(raw_db, tbl_name) == nil then
+            -- Deliberately pass `nil` for schema so sqlite.tbl skips its own
+            -- auto-alter logic. Our migration runner has already ensured the
+            -- physical schema; the tbl wrapper is purely an ergonomic front.
+            rawset(raw_db, tbl_name, sqlite_tbl.new(tbl_name, nil, raw_db))
+        end
+    end
+
+    -- Install execute(fn) transaction semantics (idempotent). The sentinel
+    -- marker lets us distinguish the wrapped function from sqlite.lua's
+    -- class-level execute across hot-reloads.
+    --
+    -- Upstream sqlite.lua's `db:execute(string)` does single-statement exec;
+    -- its internal `wrap_stmts` helper wraps in BEGIN/COMMIT but does NOT
+    -- rollback on error, leaving the transaction open on failure. Our override
+    -- adds proper pcall + ROLLBACK semantics for the function form while
+    -- passing strings through to the upstream implementation unchanged.
+    if rawget(raw_db, "__plugin_db_execute_wrapped") ~= true then
+        local class_execute = sqlite_db_class.execute
+        rawset(raw_db, "execute", function(self, arg)
+            if type(arg) ~= "function" then
+                return class_execute(self, arg)
+            end
+            local ptr_key = tostring(self.conn)
+            USER_TX_SET[ptr_key] = true
+            class_execute(self, "BEGIN")
+            local ok, result = pcall(arg, self)
+            if ok then
+                class_execute(self, "COMMIT")
+                USER_TX_SET[ptr_key] = nil
+                return result
+            else
+                pcall(class_execute, self, "ROLLBACK")
+                USER_TX_SET[ptr_key] = nil
+                error(result, 0)
+            end
+        end)
+        rawset(raw_db, "__plugin_db_execute_wrapped", true)
+    end
+
+    return raw_db
+end
+
+-- ============================================================================
+-- Handle lifecycle (close, shutdown, plugin_unloading)
+-- ============================================================================
+
+local function close_and_evict(name)
+    local entry = db_handles[name]
+    if not entry then return end
+    pcall(function() entry.wrapper:close() end)
+    db_handles[name] = nil
+end
+
+function M._on_plugin_unloading(payload)
+    if type(payload) == "table" and type(payload.name) == "string" then
+        close_and_evict(payload.name)
+    end
+end
+
+function M.shutdown_all()
+    local names = {}
+    for name, _ in pairs(db_handles) do table.insert(names, name) end
+    for _, name in ipairs(names) do close_and_evict(name) end
+end
+
+-- Test-only: reset module state so each test starts clean.
+function M._reset_for_tests()
+    M.shutdown_all()
+    db_handles = {}
+    subscribed = false
+end
+
+-- ============================================================================
+-- Main entry: plugin.db{}
+-- ============================================================================
+
+--- Resolve the database URI for a plugin.
+-- memory = true   -> ":memory:"
+-- else            -> "{config.data_dir()}/plugins/<plugin_name>/db.sqlite"
+-- The parent directory is created with fs.mkdir (mkdir -p semantics).
+local function resolve_uri(plugin_name, memory)
+    if memory then
+        return ":memory:"
+    end
+    if not (config and type(config.data_dir) == "function") then
+        error(string.format(
+            "plugin.db: cannot resolve config.data_dir() for plugin '%s'",
+            plugin_name
+        ), 0)
+    end
+    local data_dir = config.data_dir()
+    if not data_dir or data_dir == "" then
+        error(string.format(
+            "plugin.db: config.data_dir() returned nil/empty for plugin '%s'",
+            plugin_name
+        ), 0)
+    end
+    local plugin_dir = data_dir .. "/plugins/" .. plugin_name
+    local ok, err = fs.mkdir(plugin_dir)
+    if not ok then
+        error(string.format(
+            "plugin.db: failed to create plugin data directory '%s': %s",
+            plugin_dir, tostring(err)
+        ), 0)
+    end
+    return plugin_dir .. "/db.sqlite"
+end
+
+--- Public API: `plugin.db{ version=..., models=..., migrations=..., memory=... }`.
+-- Returns the sqlite db object with tbl wrappers attached. Cached per plugin
+-- name so hot-reload reuses the fd.
+function M.db(spec)
+    spec = spec or {}
+    local plugin_name = rawget(_G, "_loading_plugin_name")
+    if type(plugin_name) ~= "string" or plugin_name == "" then
+        error(
+            "plugin.db: must be called during plugin load, not from callbacks or deferred code.\nCache the db handle at the top of your plugin.lua:\n  local db = plugin.db{ ... }\n  -- then reference `db` inside callbacks, hooks, MCP tool handlers, etc.",
+            2
+        )
+    end
+
+    -- Reject model names that would shadow sqlite.db instance methods. This
+    -- is a load-time check so the error message mentions the plugin by name
+    -- instead of surfacing as a mysterious "attempt to call nil" later.
+    if type(spec.models) == "table" then
+        local reserved = {}
+        for tbl_name, _ in pairs(spec.models) do
+            if RESERVED_MODEL_NAMES[tbl_name] then
+                table.insert(reserved, "'" .. tbl_name .. "'")
+            end
+        end
+        if #reserved > 0 then
+            error(string.format(
+                "plugin.db: plugin '%s' declared model(s) with reserved name(s): %s.\nThese names collide with sqlite.db methods (close/eval/insert/...) and would break the db handle if attached.\nRename the model(s) to something plural or domain-specific (e.g. 'messages' instead of 'insert').",
+                plugin_name, table.concat(reserved, ", ")
+            ), 2)
+        end
+    end
+
+    local memory = spec.memory == true
+
+    -- Cache hit: reuse connection, reconcile against the latest spec.
+    local cached = db_handles[plugin_name]
+    if cached then
+        if cached.memory ~= memory then
+            error(string.format(
+                "plugin.db: plugin '%s' re-declared with memory=%s but existing handle was opened with memory=%s.\nChange one of the declarations. The handle is cached per plugin name across hot-reloads.",
+                plugin_name, tostring(memory), tostring(cached.memory)
+            ), 2)
+        end
+        -- Re-apply schema (reconcile or migrate forward as needed) and re-wrap
+        -- so any newly declared models pick up tbl proxies.
+        apply_schema(cached.wrapper, plugin_name, spec, cached.uri)
+        return wrap_db(cached.wrapper, spec)
+    end
+
+    -- Fresh open.
+    local uri = resolve_uri(plugin_name, memory)
+    local raw = sqlite.new(uri)
+    local open_ok, open_err = pcall(function() raw:open() end)
+    if not open_ok then
+        error(string.format(
+            "plugin.db: plugin '%s' failed to open db at '%s': %s",
+            plugin_name, uri, tostring(open_err)
+        ), 2)
+    end
+
+    -- Defaults first, then any plugin-supplied overrides.
+    for _, pair in ipairs(DEFAULT_PRAGMAS) do
+        pcall(function()
+            raw:eval(string.format("PRAGMA %s = %s", pair[1], pair[2]))
+        end)
+    end
+    if type(spec.pragmas) == "table" then
+        for k, v in pairs(spec.pragmas) do
+            pcall(function()
+                raw:eval(string.format("PRAGMA %s = %s", k, tostring(v)))
+            end)
+        end
+    end
+
+    -- Run schema apply BEFORE caching so a migration failure leaves no stale
+    -- handle. If apply_schema errors, the db is closed here and the error
+    -- propagates — the loader marks the plugin errored.
+    local schema_ok, schema_err = pcall(apply_schema, raw, plugin_name, spec, uri)
+    if not schema_ok then
+        pcall(function() raw:close() end)
+        error(schema_err, 0)
+    end
+
+    local wrapped = wrap_db(raw, spec)
+    db_handles[plugin_name] = {
+        wrapper = wrapped,
+        memory = memory,
+        uri = uri,
+    }
+    return wrapped
+end
+
+-- ============================================================================
+-- Installation: wires _G.plugin.db + subscribes to lifecycle hooks.
+-- ============================================================================
+
+--- Install `_G.plugin.db` and subscribe to `plugin_unloading` + `shutdown` so
+--- cached handles close cleanly. Called once from `cli/lua/hub/init.lua`
+--- BEFORE any plugin is loaded.
+function M.install()
+    _G.plugin = _G.plugin or {}
+    _G.plugin.db = M.db
+
+    if subscribed then return end
+
+    -- plugin_unloading: hook notified by hub/loader.lua before a plugin's
+    -- registry entry is torn down. Closes the plugin's cached db handle.
+    if hooks and type(hooks.on) == "function" then
+        hooks.on("plugin_unloading", "plugin_db.close_handle", function(payload)
+            M._on_plugin_unloading(payload)
+        end)
+    end
+
+    -- Hub shutdown event: fires before the Rust side drops the Lua runtime.
+    -- Close all cached handles so sqlite FFI pointers release cleanly.
+    if events and type(events.on) == "function" then
+        events.on("shutdown", function()
+            M.shutdown_all()
+        end)
+    end
+
+    subscribed = true
+end
+
+return M

--- a/cli/lua/lib/plugin_db.lua
+++ b/cli/lua/lib/plugin_db.lua
@@ -27,6 +27,7 @@ local sqlite = require("vendor.sqlite")
 local sqlite_tbl = require("sqlite.tbl")
 local sqlite_db_class = require("sqlite.db")
 local sqlite_defs = require("sqlite.defs")
+local hub_state = require("hub.state")
 
 -- Patch `sqlite.defs.wrap_stmts` once at module load. Upstream's implementation
 -- wraps its callback in bare BEGIN/COMMIT; when the user calls
@@ -55,23 +56,41 @@ end
 local USER_TX_SET = rawget(sqlite_defs, "__plugin_db_user_tx_set")
 
 -- ============================================================================
--- Module state
+-- Module state — backed by hub.state so it survives module hot-reload
 -- ============================================================================
+--
+-- `lib.plugin_db` is a hot-reloadable library module; core handlers reload it
+-- via `loader.reload("lib.plugin_db")` when the file changes. Plain local
+-- tables here would be torn down on reload, leaking cached sqlite fds and
+-- detaching the `_G.plugin.db` global from the current closure. Storing state
+-- in `hub.state` (which is a protected module — never reloaded) gives us the
+-- same table identity across reload so both the old and new module closures
+-- operate on one cache.
+--
+-- Cache shape: plugin_name -> { wrapper = raw_db, memory = bool, uri = string }
+local db_handles = hub_state.get("plugin_db.handles", {})
 
--- Cache: plugin_name -> { wrapper = raw_db, memory = bool, uri = string }.
--- Survives hot-reload so the sqlite fd + FFI state is reused instead of leaked.
-local db_handles = {}
+-- Guards against adding duplicate `events.on("shutdown", ...)` subscriptions
+-- on repeated install() calls. `hooks.on` is replaceable by name so it doesn't
+-- need its own guard. Wrapped in a table so the module-level local keeps a
+-- stable reference to the (mutable) state across reloads.
+local events_subscribed = hub_state.get("plugin_db.events_subscribed", { value = false })
 
--- Guard against re-subscribing to hooks/events on module reload.
-local subscribed = false
-
--- Default PRAGMAs applied after open. Applied in declaration order.
--- (journal_mode must come first so subsequent pragmas take effect in WAL.)
-local DEFAULT_PRAGMAS = {
+-- Default PRAGMAs, split by criticality.
+--
+-- `busy_timeout` MUST run first so any subsequent statement that grabs a WAL
+-- or file lock inherits the 5 s waiter. `journal_mode = WAL` and
+-- `foreign_keys = ON` are load-bearing — silently running without them is a
+-- correctness bug, so those fail LOUDLY. `synchronous = NORMAL` is a perf
+-- pragma only; a failure downgrades us to whatever sqlite's default is and
+-- is logged at WARN but does not refuse the plugin load.
+local CRITICAL_PRAGMAS = {
+    { "busy_timeout",  "5000" },  -- first: subsequent pragmas inherit the timeout
     { "journal_mode",  "WAL" },
-    { "synchronous",   "NORMAL" },
     { "foreign_keys",  "ON" },
-    { "busy_timeout",  "5000" },
+}
+local OPTIONAL_PRAGMAS = {
+    { "synchronous",   "NORMAL" },
 }
 
 -- Model names that would collide with sqlite.db methods. `wrap_db` rawsets
@@ -510,11 +529,13 @@ function M.shutdown_all()
     for _, name in ipairs(names) do close_and_evict(name) end
 end
 
--- Test-only: reset module state so each test starts clean.
+-- Test-only: reset module state so each test starts clean. The underlying
+-- hub.state tables are emptied in place so their identity is preserved for
+-- any closures that captured them.
 function M._reset_for_tests()
     M.shutdown_all()
-    db_handles = {}
-    subscribed = false
+    for k in pairs(db_handles) do db_handles[k] = nil end
+    events_subscribed.value = false
 end
 
 -- ============================================================================
@@ -612,17 +633,47 @@ function M.db(spec)
         ), 2)
     end
 
-    -- Defaults first, then any plugin-supplied overrides.
-    for _, pair in ipairs(DEFAULT_PRAGMAS) do
-        pcall(function()
+    -- Critical PRAGMAs: any failure is a correctness bug, refuse the load.
+    -- busy_timeout goes first so the WAL lock-taking statements inherit it.
+    for _, pair in ipairs(CRITICAL_PRAGMAS) do
+        local pragma_ok, pragma_err = pcall(function()
             raw:eval(string.format("PRAGMA %s = %s", pair[1], pair[2]))
         end)
+        if not pragma_ok then
+            pcall(function() raw:close() end)
+            error(string.format(
+                "plugin.db: plugin '%s' failed to apply PRAGMA %s = %s: %s",
+                plugin_name, pair[1], pair[2], tostring(pragma_err)
+            ), 2)
+        end
     end
+
+    -- Optional PRAGMAs: perf knobs only; warn but continue on failure.
+    for _, pair in ipairs(OPTIONAL_PRAGMAS) do
+        local pragma_ok, pragma_err = pcall(function()
+            raw:eval(string.format("PRAGMA %s = %s", pair[1], pair[2]))
+        end)
+        if not pragma_ok then
+            log.warn(string.format(
+                "plugin.db: PRAGMA %s = %s failed for plugin '%s' (non-fatal): %s",
+                pair[1], pair[2], plugin_name, tostring(pragma_err)
+            ))
+        end
+    end
+
+    -- Author-supplied overrides. These are plugin-managed, so a typo or bad
+    -- value shouldn't refuse the plugin load — warn and continue.
     if type(spec.pragmas) == "table" then
         for k, v in pairs(spec.pragmas) do
-            pcall(function()
+            local pragma_ok, pragma_err = pcall(function()
                 raw:eval(string.format("PRAGMA %s = %s", k, tostring(v)))
             end)
+            if not pragma_ok then
+                log.warn(string.format(
+                    "plugin.db: user PRAGMA %s = %s failed for plugin '%s' (non-fatal): %s",
+                    k, tostring(v), plugin_name, tostring(pragma_err)
+                ))
+            end
         end
     end
 
@@ -650,30 +701,67 @@ end
 
 --- Install `_G.plugin.db` and subscribe to `plugin_unloading` + `shutdown` so
 --- cached handles close cleanly. Called once from `cli/lua/hub/init.lua`
---- BEFORE any plugin is loaded.
+--- BEFORE any plugin is loaded AND again on `_after_reload` so the fresh
+--- module's closures replace the stale ones.
+--
+-- Idempotency notes:
+--   * `_G.plugin.db = M.db` is assigned every call so reloads swap to the
+--     fresh closure (without this, the global keeps pointing at the old
+--     module's `db_handles` — invisible edits + the stale-closure bug codex
+--     flagged).
+--   * `hooks.on(event, name, fn)` replaces the previous entry with the same
+--     name, so repeated calls are safe and keep the handler up-to-date with
+--     the latest closure.
+--   * `events.on("shutdown", fn)` has no by-name replacement in Lua. We
+--     guard on `events_subscribed.value` (backed by hub.state) so exactly
+--     one subscription persists across reloads. The subscribed callback
+--     resolves `M` lazily via `package.loaded` so it always runs the latest
+--     `shutdown_all` against the shared `db_handles` table.
 function M.install()
     _G.plugin = _G.plugin or {}
     _G.plugin.db = M.db
 
-    if subscribed then return end
-
-    -- plugin_unloading: hook notified by hub/loader.lua before a plugin's
-    -- registry entry is torn down. Closes the plugin's cached db handle.
+    -- Every install() re-registers the hook so the fresh closure wins.
     if hooks and type(hooks.on) == "function" then
         hooks.on("plugin_unloading", "plugin_db.close_handle", function(payload)
-            M._on_plugin_unloading(payload)
+            local mod = package.loaded["lib.plugin_db"] or M
+            mod._on_plugin_unloading(payload)
         end)
     end
 
-    -- Hub shutdown event: fires before the Rust side drops the Lua runtime.
-    -- Close all cached handles so sqlite FFI pointers release cleanly.
-    if events and type(events.on) == "function" then
+    if events and type(events.on) == "function" and not events_subscribed.value then
         events.on("shutdown", function()
-            M.shutdown_all()
+            local mod = package.loaded["lib.plugin_db"] or M
+            mod.shutdown_all()
         end)
+        events_subscribed.value = true
     end
+end
 
-    subscribed = true
+-- ============================================================================
+-- Hot-reload lifecycle
+-- ============================================================================
+-- Core Lua libraries under `lib/` are hot-reloaded by
+-- `handlers.module_watcher`. `loader.reload("lib.plugin_db")` drops the old
+-- module from `package.loaded` and re-`require`s this file. Without the hook
+-- below, the old `_G.plugin.db` closure (and the subscribed hook callbacks)
+-- keep pointing at the torn-down module. `_after_reload` reinstalls the
+-- global + replaces the hook callback with the fresh closure.
+--
+-- The underlying db handle cache lives in `hub.state` so it's preserved
+-- across the reload cycle — no fds are leaked and no plugin's data is lost.
+
+function M._before_reload()
+    if log and log.info then
+        log.info("lib.plugin_db reloading (handles + subscriptions persist via hub.state)")
+    end
+end
+
+function M._after_reload()
+    M.install()
+    if log and log.info then
+        log.info("lib.plugin_db reloaded (_G.plugin.db and plugin_unloading hook re-wired)")
+    end
 end
 
 return M

--- a/cli/tests/plugin_db_test.rs
+++ b/cli/tests/plugin_db_test.rs
@@ -1017,18 +1017,27 @@ fn foreign_keys_enforced_via_on_delete_cascade() {
 }
 
 // ============================================================================
-// 17. test_wal_mode_active (nice-to-have)
+// 17. test_wal_mode_active — all four default pragmas applied (contract test)
 // ============================================================================
+//
+// Codex flagged two PRAGMA-related concerns:
+//   (a) `busy_timeout` must be set BEFORE any WAL/lock-taking pragma so
+//       subsequent statements inherit the waiter.
+//   (b) Every default PRAGMA must actually take effect; we can't rely on the
+//       journal_mode + foreign_keys spot-check that the earlier test did.
+//
+// This test queries all four and asserts each one reflects the configured
+// value, so a regression in ordering or silent-swallow would trip.
 
 #[test]
-fn default_pragmas_set_wal_and_foreign_keys() {
+fn all_default_pragmas_applied_in_correct_order() {
     let _lock = lock_env();
     let tmp = TempDir::new().unwrap();
     set_config_dir(tmp.path());
     let lua = new_test_lua();
     set_loading_plugin(&lua, "pragmas");
 
-    let (jmode, fkeys): (String, i64) = lua
+    let (jmode, fkeys, busy_timeout, sync_mode): (String, i64, i64, i64) = lua
         .load(
             r#"
             local db = plugin.db{
@@ -1037,16 +1046,27 @@ fn default_pragmas_set_wal_and_foreign_keys() {
                     t = { id = true },
                 },
             }
-            local jm = db:eval("PRAGMA journal_mode")
-            local fk = db:eval("PRAGMA foreign_keys")
-            return jm[1].journal_mode, fk[1].foreign_keys
+            local jm      = db:eval("PRAGMA journal_mode")
+            local fk      = db:eval("PRAGMA foreign_keys")
+            local busy    = db:eval("PRAGMA busy_timeout")
+            local sync    = db:eval("PRAGMA synchronous")
+            return jm[1].journal_mode, fk[1].foreign_keys,
+                   busy[1].timeout, sync[1].synchronous
             "#,
         )
         .eval()
-        .expect("query pragmas");
+        .expect("query all four default pragmas");
 
     assert_eq!(jmode, "wal", "journal_mode should be WAL for file-backed db");
-    assert_eq!(fkeys, 1, "foreign_keys should be ON");
+    assert_eq!(fkeys, 1, "foreign_keys should be ON (= 1)");
+    assert_eq!(
+        busy_timeout, 5000,
+        "busy_timeout should be 5000 ms — must be set BEFORE WAL so contention is bounded"
+    );
+    assert_eq!(
+        sync_mode, 1,
+        "synchronous should be NORMAL (= 1), not FULL (= 2)"
+    );
 }
 
 // ============================================================================
@@ -1113,7 +1133,118 @@ fn redeclaring_memory_flag_is_rejected() {
 }
 
 // ============================================================================
-// 20. test_reserved_model_name_rejected
+// 20. test_lib_plugin_db_hot_reload_preserves_handle_and_rewires_global
+// ============================================================================
+//
+// Core lib/*.lua modules are hot-reloaded by `handlers.module_watcher` via
+// `loader.reload("lib.plugin_db")`. Codex flagged that without `_before_reload`
+// / `_after_reload` hooks:
+//   (a) `_G.plugin.db` stays bound to the old module's closure, so edits to
+//       plugin_db.lua are invisible at runtime.
+//   (b) the cached db handles (module-level local) vanish, silently leaking
+//       sqlite fds.
+//
+// This test simulates the reload by clearing `package.loaded["lib.plugin_db"]`
+// and calling the reload lifecycle hooks the same way `hub.loader.reload`
+// does, then verifies:
+//   - a plugin that already had a db open before reload can still call
+//     `plugin.db{...}` and get the SAME cached handle (sentinel preserved),
+//   - previously inserted data is still readable,
+//   - `_G.plugin.db` points at the NEW module's closure (added a marker to
+//     the fresh module during reload and confirm the global saw it).
+
+#[test]
+fn lib_plugin_db_hot_reload_preserves_handle_and_rewires_global() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "hotmod");
+
+    // Initial load: open db, stash a sentinel on the instance, insert a row.
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = { logs = {
+                id = true,
+                msg = { 'text', required = true, default = '' },
+            } },
+        }
+        rawset(db, '__pre_reload_sentinel', 'before-reload')
+        db.logs:insert{ msg = 'survived' }
+        "#,
+    )
+    .exec()
+    .expect("pre-reload load + insert");
+
+    // Simulate `loader.reload("lib.plugin_db")` — the same sequence
+    // `cli/lua/hub/loader.lua:M.reload` runs for a lib module:
+    //   1. call `_before_reload` on the current module
+    //   2. drop it from package.loaded
+    //   3. require() it again (fresh evaluation)
+    //   4. call `_after_reload` on the new module
+    lua.load(
+        r#"
+        local old = package.loaded['lib.plugin_db']
+        assert(type(old._before_reload) == 'function',
+               'plugin_db must export _before_reload')
+        old._before_reload()
+        package.loaded['lib.plugin_db'] = nil
+
+        local fresh = require('lib.plugin_db')
+        assert(fresh ~= old, 'require after drop should return a new module table')
+        assert(type(fresh._after_reload) == 'function',
+               'plugin_db must export _after_reload')
+        fresh._after_reload()
+        _G._reloaded_module = fresh
+        "#,
+    )
+    .exec()
+    .expect("simulate hot-reload lifecycle");
+
+    // Post-reload: the global must point at the fresh module, the handle
+    // must be reused (same sentinel), and the row must still be visible.
+    let (global_rewired, same_handle, row_survived): (bool, bool, bool) = lua
+        .load(
+            r#"
+            local db2 = plugin.db{
+                version = 1,
+                models = { logs = {
+                    id = true,
+                    msg = { 'text', required = true, default = '' },
+                } },
+            }
+            local same_handle = rawget(db2, '__pre_reload_sentinel') == 'before-reload'
+
+            -- Global points at the fresh module's closure, not the old one.
+            local global_rewired = (plugin.db == _G._reloaded_module.db)
+
+            local rows = db2.logs:get{}
+            local row_survived = (#rows == 1 and rows[1].msg == 'survived')
+
+            return global_rewired, same_handle, row_survived
+            "#,
+        )
+        .eval()
+        .expect("post-reload assertions");
+
+    assert!(
+        global_rewired,
+        "_G.plugin.db must point at the FRESH module after reload — edits to plugin_db.lua wouldn't take effect otherwise"
+    );
+    assert!(
+        same_handle,
+        "cached sqlite connection must survive module hot-reload — otherwise we leak fds and break in-flight plugin state"
+    );
+    assert!(
+        row_survived,
+        "previously inserted row must still be readable through the new module's closure"
+    );
+}
+
+// ============================================================================
+// 21. test_reserved_model_name_rejected
 // ============================================================================
 //
 // A plugin that declared a model named after a sqlite.db method (e.g. `close`,

--- a/cli/tests/plugin_db_test.rs
+++ b/cli/tests/plugin_db_test.rs
@@ -1,0 +1,1309 @@
+//! Integration tests for `cli/lua/lib/plugin_db.lua` — the public `plugin.db{}`
+//! persistence API for Lua plugins.
+//!
+//! The wrapper layers onto the vendored `sqlite.lua` (PR B.1) and provides:
+//!   * path derivation under `{data_dir}/plugins/<name>/db.sqlite`
+//!   * default PRAGMAs (WAL + NORMAL sync + foreign_keys + busy_timeout)
+//!   * declarative schema reconciliation (additive adds vs strict mismatches)
+//!   * a migration runner driven by `PRAGMA user_version`
+//!   * per-plugin handle cache (hot-reload safe)
+//!   * a `memory = true` shortcut that skips file I/O for tests
+//!
+//! These tests exercise the public surface end-to-end: they spin up a real
+//! LuaJIT VM with FFI, register the `fs`/`log`/`config` primitives, and load
+//! `require('lib.plugin_db').install()` the same way `hub/init.lua` does in
+//! production. Each test isolates via its own `BOTSTER_CONFIG_DIR` tempdir.
+//!
+//! Run with: `cd cli && ./test.sh -- plugin_db`.
+
+#![expect(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::needless_borrows_for_generic_args,
+    clippy::redundant_closure_for_method_calls,
+    clippy::too_many_lines,
+    reason = "test-code brevity: assertion-heavy tests that exercise a large API"
+)]
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use mlua::{Lua, LuaOptions, StdLib, Table};
+use tempfile::TempDir;
+
+/// Serialises tests that mutate process env (`BOTSTER_CONFIG_DIR`). Each test
+/// takes this lock before setting env and dropping the VM.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn cli_manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+/// Build a LuaJIT VM wired up the same way a production hub builds its one,
+/// minus primitives we don't need here.
+///
+/// Mirrors `LuaRuntime::new` for the bits that matter to `plugin.db`:
+///   * `unsafe_new_with(ALL_SAFE | FFI)` — required so `vendor.sqlite` can load.
+///   * `fs.mkdir` — used to create `plugins/<name>/` parent dirs.
+///   * `log.{info,warn,error,debug}` — used by the migration runner.
+///   * `config.data_dir()` — resolves to `$BOTSTER_CONFIG_DIR` or `~/.botster`.
+///   * `package.path` wired to `cli/lua/` so `require('vendor.sqlite')` and
+///     `require('lib.plugin_db')` resolve.
+fn new_test_lua() -> Lua {
+    let lua = unsafe { Lua::unsafe_new_with(StdLib::ALL_SAFE | StdLib::FFI, LuaOptions::default()) };
+
+    botster::lua::primitives::fs::register(&lua).expect("register fs");
+    botster::lua::primitives::log::register(&lua).expect("register log");
+    botster::lua::primitives::config::register(&lua).expect("register config");
+
+    // Stub hooks + events. Real implementations live elsewhere; plugin_db.lua
+    // only needs `hooks.on(event, name, fn)` and `events.on(event, fn)` to
+    // subscribe. The stubs record subscriptions so tests can fire them.
+    let globals = lua.globals();
+    lua.load(
+        r#"
+        _G.hooks = {
+            _subs = {},
+            on = function(event, name, fn)
+                _G.hooks._subs[event] = _G.hooks._subs[event] or {}
+                _G.hooks._subs[event][name] = fn
+            end,
+            notify = function(event, payload)
+                local subs = _G.hooks._subs[event] or {}
+                for _, fn in pairs(subs) do fn(payload) end
+            end,
+        }
+        _G.events = {
+            _subs = {},
+            on = function(event, fn)
+                _G.events._subs[event] = _G.events._subs[event] or {}
+                table.insert(_G.events._subs[event], fn)
+                return tostring(event) .. "-" .. tostring(#_G.events._subs[event])
+            end,
+            fire = function(event)
+                for _, fn in ipairs(_G.events._subs[event] or {}) do fn() end
+            end,
+        }
+        "#,
+    )
+    .exec()
+    .expect("install hooks/events stubs");
+
+    let lua_base = cli_manifest_dir().join("lua");
+    let base = lua_base.to_string_lossy();
+    let package: Table = globals.get("package").unwrap();
+    let current_path: String = package.get("path").unwrap();
+    let new_path = format!(
+        "{base}/?.lua;{base}/?/init.lua;{base}/lib/?.lua;{base}/vendor/?.lua;{base}/vendor/?/init.lua;{current_path}"
+    );
+    package.set("path", new_path).unwrap();
+
+    lua.load(
+        r#"
+        local plugin_db = require('lib.plugin_db')
+        plugin_db._reset_for_tests()
+        plugin_db.install()
+        "#,
+    )
+    .exec()
+    .expect("install plugin_db");
+
+    lua
+}
+
+/// Set the loading-plugin name for the duration of the test. Mirrors what the
+/// real plugin loader does around a plugin's `init.lua` chunk.
+fn set_loading_plugin(lua: &Lua, name: &str) {
+    lua.globals().set("_loading_plugin_name", name).unwrap();
+}
+
+fn set_config_dir(dir: &std::path::Path) {
+    // SAFETY: Tests serialise via ENV_LOCK so no other thread observes the
+    // mutation concurrently.
+    unsafe { std::env::set_var("BOTSTER_CONFIG_DIR", dir) };
+}
+
+// ============================================================================
+// 1. test_db_open_creates_file
+// ============================================================================
+
+#[test]
+fn db_open_creates_file_under_data_dir() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "messaging");
+
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                messages = {
+                    id = true,
+                    body = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        assert(db ~= nil, "plugin.db returned nil")
+        "#,
+    )
+    .exec()
+    .expect("open fresh db");
+
+    let expected = tmp.path().join("plugins/messaging/db.sqlite");
+    assert!(
+        expected.exists(),
+        "expected db file at {}",
+        expected.display()
+    );
+}
+
+// ============================================================================
+// 2. test_insert_and_get
+// ============================================================================
+
+#[test]
+fn insert_and_get_round_trip_preserves_types() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "insert_get");
+
+    let (author, body, channel, ts): (String, String, i64, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        channel_id = { 'integer', required = true },
+                        author = { 'text', required = true },
+                        body = { 'text', required = true },
+                        created_at = { 'integer', required = true },
+                    },
+                },
+            }
+            db.messages:insert{
+                channel_id = 7,
+                author = 'jason',
+                body = 'hello world',
+                created_at = 1776900000,
+            }
+            local rows = db.messages:get{}
+            assert(#rows == 1, 'expected 1 row, got ' .. tostring(#rows))
+            local r = rows[1]
+            return r.author, r.body, r.channel_id, r.created_at
+            "#,
+        )
+        .eval()
+        .expect("insert + get");
+
+    assert_eq!(author, "jason");
+    assert_eq!(body, "hello world");
+    assert_eq!(channel, 7);
+    assert_eq!(ts, 1_776_900_000);
+}
+
+// ============================================================================
+// 3. test_where_clause
+// ============================================================================
+
+#[test]
+fn get_with_where_filters_rows() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "wherec");
+
+    let count: i64 = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        channel_id = { 'integer', required = true },
+                        body = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            for i = 1, 5 do
+                db.messages:insert{ channel_id = (i % 2) + 1, body = 'm' .. i }
+            end
+            local rows = db.messages:get{ where = { channel_id = 2 } }
+            return #rows
+            "#,
+        )
+        .eval()
+        .expect("filter by where");
+
+    // Channels assigned 2,1,2,1,2 (i=1..5 → (i%2)+1). Three in channel 2.
+    assert_eq!(count, 3);
+}
+
+// ============================================================================
+// 4. test_update
+// ============================================================================
+
+#[test]
+fn update_changes_matching_row_only() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "updt");
+
+    let (total, edited, other): (i64, String, String) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        body = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            db.messages:insert{ body = 'a' }
+            db.messages:insert{ body = 'b' }
+            db.messages:update{ where = { id = 1 }, set = { body = 'edited' } }
+            local all = db.messages:get{}
+            local by_id = {}
+            for _, r in ipairs(all) do by_id[r.id] = r.body end
+            return #all, by_id[1], by_id[2]
+            "#,
+        )
+        .eval()
+        .expect("update");
+
+    assert_eq!(total, 2, "update must not insert extra rows");
+    assert_eq!(edited, "edited");
+    assert_eq!(other, "b");
+}
+
+// ============================================================================
+// 5. test_remove
+// ============================================================================
+
+#[test]
+fn remove_deletes_matching_rows() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "rm");
+
+    let (before, after): (i64, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        body = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            db.messages:insert{ body = 'a' }
+            db.messages:insert{ body = 'b' }
+            db.messages:insert{ body = 'c' }
+            local before = #db.messages:get{}
+            db.messages:remove{ id = 2 }
+            local after = #db.messages:get{}
+            return before, after
+            "#,
+        )
+        .eval()
+        .expect("remove");
+
+    assert_eq!(before, 3);
+    assert_eq!(after, 2);
+}
+
+// ============================================================================
+// 6. test_transaction (db:execute(fn) rollback semantics)
+// ============================================================================
+
+#[test]
+fn execute_fn_rolls_back_on_error() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "tx");
+
+    let (rolled_back, later_insert_works): (bool, bool) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    counters = {
+                        id = true,
+                        name = { 'text', required = true },
+                    },
+                },
+            }
+
+            -- attempt a transaction that errors mid-way
+            local ok = pcall(function()
+                db:execute(function(self)
+                    self.counters:insert{ name = 'should_rollback' }
+                    error('deliberate abort')
+                end)
+            end)
+            assert(not ok, 'pcall should have seen the error')
+
+            -- connection must still be usable: insert outside a tx
+            local rows_before = db.counters:get{}
+            local rolled_back = (#rows_before == 0)
+
+            local insert_ok, _ = pcall(function()
+                db.counters:insert{ name = 'fresh' }
+            end)
+            return rolled_back, insert_ok
+            "#,
+        )
+        .eval()
+        .expect("transaction rollback");
+
+    assert!(rolled_back, "error inside db:execute(fn) must ROLLBACK");
+    assert!(
+        later_insert_works,
+        "connection must be usable after rollback (tx not stuck open)"
+    );
+}
+
+// ============================================================================
+// 7. test_eval_escape_hatch (raw SQL with placeholders)
+// ============================================================================
+
+#[test]
+fn eval_raw_sql_with_placeholders() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "ev");
+
+    let (row_body, count): (String, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        body = { 'text', required = true },
+                    },
+                },
+            }
+            db:eval("INSERT INTO messages (body) VALUES (?)", 'via_eval')
+            local rows = db:eval("SELECT body FROM messages WHERE body = ?", 'via_eval')
+            return rows[1].body, #rows
+            "#,
+        )
+        .eval()
+        .expect("eval with args");
+
+    assert_eq!(row_body, "via_eval");
+    assert_eq!(count, 1);
+}
+
+// ============================================================================
+// 8. test_additive_migration_new_column — file-backed
+// ============================================================================
+
+#[test]
+fn reload_with_new_column_adds_it_and_preserves_data() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "addcol");
+
+    // First load: only `body`.
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                messages = {
+                    id = true,
+                    body = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        db.messages:insert{ body = 'first' }
+        db.messages:insert{ body = 'second' }
+        "#,
+    )
+    .exec()
+    .expect("v1 load");
+
+    // Simulate hot-reload: clear the cached handle (new Lua VM, same data dir).
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "addcol");
+
+    let (count, author_for_first, author_for_second): (i64, String, String) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        body = { 'text', required = true, default = '' },
+                        -- New column, still nullable with a default.
+                        author = { 'text', default = 'anonymous' },
+                    },
+                },
+            }
+            local rows = db.messages:get{}
+            local by_body = {}
+            for _, r in ipairs(rows) do by_body[r.body] = r.author end
+            return #rows, by_body['first'] or '', by_body['second'] or ''
+            "#,
+        )
+        .eval()
+        .expect("v1 reload with new column");
+
+    assert_eq!(count, 2, "existing rows must survive ADD COLUMN");
+    assert_eq!(author_for_first, "anonymous");
+    assert_eq!(author_for_second, "anonymous");
+}
+
+// ============================================================================
+// 9. test_additive_migration_new_table
+// ============================================================================
+
+#[test]
+fn reload_with_new_table_creates_it_and_preserves_original() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "addtbl");
+
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                messages = {
+                    id = true,
+                    body = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        db.messages:insert{ body = 'original' }
+        "#,
+    )
+    .exec()
+    .expect("v1 load");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "addtbl");
+
+    let (messages_count, channels_count, first_msg_body): (i64, i64, String) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                version = 1,
+                models = {
+                    messages = {
+                        id = true,
+                        body = { 'text', required = true, default = '' },
+                    },
+                    channels = {
+                        id = true,
+                        name = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            db.channels:insert{ name = 'general' }
+            local msgs = db.messages:get{}
+            return #msgs, #db.channels:get{}, msgs[1].body
+            "#,
+        )
+        .eval()
+        .expect("reload with new table");
+
+    assert_eq!(messages_count, 1);
+    assert_eq!(channels_count, 1);
+    assert_eq!(first_msg_body, "original");
+}
+
+// ============================================================================
+// 10. test_version_bump_runs_migration_fn (+ idempotent on subsequent reload)
+// ============================================================================
+
+#[test]
+fn version_bump_runs_migration_fn_exactly_once() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "versbump");
+
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                messages = {
+                    id = true,
+                    author = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        db.messages:insert{ author = 'JASON' }
+        db.messages:insert{ author = 'Alice' }
+        "#,
+    )
+    .exec()
+    .expect("v1 load");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "versbump");
+
+    // Reload at v2 with a migration that lowercases author. Track invocations
+    // in a persistent registry file so a second reload at v2 can prove it did
+    // not re-run. (A simple in-Lua counter resets across VMs.)
+    let (a_lower, b_lower, run_count_first): (String, String, i64) = lua
+        .load(
+            r#"
+            _G._mig_runs = 0
+            local db = plugin.db{
+                version = 2,
+                models = {
+                    messages = {
+                        id = true,
+                        author = { 'text', required = true, default = '' },
+                    },
+                },
+                migrations = {
+                    [2] = function(db)
+                        _G._mig_runs = _G._mig_runs + 1
+                        db:eval("UPDATE messages SET author = lower(author)")
+                    end,
+                },
+            }
+            local rows = db.messages:get{}
+            local by_id = {}
+            for _, r in ipairs(rows) do by_id[r.id] = r.author end
+            return by_id[1] or '', by_id[2] or '', _G._mig_runs
+            "#,
+        )
+        .eval()
+        .expect("v1 -> v2 migration");
+    assert_eq!(a_lower, "jason");
+    assert_eq!(b_lower, "alice");
+    assert_eq!(run_count_first, 1, "migration[2] should run exactly once");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "versbump");
+
+    let run_count_second: i64 = lua
+        .load(
+            r#"
+            _G._mig_runs = 0
+            plugin.db{
+                version = 2,
+                models = {
+                    messages = {
+                        id = true,
+                        author = { 'text', required = true, default = '' },
+                    },
+                },
+                migrations = {
+                    [2] = function(db)
+                        _G._mig_runs = _G._mig_runs + 1
+                    end,
+                },
+            }
+            return _G._mig_runs
+            "#,
+        )
+        .eval()
+        .expect("reload at v2 should not re-run migration");
+    assert_eq!(
+        run_count_second, 0,
+        "reload at same version must not re-run migrations"
+    );
+}
+
+// ============================================================================
+// 11. test_user_version_honored (reload at same version = no migration)
+// ============================================================================
+
+#[test]
+fn reload_at_same_version_does_not_re_run_migrations() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "uvhonored");
+
+    lua.load(
+        r#"
+        plugin.db{
+            version = 3,
+            models = {
+                t = {
+                    id = true,
+                    v = { 'integer', required = true, default = 0 },
+                },
+            },
+            migrations = {
+                [2] = function(db) db:eval("UPDATE t SET v = v + 1") end,
+                [3] = function(db) db:eval("UPDATE t SET v = v + 10") end,
+            },
+        }
+        "#,
+    )
+    .exec()
+    .expect("initial load at v3 (fresh db, migrations 1->2->3 apply)");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "uvhonored");
+
+    let uv: i64 = lua
+        .load(
+            r#"
+            local ran = {}
+            local db = plugin.db{
+                version = 3,
+                models = {
+                    t = {
+                        id = true,
+                        v = { 'integer', required = true, default = 0 },
+                    },
+                },
+                migrations = {
+                    [2] = function() ran[#ran+1] = 2 end,
+                    [3] = function() ran[#ran+1] = 3 end,
+                },
+            }
+            assert(#ran == 0, 'no migrations should re-run: ' .. table.concat(ran, ','))
+            local r = db:eval("PRAGMA user_version")
+            return r[1].user_version
+            "#,
+        )
+        .eval::<i64>()
+        .expect("read user_version on reload");
+    assert_eq!(uv, 3, "user_version should be 3 after reload at v3");
+}
+
+// ============================================================================
+// 12. test_downgrade_refused
+// ============================================================================
+
+#[test]
+fn declaring_lower_version_refuses_load() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "downgr");
+
+    lua.load(
+        r#"
+        plugin.db{
+            version = 3,
+            models = {
+                t = {
+                    id = true,
+                    v = { 'integer', required = true, default = 0 },
+                },
+            },
+        }
+        "#,
+    )
+    .exec()
+    .expect("initial v3 load");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "downgr");
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{
+                version = 2,
+                models = {
+                    t = {
+                        id = true,
+                        v = { 'integer', required = true, default = 0 },
+                    },
+                },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("downgrade must raise");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Downgrades are not supported") && msg.contains("version=2")
+            && msg.contains("database is at version 3"),
+        "downgrade error message missing expected content: {msg}"
+    );
+}
+
+// ============================================================================
+// 13. test_non_additive_mismatch_refused
+// ============================================================================
+
+#[test]
+fn non_additive_change_without_version_bump_is_refused() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "strict");
+
+    lua.load(
+        r#"
+        plugin.db{
+            version = 1,
+            models = {
+                t = {
+                    id = true,
+                    name = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        "#,
+    )
+    .exec()
+    .expect("initial v1 load");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "strict");
+
+    let err = lua
+        .load(
+            r#"
+            -- Change `name` from text to integer at the same version.
+            plugin.db{
+                version = 1,
+                models = {
+                    t = {
+                        id = true,
+                        name = { 'integer', required = true, default = 0 },
+                    },
+                },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("non-additive change must raise");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Non-additive changes detected")
+            && msg.contains("type changed")
+            && msg.contains("text")
+            && msg.contains("integer"),
+        "schema-mismatch message missing expected content: {msg}"
+    );
+}
+
+// ============================================================================
+// 14. test_hot_reload_preserves_data_and_handle (same connection reused)
+// ============================================================================
+
+#[test]
+fn hot_reload_same_vm_reuses_handle_and_data() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "hot");
+
+    // Open the db, stash a sentinel on the returned instance, insert a row.
+    // Then call `plugin.db{...}` again — with the same plugin name — and
+    // confirm the returned value IS the same sentinel-bearing table.
+    let (same_handle, row_count): (bool, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                version = 1,
+                models = {
+                    things = {
+                        id = true,
+                        label = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            rawset(db, '__test_marker', 'original')
+            db.things:insert{ label = 'one' }
+
+            local db2 = plugin.db{
+                version = 1,
+                models = {
+                    things = {
+                        id = true,
+                        label = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            local same = rawget(db2, '__test_marker') == 'original'
+            local rows = db2.things:get{}
+            return same, #rows
+            "#,
+        )
+        .eval()
+        .expect("hot reload");
+
+    assert!(
+        same_handle,
+        "plugin.db should return the SAME db instance for a repeated call with the same plugin name"
+    );
+    assert_eq!(
+        row_count, 1,
+        "data must persist across the second plugin.db call"
+    );
+}
+
+// ============================================================================
+// 15. test_plugin_disable_keeps_file (nice-to-have)
+// ============================================================================
+
+#[test]
+fn plugin_unload_evicts_cache_but_leaves_file() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "disabletest");
+
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                kv = {
+                    id = true,
+                    k = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        db.kv:insert{ k = 'hello' }
+        "#,
+    )
+    .exec()
+    .expect("initial load + insert");
+
+    let expected = tmp.path().join("plugins/disabletest/db.sqlite");
+    assert!(expected.exists(), "db file must be created on first load");
+
+    // Simulate hub/loader firing plugin_unloading — our stub's `hooks.notify`
+    // invokes subscribed callbacks, which the install() wiring routes to
+    // plugin_db._on_plugin_unloading.
+    lua.load(r#"hooks.notify('plugin_unloading', { name = 'disabletest' })"#)
+        .exec()
+        .expect("fire plugin_unloading");
+
+    assert!(
+        expected.exists(),
+        "db file must persist through an unload (we just evict the cached handle)"
+    );
+
+    // Re-require the plugin and confirm the row is still there.
+    lua.load(
+        r#"
+        local db = plugin.db{
+            version = 1,
+            models = {
+                kv = {
+                    id = true,
+                    k = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        local rows = db.kv:get{}
+        assert(#rows == 1 and rows[1].k == 'hello',
+               'row must survive eviction + re-open')
+        "#,
+    )
+    .exec()
+    .expect("reopen after unload");
+}
+
+// ============================================================================
+// 16. test_foreign_keys_enforced (nice-to-have)
+// ============================================================================
+
+#[test]
+fn foreign_keys_enforced_via_on_delete_cascade() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "fk");
+
+    let (before, after): (i64, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    channels = {
+                        id = true,
+                        name = { 'text', required = true, default = '' },
+                    },
+                    messages = {
+                        id = true,
+                        channel_id = {
+                            'integer',
+                            required = true,
+                            reference = 'channels.id',
+                            on_delete = 'cascade',
+                        },
+                        body = { 'text', required = true, default = '' },
+                    },
+                },
+            }
+            db.channels:insert{ name = 'general' }
+            db.messages:insert{ channel_id = 1, body = 'hi' }
+            db.messages:insert{ channel_id = 1, body = 'hello' }
+            local before = #db.messages:get{}
+            db.channels:remove{ id = 1 }
+            local after = #db.messages:get{}
+            return before, after
+            "#,
+        )
+        .eval()
+        .expect("FK cascade");
+
+    assert_eq!(before, 2);
+    assert_eq!(
+        after, 0,
+        "ON DELETE CASCADE should have removed both messages when parent channel was deleted"
+    );
+}
+
+// ============================================================================
+// 17. test_wal_mode_active (nice-to-have)
+// ============================================================================
+
+#[test]
+fn default_pragmas_set_wal_and_foreign_keys() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "pragmas");
+
+    let (jmode, fkeys): (String, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                version = 1,
+                models = {
+                    t = { id = true },
+                },
+            }
+            local jm = db:eval("PRAGMA journal_mode")
+            local fk = db:eval("PRAGMA foreign_keys")
+            return jm[1].journal_mode, fk[1].foreign_keys
+            "#,
+        )
+        .eval()
+        .expect("query pragmas");
+
+    assert_eq!(jmode, "wal", "journal_mode should be WAL for file-backed db");
+    assert_eq!(fkeys, 1, "foreign_keys should be ON");
+}
+
+// ============================================================================
+// 18. test_must_be_called_during_plugin_load
+// ============================================================================
+
+#[test]
+fn calling_plugin_db_outside_plugin_load_errors_clearly() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    // Intentionally NOT setting _loading_plugin_name.
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{
+                version = 1,
+                models = { t = { id = true } },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("must raise when _loading_plugin_name is unset");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("must be called during plugin load"),
+        "missing guidance about plugin-load context: {msg}"
+    );
+}
+
+// ============================================================================
+// 19. test_memory_vs_file_redeclared_rejected
+// ============================================================================
+
+#[test]
+fn redeclaring_memory_flag_is_rejected() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "memswap");
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{ memory = true, version = 1, models = { t = { id = true } } }
+            plugin.db{ memory = false, version = 1, models = { t = { id = true } } }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("memory flag flip must raise");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("re-declared with memory=")
+            && msg.contains("existing handle was opened with memory="),
+        "memory-flag mismatch message missing expected content: {msg}"
+    );
+}
+
+// ============================================================================
+// 20. test_reserved_model_name_rejected
+// ============================================================================
+//
+// A plugin that declared a model named after a sqlite.db method (e.g. `close`,
+// `insert`, `eval`) would silently break the db handle because `wrap_db`
+// rawsets each model as an instance field, shadowing the class method. We
+// reject at load time with a clear message.
+
+#[test]
+fn reserved_model_names_rejected_with_plugin_scoped_error() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "reserved");
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{
+                memory = true,
+                version = 1,
+                models = {
+                    close = { id = true },   -- would shadow sqlite.db:close
+                },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("reserved model name should raise");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("reserved name") && msg.contains("'close'") && msg.contains("reserved"),
+        "reserved-name error missing expected content: {msg}"
+    );
+}
+
+// ============================================================================
+// 21. test_migration_rolls_back_on_failure_with_mixed_methods
+// ============================================================================
+//
+// If a migration fn calls sqlite.db:insert/update/delete (which internally
+// wrap in BEGIN/COMMIT via `wrap_stmts`), the outer migration step's tx must
+// still roll back atomically on a later error. Without the USER_TX_SET
+// guard in run_migrations, the inner COMMIT would close our outer tx early
+// and leave partial state committed.
+
+#[test]
+fn migration_step_rollback_is_atomic_across_wrap_stmts_calls() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "migatomic");
+
+    lua.load(
+        r#"
+        plugin.db{
+            version = 1,
+            models = { t = { id = true, v = { 'integer', default = 0 } } },
+        }
+        "#,
+    )
+    .exec()
+    .expect("v1 initial load");
+
+    // Reload at v2 with a migration that first inserts via sqlite.db:insert
+    // (uses wrap_stmts) and then errors. The whole step must roll back —
+    // when we reopen at v1 (not v2) the row must NOT be present.
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "migatomic");
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{
+                version = 2,
+                models = { t = { id = true, v = { 'integer', default = 0 } } },
+                migrations = {
+                    [2] = function(db)
+                        -- This goes through sqlite.db:insert -> wrap_stmts,
+                        -- which would (without our patch) commit the outer tx.
+                        db:insert('t', { v = 999 })
+                        -- Then explicitly fail the step.
+                        error('intentional failure', 0)
+                    end,
+                },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("migration step should propagate the error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("migration 2 (v1 -> v2) failed"),
+        "missing expected migration-failure preamble: {msg}"
+    );
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "migatomic");
+
+    let (user_version, row_count): (i64, i64) = lua
+        .load(
+            r#"
+            local db = plugin.db{
+                version = 1,
+                models = { t = { id = true, v = { 'integer', default = 0 } } },
+            }
+            local uv = db:eval('PRAGMA user_version')[1].user_version
+            -- sqlite.lua's eval returns `true` for an empty SELECT, not {},
+            -- so use COUNT(*) for an unconditional row-count.
+            local count = db:eval('SELECT COUNT(*) AS n FROM t')[1].n
+            return uv, count
+            "#,
+        )
+        .eval()
+        .expect("reopen at v1 after failed upgrade");
+
+    assert_eq!(
+        user_version, 1,
+        "user_version must stay at 1 when the v2 migration rolled back"
+    );
+    assert_eq!(
+        row_count, 0,
+        "the db:insert inside the failed migration must have rolled back"
+    );
+}
+
+// ============================================================================
+// 22. test_required_column_without_default_errors_on_add
+// ============================================================================
+
+#[test]
+fn adding_required_column_without_default_errors_clearly() {
+    let _lock = lock_env();
+    let tmp = TempDir::new().unwrap();
+    set_config_dir(tmp.path());
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "reqnodefault");
+
+    lua.load(
+        r#"
+        plugin.db{
+            version = 1,
+            models = {
+                t = {
+                    id = true,
+                    a = { 'text', required = true, default = '' },
+                },
+            },
+        }
+        "#,
+    )
+    .exec()
+    .expect("initial load");
+
+    drop(lua);
+    let lua = new_test_lua();
+    set_loading_plugin(&lua, "reqnodefault");
+
+    let err = lua
+        .load(
+            r#"
+            plugin.db{
+                version = 1,
+                models = {
+                    t = {
+                        id = true,
+                        a = { 'text', required = true, default = '' },
+                        -- New required column without default: sqlite refuses
+                        -- ADD COLUMN NOT NULL without DEFAULT.
+                        b = { 'text', required = true },
+                    },
+                },
+            }
+            "#,
+        )
+        .exec()
+        .err()
+        .expect("required-without-default should raise");
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("cannot add required column")
+            && msg.contains("b")
+            && msg.contains("default"),
+        "required-without-default message missing expected content: {msg}"
+    );
+}

--- a/docs/lua/plugin-db.md
+++ b/docs/lua/plugin-db.md
@@ -1,0 +1,218 @@
+# `plugin.db{}` — per-plugin persistence
+
+`plugin.db{}` gives Lua plugins a private sqlite database with a declarative
+schema and a migration runner. One call at plugin load time returns a handle
+that survives hot-reload and closes cleanly on hub shutdown.
+
+The underlying library is [vendored sqlite.lua](../../cli/lua/vendor/sqlite/)
+(bundled in PR B.1); `plugin.db` is the Botster-specific wrapper around it.
+
+## Shape
+
+```lua
+-- plugins/messaging/init.lua
+local db = plugin.db{
+  version = 1,
+  models = {
+    messages = {
+      id         = true,                              -- INTEGER PRIMARY KEY
+      channel_id = { 'integer', required = true },
+      author     = { 'text',    required = true },
+      body       = { 'text',    required = true },
+      created_at = { 'integer', required = true },
+    },
+    channels = {
+      id       = true,
+      name     = { 'text',    required = true, unique = true },
+      archived = { 'integer', default = 0 },
+    },
+  },
+}
+
+-- CRUD
+db.messages:insert{
+  channel_id = 1,
+  author = 'jason',
+  body = 'hi',
+  created_at = os.time(),
+}
+local rows = db.messages:get{ where = { channel_id = 1 } }
+db.messages:update{ where = { id = 1 }, set = { body = 'edited' } }
+db.messages:remove{ where = { id = 1 } }
+
+-- Multi-statement transaction: BEGIN on entry, COMMIT on clean return,
+-- ROLLBACK on any raised error. Nested calls to `db.t:insert`/etc. run
+-- inside the same transaction.
+db:execute(function(db)
+  db.channels:insert{ name = 'general' }
+  db.messages:insert{ channel_id = 1, author = 'bot',
+                      body = 'welcome', created_at = os.time() }
+end)
+
+-- Escape hatch: raw SQL with `?` placeholders
+local rows = db:eval('SELECT COUNT(*) AS n FROM messages WHERE author = ?',
+                     'jason')
+```
+
+## File layout
+
+`plugin.db` derives `{config.data_dir()}/plugins/<plugin_name>/db.sqlite`
+and creates the parent directory if missing. `<plugin_name>` is whatever
+the hub registered for the loading plugin (matches the plugin's directory
+name). The file is NOT deleted when the plugin is disabled or unloaded —
+only the in-memory handle is.
+
+## Default PRAGMAs
+
+Every open applies, in order:
+
+| PRAGMA          | Value    | Why                                   |
+|-----------------|----------|---------------------------------------|
+| `journal_mode`  | `WAL`    | Concurrent readers + single writer    |
+| `synchronous`   | `NORMAL` | Safe under WAL; faster than `FULL`    |
+| `foreign_keys`  | `ON`     | Enforce `reference = '<tbl>.<col>'`   |
+| `busy_timeout`  | `5000`   | Wait 5s on write contention           |
+
+You can override or add to these via `pragmas = { ... }` on the spec:
+
+```lua
+plugin.db{
+  version = 1,
+  models = { ... },
+  pragmas = { cache_size = -20000 },  -- 20 MB page cache
+}
+```
+
+## Schema DSL
+
+Each field in `models.<table>` accepts one of:
+
+| Form                                  | Meaning                                  |
+|---------------------------------------|------------------------------------------|
+| `true`                                | `INTEGER PRIMARY KEY`                    |
+| `'text'` / `'integer'` / `'real'` / `'blob'` | bare column of that type          |
+| `{ 'text', required = true, ... }`    | typed column with options                |
+| `{ type = 'text', required = true, ... }` | same as positional type             |
+
+Options (in addition to positional or named `type`):
+
+| Key          | Meaning                                                        |
+|--------------|----------------------------------------------------------------|
+| `required`   | `NOT NULL`                                                     |
+| `primary`    | `PRIMARY KEY`                                                  |
+| `unique`     | `UNIQUE`                                                       |
+| `default`    | default value (strings are quoted; booleans map to 0/1)        |
+| `reference`  | `"other_table.col"` — foreign key                              |
+| `on_delete`  | `'cascade'` \| `'null'` \| `'default'` \| `'restrict'`          |
+| `on_update`  | same values as `on_delete`                                     |
+
+### No declarative indexes
+
+The v1 DSL does not include indexes. If you need one, create it in a
+migration function (or at plugin top-level, since `IF NOT EXISTS` makes the
+statement idempotent):
+
+```lua
+db:eval('CREATE INDEX IF NOT EXISTS messages_channel_idx ON messages (channel_id)')
+```
+
+## Migrations
+
+`version` defaults to `1`. On load, `plugin.db` reads `PRAGMA user_version`:
+
+- **`current < version`** — run each step from `current+1 .. version` inside
+  its own BEGIN/COMMIT. Each step applies **additive** schema changes
+  implied by `models` (new tables, new columns), invokes `migrations[i]` if
+  provided, then writes `PRAGMA user_version = i`. A single failure rolls
+  that step back and refuses plugin load — the database stays at the
+  previous version.
+- **`current == version`** — reconcile the live schema against `models`
+  and apply any additive changes (new tables, new columns with a default
+  or nullable). Any non-additive drift (removed column, type change,
+  nullability change) refuses plugin load with a printable diff.
+- **`current > version`** — refuse plugin load. Downgrades are not
+  supported; bump the declared `version` to match or delete the db file to
+  reset.
+
+### Example migration
+
+```lua
+plugin.db{
+  version = 3,
+  models = {
+    messages = {
+      id = true,
+      author = { 'text', required = true, default = '' },
+      body = { 'text', required = true, default = '' },
+      reactions = { 'text', default = '[]' },  -- new in v3
+    },
+  },
+  migrations = {
+    [2] = function(db)
+      -- normalise existing author values
+      db:eval('UPDATE messages SET author = lower(author)')
+    end,
+    [3] = function(db)
+      -- backfill the new column for existing rows
+      db:eval("UPDATE messages SET reactions = '[]' WHERE reactions IS NULL")
+    end,
+  },
+}
+```
+
+Each migration function receives the raw sqlite db; prefer `db:eval(...)`
+for individual statements. **Do not call `db:execute(function() end)`
+inside a migration** — the step is already inside a transaction and sqlite
+rejects nested `BEGIN`.
+
+### Adding a required column
+
+Sqlite refuses `ALTER TABLE ... ADD COLUMN <col> NOT NULL` without a
+`DEFAULT`. `plugin.db` surfaces this as a clear error with two fixes:
+
+```lua
+-- Option A: give it a default
+author = { 'text', required = true, default = 'anonymous' }
+
+-- Option B: make it optional and backfill in a migration step
+models = { messages = { author = { 'text' } } },
+migrations = {
+  [2] = function(db) db:eval("UPDATE messages SET author = 'anonymous' WHERE author IS NULL") end,
+}
+```
+
+## Lifecycle
+
+The handle cache is keyed by plugin name, so a hot-reload that calls
+`plugin.db{}` again returns the **same** sqlite connection — data is
+preserved, no fds leak. When the plugin is disabled, unloaded, or the hub
+shuts down, the handle closes. Tests that need an ephemeral database pass
+`memory = true`:
+
+```lua
+local db = plugin.db{ memory = true, version = 1, models = { ... } }
+```
+
+`memory = true` creates a `:memory:` sqlite database per plugin process.
+Data is discarded on hub exit. Re-declaring a plugin with a different
+`memory` flag than its cached handle raises an error; pick one.
+
+## Constraints
+
+- `plugin.db{}` must run **during plugin load**. Call it at the top of
+  `init.lua` and capture the handle in a local; references from callbacks,
+  hooks, and MCP tool handlers use the captured value.
+- All plugin code runs on the hub's main thread. No locking is needed
+  because concurrent access is not possible from Lua.
+- `plugin.db` does not currently migrate data across a plugin rename.
+  If you rename the plugin directory, copy the old file manually:
+  `~/.botster/plugins/<old>/db.sqlite` → `~/.botster/plugins/<new>/db.sqlite`.
+
+## Related
+
+- [`cli/lua/vendor/sqlite/`](../../cli/lua/vendor/sqlite/) — vendored
+  upstream library (see its `VENDOR_CHANGES.md` for local patches).
+- [`cli/lua/lib/plugin_db.lua`](../../cli/lua/lib/plugin_db.lua) —
+  wrapper implementation.
+- [`cli/tests/plugin_db_test.rs`](../../cli/tests/plugin_db_test.rs) —
+  integration tests covering the full API surface.


### PR DESCRIPTION
## Summary

**PR B.2**: the public-facing plugin persistence layer. Builds on PR B.1 (vendored sqlite.lua + LuaJIT FFI). Plugin authors get a Neovim-style declarative API for per-plugin SQLite storage with auto-managed migrations.

```lua
local db = plugin.db{
  version = 2,
  models = {
    messages = {
      id = true,
      channel_id = { "integer", required = true },
      author     = { "text", required = true },
      body       = { "text", required = true },
      created_at = { "integer", required = true },
    },
  },
  migrations = {
    [2] = function(db)
      db:eval("UPDATE messages SET author = lower(author)")
    end,
  },
}

db.messages:insert{ channel_id = 1, author = "jason", body = "hi", created_at = os.time() }
local rows = db.messages:get{ where = { channel_id = 1 } }
db:execute(function() ... end)  -- transaction
local raw = db:eval("SELECT ...", args)  -- escape hatch
```

## Architecture highlights

### Per-plugin scoping
- Auto-derives plugin name from `_G._loading_plugin_name` (set by the loader during plugin init). Calling from a callback rejects with a clear error.
- File path: `{data_dir}/plugins/<plugin_name>/db.sqlite` (or `:memory:` for `memory = true`).

### Migration runner (built on top of sqlite.lua, which has no real migration support)
- Tracks schema version via `PRAGMA user_version`.
- Additive changes (new tables/columns/indexes) auto-apply without version bump.
- Non-additive changes (rename/drop/retype) require bumping `version` + providing `migrations[N] = fn`.
- Each migration step is a single transaction: `BEGIN → additive diff → user fn → user_version = N → COMMIT`. Rollback + refuse plugin load on error.
- Downgrade refused (plugin declares lower version than `user_version` on disk).
- Final strict reconcile catches plugins that forget to materialize declared `models` in a migration fn.

### Hot-reload safety (matches `lib/surfaces.lua` pattern)
- State (`db_handles`, events-subscribed guard) persisted via `hub.state.get(...)`.
- `_before_reload` / `_after_reload` hooks rebind `_G.plugin.db` to fresh closure + re-register `plugin_unloading` hook.
- `hooks.on` is name-replaceable so re-registration doesn't leak duplicate callbacks.
- `events.on('shutdown')` guarded by `events_subscribed` sentinel; callback resolves `M` via `package.loaded` so post-reload shutdown runs the latest `shutdown_all`.

### Monkey-patch of sqlite.lua's `wrap_stmts`
- sqlite.lua wraps `insert/update/delete/select` in nested `BEGIN`/`COMMIT`, which would close outer user/migration transactions early.
- Patched ONCE at module load (idempotent via sentinel) to no-op BEGIN/COMMIT when a connection is inside a user tx or migration step (tracked per-connection via `USER_TX_SET`).
- Uses `rawget`/`rawset` to sidestep `sqlite.defs`'s FFI-fallback metatable.

### Open-time PRAGMA contract
- Order: `busy_timeout=5000` FIRST (so subsequent lock-taking statements inherit the waiter), then `journal_mode=WAL`, `foreign_keys=ON`, `synchronous=NORMAL`.
- Critical PRAGMAs (`busy_timeout`, `journal_mode`, `foreign_keys`) fail LOUDLY on error — close connection + refuse plugin load.
- `synchronous` + user-supplied `spec.pragmas` overrides remain pcall-wrapped with WARN log (non-critical).

### Reserved-name enforcement
- Plugin declaring `models.close` (or any sqlite.db method / instance field name) rejected at load with a plugin-scoped error. Full reserved list in `plugin_db.lua`.

## Codex audit

**Cycle 1 — BLOCKING** (2 findings):
1. PRAGMA contract not enforced (busy_timeout applied last; silent pcall swallow on critical PRAGMAs)
2. `lib.plugin_db` didn't participate in core Lua hot-reload (plain locals, no hooks)

**Fix commit** (`1e9b2227`): both addressed in code + 2 new regression tests.

**Cycle 2 — APPROVED**, zero findings. Codex verified:
- `busy_timeout` is actually first in `CRITICAL_PRAGMAS` + applied before any lock-taking op
- State management now follows `lib/surfaces.lua` convention
- `hooks.on` is name-replaceable (verified against `hub/hooks.lua`)
- Lazy `package.loaded` lookup is race-safe on single-threaded Lua
- The 2 new regression tests bite against the pre-fix code

## Test plan

- [x] `./test.sh` (CLI) — all pass (+24 plugin_db tests: 14 core + 4 nice-to-have + 2 reserved-name/atomicity + 2 codex regressions)
- [x] `bin/rails test` — 442/0/0
- [x] `bin/rails test:system` — 37/0/0
- [x] `npx vitest --run` — 172/172 unchanged
- [x] `bin/rubocop` — clean
- [x] Codex APPROVED on `1e9b2227`

## Files (5 changed, +2219 LOC — mostly tests + docs)

- `cli/lua/lib/plugin_db.lua` — wrapper + migration runner + monkey-patch
- `cli/tests/plugin_db_test.rs` — 24 integration tests
- `docs/lua/plugin-db.md` — plugin author guide with messaging-history example
- `cli/lua/hub/init.lua` — 2-line wiring
- `cli/lua/hub/loader.lua` — 2-line `plugin_unloading` hook emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)