### PR TITLE
perf(cli): hub input-lag tactical fixes + Lua hot-path instrumentation

### DIFF
--- a/cli/lua/handlers/connections.lua
+++ b/cli/lua/handlers/connections.lua
@@ -30,6 +30,9 @@ local last_agent_list_snapshot = state.get("connections.last_agent_list_snapshot
 local hub_recovery_state = state.get("connections.hub_recovery_state", {
     state = "starting",
 })
+local pending_osc_session_updates = state.get("connections.pending_osc_session_updates", {})
+
+local OSC_SESSION_UPDATE_DEBOUNCE_SECS = 0.5
 
 -- ============================================================================
 -- Client Registry
@@ -425,20 +428,52 @@ function _clear_session_notification(session_uuid)
     return any_remaining
 end
 
+local function queue_osc_session_update(session_uuid, fields)
+    if not session_uuid or type(fields) ~= "table" then return end
+
+    local agent = Agent.get(session_uuid)
+    if not agent then return end
+
+    local pending = pending_osc_session_updates[session_uuid]
+    if type(pending) ~= "table" then
+        pending = {}
+        pending_osc_session_updates[session_uuid] = pending
+    end
+
+    local changed = false
+    for k, v in pairs(fields) do
+        if agent[k] ~= v then
+            agent[k] = v
+            pending[k] = v
+            changed = true
+        end
+    end
+    if not changed then return end
+
+    timer.after_idle("session_osc_update:" .. session_uuid, OSC_SESSION_UPDATE_DEBOUNCE_SECS, function()
+        local current = pending_osc_session_updates[session_uuid]
+        pending_osc_session_updates[session_uuid] = nil
+
+        local s = Agent.get(session_uuid)
+        if not s or type(current) ~= "table" or next(current) == nil then return end
+
+        s:_sync_session_manifest()
+        hooks.notify("session_updated", {
+            session_uuid = session_uuid,
+            source = "osc_debounced",
+            fields = current,
+        })
+    end)
+end
+
 -- Update agent title when the running program sets the terminal title (OSC 0/2).
 hooks.on("pty_title_changed", "update_agent_title", function(info)
-    local agent = (info.session_uuid and Agent.get(info.session_uuid))
-    if agent then
-        agent:update({ title = info.title })
-    end
+    queue_osc_session_update(info.session_uuid, { title = info.title })
 end)
 
 -- Update agent CWD when the shell reports a directory change (OSC 7).
 hooks.on("pty_cwd_changed", "update_agent_cwd", function(info)
-    local agent = (info.session_uuid and Agent.get(info.session_uuid))
-    if agent then
-        agent:update({ cwd = info.cwd })
-    end
+    queue_osc_session_update(info.session_uuid, { cwd = info.cwd })
 end)
 
 -- Track shell integration prompt marks (OSC 133/633).
@@ -659,6 +694,10 @@ function M._before_reload()
         events.off(sub_id)
     end
     _event_subs = {}
+    for session_uuid in pairs(pending_osc_session_updates) do
+        timer.cancel("session_osc_update:" .. session_uuid)
+        pending_osc_session_updates[session_uuid] = nil
+    end
     hooks.off("agent_created", "broadcast_agent_created")
     hooks.off("agent_deleted", "broadcast_agent_deleted")
     hooks.off("agent_lifecycle", "broadcast_lifecycle")

--- a/cli/src/lua/primitives/timer.rs
+++ b/cli/src/lua/primitives/timer.rs
@@ -29,7 +29,7 @@
 //! `timer.after` and `timer.every` return a timer ID string.
 //! `timer.cancel` returns `true` if the timer was found, `false` otherwise.
 
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Result};
@@ -71,6 +71,15 @@ pub struct TimerEntries {
     hub_event_tx: Option<crate::hub::events::HubEventTx>,
     /// Tokio runtime handle for spawning timer tasks from sync Lua closures.
     tokio_handle: Option<tokio::runtime::Handle>,
+}
+
+fn timer_perf_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("BOTSTER_LUA_PERF")
+            .map(|value| value != "0" && !value.is_empty())
+            .unwrap_or(false)
+    })
 }
 
 impl Default for TimerEntries {
@@ -468,6 +477,9 @@ pub fn poll_timers(lua: &Lua, registry: &TimerRegistry) -> usize {
 /// The registry lock is released before firing the Lua callback, allowing
 /// the callback to call `timer.cancel()` or create new timers.
 pub(crate) fn fire_single_timer(lua: &Lua, registry: &TimerRegistry, timer_id: &str) {
+    let perf = timer_perf_enabled();
+    let total_started = Instant::now();
+
     // Phase 1: look up entry under lock, clone callback, handle one-shot.
     let callback_key = {
         let mut entries = registry.lock().expect("TimerEntries mutex poisoned");
@@ -508,6 +520,7 @@ pub(crate) fn fire_single_timer(lua: &Lua, registry: &TimerRegistry, timer_id: &
 
         cloned_key
     };
+    let lookup_done = Instant::now();
     // Lock released — callback can safely call timer functions.
 
     // Phase 2: fire callback.
@@ -516,6 +529,7 @@ pub(crate) fn fire_single_timer(lua: &Lua, registry: &TimerRegistry, timer_id: &
         callback.call::<()>(())?;
         Ok(())
     })();
+    let callback_done = Instant::now();
 
     if let Err(e) = result {
         log::warn!("[timer] Callback error for {timer_id}: {e}");
@@ -531,6 +545,18 @@ pub(crate) fn fire_single_timer(lua: &Lua, registry: &TimerRegistry, timer_id: &
         for (_, entry) in removed {
             let _ = lua.remove_registry_value(entry.callback_key);
         }
+    }
+    let cleanup_done = Instant::now();
+
+    if perf {
+        log::info!(
+            "[PERF][lua] timer_fired id={} lookup_us={} callback_us={} cleanup_us={} total_us={}",
+            timer_id,
+            lookup_done.duration_since(total_started).as_micros(),
+            callback_done.duration_since(lookup_done).as_micros(),
+            cleanup_done.duration_since(callback_done).as_micros(),
+            cleanup_done.duration_since(total_started).as_micros()
+        );
     }
 }
 

--- a/cli/src/lua/primitives/timer.rs
+++ b/cli/src/lua/primitives/timer.rs
@@ -281,17 +281,9 @@ pub fn register(lua: &Lua, registry: TimerRegistry) -> Result<()> {
                 let duration = Duration::from_secs_f64(seconds);
                 let mut entries = reg_idle.lock().expect("TimerEntries mutex poisoned");
 
-                // Cancel any existing timer with this ID.
-                for (eid, entry) in &mut entries.entries {
-                    if *eid == id && !entry.cancelled {
-                        entry.cancelled = true;
-                        if let Some(handle) = entry.task_handle.take() {
-                            handle.abort();
-                        }
-                    }
-                }
-
-                // Spawn a fresh tokio task.
+                // Refresh a single slot for this ID instead of appending a new
+                // cancelled entry every reset. Hot paths such as PTY idle
+                // detection call after_idle on nearly every output chunk.
                 let task_handle = match (&entries.hub_event_tx, &entries.tokio_handle) {
                     (Some(tx), Some(handle)) => {
                         let tx = tx.clone();
@@ -304,16 +296,28 @@ pub fn register(lua: &Lua, registry: TimerRegistry) -> Result<()> {
                     _ => None,
                 };
 
-                entries.entries.push((
-                    id.clone(),
-                    TimerEntry {
-                        callback_key,
-                        fire_at: Instant::now() + duration,
-                        repeat_interval: None,
-                        cancelled: false,
-                        task_handle,
-                    },
-                ));
+                if let Some((_, entry)) = entries.entries.iter_mut().find(|(eid, _)| *eid == id) {
+                    if let Some(handle) = entry.task_handle.take() {
+                        handle.abort();
+                    }
+                    let old_key = std::mem::replace(&mut entry.callback_key, callback_key);
+                    let _ = lua.remove_registry_value(old_key);
+                    entry.fire_at = Instant::now() + duration;
+                    entry.repeat_interval = None;
+                    entry.cancelled = false;
+                    entry.task_handle = task_handle;
+                } else {
+                    entries.entries.push((
+                        id.clone(),
+                        TimerEntry {
+                            callback_key,
+                            fire_at: Instant::now() + duration,
+                            repeat_interval: None,
+                            cancelled: false,
+                            task_handle,
+                        },
+                    ));
+                }
 
                 Ok(id)
             },
@@ -879,6 +883,33 @@ mod tests {
         let entries = registry.lock().expect("mutex");
         assert_eq!(entries.len(), 1, "len() should exclude cancelled timers");
         assert!(!entries.is_empty());
+    }
+
+    #[test]
+    fn test_after_idle_reuses_same_entry_for_same_id() {
+        let lua = Lua::new();
+        let registry = new_timer_registry();
+
+        register(&lua, Arc::clone(&registry)).expect("Should register");
+
+        lua.load(
+            r#"
+            timer.after_idle("idle:test", 10, function() end)
+            timer.after_idle("idle:test", 10, function() end)
+            timer.after_idle("idle:test", 10, function() end)
+        "#,
+        )
+        .exec()
+        .expect("create idle timers");
+
+        let entries = registry.lock().expect("mutex");
+        assert_eq!(
+            entries.entries.len(),
+            1,
+            "same-id after_idle resets should not accumulate entries"
+        );
+        assert_eq!(entries.entries[0].0, "idle:test");
+        assert!(!entries.entries[0].1.cancelled);
     }
 
     #[test]

--- a/cli/src/lua/runtime.rs
+++ b/cli/src/lua/runtime.rs
@@ -5,7 +5,8 @@
 //! on environment configuration.
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
 use mlua::{IntoLuaMulti, Lua};
@@ -81,6 +82,15 @@ pub struct LuaRuntime {
     /// (99.9% of the time), the Lua call is skipped entirely.
     /// Cleared when the last notification is dismissed.
     pty_input_listening: bool,
+}
+
+fn lua_perf_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("BOTSTER_LUA_PERF")
+            .map(|value| value != "0" && !value.is_empty())
+            .unwrap_or(false)
+    })
 }
 
 impl std::fmt::Debug for LuaRuntime {
@@ -1004,10 +1014,13 @@ impl LuaRuntime {
         peer_id: &str,
         message: serde_json::Value,
     ) -> Result<()> {
+        let perf = lua_perf_enabled();
+        let total_started = Instant::now();
         let key_result: mlua::Result<mlua::RegistryKey> =
             self.lua.named_registry_value(registry_keys::ON_MESSAGE);
 
         if let Ok(key) = key_result {
+            let registry_done = Instant::now();
             let callback: mlua::Function = self
                 .lua
                 .registry_value(&key)
@@ -1016,10 +1029,23 @@ impl LuaRuntime {
             // Convert JSON to Lua value, mapping null → nil (not userdata)
             let lua_value = crate::lua::primitives::json::json_to_lua(&self.lua, &message)
                 .map_err(|e| anyhow!("Failed to convert JSON to Lua value: {e}"))?;
+            let json_done = Instant::now();
 
             callback
                 .call::<()>((peer_id, lua_value))
                 .map_err(|e| anyhow!("webrtc_message callback failed: {e}"))?;
+
+            if perf {
+                let done = Instant::now();
+                log::info!(
+                    "[PERF][lua] webrtc_message peer_id={} registry_us={} json_us={} call_us={} total_us={}",
+                    peer_id,
+                    registry_done.duration_since(total_started).as_micros(),
+                    json_done.duration_since(registry_done).as_micros(),
+                    done.duration_since(json_done).as_micros(),
+                    done.duration_since(total_started).as_micros()
+                );
+            }
         }
 
         Ok(())
@@ -1290,19 +1316,34 @@ impl LuaRuntime {
         client_id: &str,
         message: serde_json::Value,
     ) -> Result<()> {
+        let perf = lua_perf_enabled();
+        let total_started = Instant::now();
         let key_result: mlua::Result<mlua::RegistryKey> = self
             .lua
             .named_registry_value(socket_registry_keys::ON_MESSAGE);
         if let Ok(key) = key_result {
+            let registry_done = Instant::now();
             let callback: mlua::Function = self
                 .lua
                 .registry_value(&key)
                 .map_err(|e| anyhow!("Failed to get socket_message callback: {e}"))?;
             let lua_value = crate::lua::primitives::json::json_to_lua(&self.lua, &message)
                 .map_err(|e| anyhow!("Failed to convert JSON to Lua value: {e}"))?;
+            let json_done = Instant::now();
             callback
                 .call::<()>((client_id, lua_value))
                 .map_err(|e| anyhow!("socket_message callback failed: {e}"))?;
+            if perf {
+                let done = Instant::now();
+                log::info!(
+                    "[PERF][lua] socket_message client_id={} registry_us={} json_us={} call_us={} total_us={}",
+                    client_id,
+                    registry_done.duration_since(total_started).as_micros(),
+                    json_done.duration_since(registry_done).as_micros(),
+                    done.duration_since(json_done).as_micros(),
+                    done.duration_since(total_started).as_micros()
+                );
+            }
         }
         Ok(())
     }
@@ -1685,6 +1726,8 @@ impl LuaRuntime {
     where
         F: Fn(&Lua) -> Result<mlua::Value>,
     {
+        let perf = lua_perf_enabled();
+        let total_started = Instant::now();
         // Collect callbacks and their functions in one lock acquisition
         let callbacks_to_call: Vec<mlua::Function> = {
             let callbacks = self
@@ -1697,20 +1740,46 @@ impl LuaRuntime {
                 .filter_map(|key| self.lua.registry_value::<mlua::Function>(key).ok())
                 .collect()
         };
+        let callbacks_collected = Instant::now();
         // Lock released here
 
         if callbacks_to_call.is_empty() {
             return Ok(());
         }
 
+        let callback_count = callbacks_to_call.len();
+
         // Build args once
         let args = args_fn(&self.lua)?;
+        let args_built = Instant::now();
 
         // Call callbacks without holding the lock
+        let mut callback_total_us = 0u128;
+        let mut callback_max_us = 0u128;
         for callback in callbacks_to_call {
+            let callback_started = perf.then(Instant::now);
             if let Err(e) = callback.call::<()>(args.clone()) {
                 log::error!("Event callback error for '{}': {}", event, e);
             }
+            if let Some(started) = callback_started {
+                let elapsed = started.elapsed().as_micros();
+                callback_total_us += elapsed;
+                callback_max_us = callback_max_us.max(elapsed);
+            }
+        }
+
+        if perf {
+            let done = Instant::now();
+            log::info!(
+                "[PERF][lua] fire_event event={} callbacks={} collect_us={} args_us={} callbacks_us={} callback_max_us={} total_us={}",
+                event,
+                callback_count,
+                callbacks_collected.duration_since(total_started).as_micros(),
+                args_built.duration_since(callbacks_collected).as_micros(),
+                callback_total_us,
+                callback_max_us,
+                done.duration_since(total_started).as_micros()
+            );
         }
 
         Ok(())
@@ -1916,6 +1985,8 @@ impl LuaRuntime {
     ) {
         use crate::agent::pty::PtyEvent;
 
+        let perf = lua_perf_enabled();
+        let total_started = Instant::now();
         let result: mlua::Result<()> = (|| {
             let data = self.lua.create_table()?;
             data.set("session_uuid", session_uuid)?;
@@ -1944,6 +2015,14 @@ impl LuaRuntime {
             let hooks: mlua::Table = self.lua.globals().get("hooks")?;
             let notify: mlua::Function = hooks.get("notify")?;
             notify.call::<mlua::Value>((hook_name, data))?;
+            if perf {
+                log::info!(
+                    "[PERF][lua] pty_osc hook={} session_uuid={} total_us={}",
+                    hook_name,
+                    session_uuid,
+                    total_started.elapsed().as_micros()
+                );
+            }
             Ok(())
         })();
 
@@ -4289,8 +4368,7 @@ mod tests {
     /// and the `__hook_timed_pcall` primitive registered (production VMs have
     /// this registered by `primitives::register_all`).
     fn load_hooks_module(lua: &mlua::Lua) {
-        crate::lua::primitives::hook_timeout::register(lua)
-            .expect("register __hook_timed_pcall");
+        crate::lua::primitives::hook_timeout::register(lua).expect("register __hook_timed_pcall");
 
         // hooks.lua calls log.debug/log.error on register/error paths.
         lua.load(
@@ -4318,9 +4396,8 @@ mod tests {
                     .join("lua")
                     .join("hub")
                     .join("hooks.lua");
-                std::fs::read_to_string(&path).unwrap_or_else(|e| {
-                    panic!("read hub/hooks.lua from {}: {e}", path.display())
-                })
+                std::fs::read_to_string(&path)
+                    .unwrap_or_else(|e| panic!("read hub/hooks.lua from {}: {e}", path.display()))
             }
         };
 


### PR DESCRIPTION
## Summary

Tactical fixes + diagnostic instrumentation for the hub input-lag regression. Architectural cleanup (delta-based wire protocol) tracked separately.

## Commits

1. **OSC session update debounce** (codex fix): `pty_title_changed` / `pty_cwd_changed` no longer fire full broadcasts per shell-prompt event. They accumulate in `pending_osc_session_updates` and flush once per 500ms quiet window via `timer.after_idle("session_osc_update:<uuid>", 0.5, ...)`.

2. **Timer slot reuse on after_idle reset** (codex fix): `after_idle(id, ...)` previously appended a new `TimerEntry` on every reset, leaving the old one cancelled. Under heavy PTY output (idle-timer reset per chunk) the registry grew unboundedly. Fix reuses the existing slot in place. Includes `test_after_idle_reuses_same_entry_for_same_id` regression test.

3. **Lua hot-path perf instrumentation** (codex instrumentation): opt-in behind `BOTSTER_LUA_PERF=1`. Emits `[PERF][lua]` logs at `fire_event`, `webrtc_message`, `socket_message`, `pty_osc`, `timer_fired` split into registry/marshalling/callback-body/cleanup phases. Tells us whether time is in Rust marshalling or Lua callback body.

## Current diagnosis (confirmed by the instrumentation)

Running with `BOTSTER_LUA_PERF=1`, `timer_fired id=agent_list_broadcast callback_us=1725281` per fire. Two consecutive fires both at 1.72s. The slow work is **in the Lua callback body** (broadcast path), not FFI, not mlua marshalling, not timer registry churn.

Root cause in the broadcast path (codex analysis):
- Every session_updated → agent_list_broadcast → per-subscription `Client:send_ui_layout_trees` → `LayoutInput.build_for_subscription` rebuilds `AgentListPayload` from scratch
- `AgentListPayload.build` does O(n²) close-actions and reads session manifests from disk
- Built-in workspace surfaces do a nested render trampoline (inner `web_layout.render('workspace_surface')` + multiple json encode/decode round-trips per surface)
- At startup, `sessions_discovered` fires `agent_created` per recovered session, each triggering the full broadcast pipeline

Follow-up PRs will attack these in order:
1. Eliminate workspace-surface JSON trampoline (Rust primitive returning Lua value instead of JSON string)
2. Precompute AgentListPayload once per broadcast; thread through fanout
3. Cache workspace-groups; no disk reads on hot broadcast path
4. Batch recovery fanout at startup

And then: architectural redesign — delta-based wire protocol where tree snapshots only ship on connect or structural change, entity updates send only the delta.

## Test plan

- [x] `cargo test --lib lua::primitives::timer` — 15 pass including new regression
- [x] `cargo check` — clean
- [ ] Hub reboot on user's machine with `BOTSTER_LUA_PERF=1` — confirm instrumentation emits expected signal

## Files (3 changed, ~200 LOC)

- `cli/lua/handlers/connections.lua` — OSC session update debounce
- `cli/src/lua/primitives/timer.rs` — slot reuse + instrumentation
- `cli/src/lua/runtime.rs` — instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)