### PR TITLE
Fix GitHub PR markdown bodies and ready review tools

### DIFF
--- a/app/mcp/tools/application_mcp_tool.rb
+++ b/app/mcp/tools/application_mcp_tool.rb
@@ -139,4 +139,12 @@ class ApplicationMCPTool < ActionMCP::Tool
 
     hash[key] || hash[key.to_sym]
   end
+
+  def normalize_github_markdown_body(value)
+    text = value.to_s
+    return text unless text.include?("\\n") || text.include?("\\r\\n")
+    return text if text.include?("\n") || text.include?("\r")
+
+    text.gsub("\\r\\n", "\n").gsub("\\n", "\n")
+  end
 end

--- a/app/mcp/tools/github_comment_issue_tool.rb
+++ b/app/mcp/tools/github_comment_issue_tool.rb
@@ -32,8 +32,9 @@ class GithubCommentIssueTool < ApplicationMCPTool
     agent_info = botster_session_attribution
     render(text: "Adding comment to #{repo}##{issue_number} as [bot] (#{agent_info})...")
 
+    normalized_body = normalize_github_markdown_body(body)
     # Add attribution footer to comment body
-    enhanced_body = body + attribution_footer
+    enhanced_body = normalized_body + attribution_footer
 
     # Create comment using installation token (bot attribution)
     comment = client.add_comment(repo, issue_number.to_i, enhanced_body)
@@ -47,8 +48,8 @@ class GithubCommentIssueTool < ApplicationMCPTool
       "",
       "Preview:",
       "---",
-      body.lines.first(5).join,
-      (body.lines.count > 5 ? "... (truncated)" : ""),
+      normalized_body.lines.first(5).join,
+      (normalized_body.lines.count > 5 ? "... (truncated)" : ""),
       "---",
       "",
       "View full comment at: #{comment[:html_url]}"

--- a/app/mcp/tools/github_create_issue_tool.rb
+++ b/app/mcp/tools/github_create_issue_tool.rb
@@ -29,7 +29,7 @@ class GithubCreateIssueTool < ApplicationMCPTool
     label_array = labels.present? ? labels.split(",").map(&:strip) : []
 
     # Add attribution footer to issue body
-    enhanced_body = body.to_s + attribution_footer
+    enhanced_body = normalize_github_markdown_body(body) + attribution_footer
 
     # Create issue using installation token (bot attribution)
     issue = client.create_issue(repo, title, enhanced_body, labels: label_array)

--- a/app/mcp/tools/github_create_pull_request_review_tool.rb
+++ b/app/mcp/tools/github_create_pull_request_review_tool.rb
@@ -61,12 +61,17 @@ class GithubCreatePullRequestReviewTool < ApplicationMCPTool
     agent_info = botster_session_attribution
 
     review_options = { event: event }
-    review_options[:body] = body.to_s + attribution_footer if body.present?
+    normalized_body = normalize_github_markdown_body(body) if body.present?
+    review_options[:body] = normalized_body + attribution_footer if body.present?
 
     parsed = parsed_comments
     if parsed.present?
       review_options[:comments] = parsed.map do |c|
-        { path: c["path"] || c[:path], line: (c["line"] || c[:line]).to_i, body: c["body"] || c[:body] }
+        {
+          path: c["path"] || c[:path],
+          line: (c["line"] || c[:line]).to_i,
+          body: normalize_github_markdown_body(c["body"] || c[:body])
+        }
       end
     end
 
@@ -94,7 +99,7 @@ class GithubCreatePullRequestReviewTool < ApplicationMCPTool
     if body.present?
       output << ""
       output << "📝 Review summary:"
-      output << body
+      output << normalized_body
     end
 
     response_text = output.join("\n")

--- a/app/mcp/tools/github_create_pull_request_tool.rb
+++ b/app/mcp/tools/github_create_pull_request_tool.rb
@@ -30,7 +30,7 @@ class GithubCreatePullRequestTool < ApplicationMCPTool
     render(text: "Creating pull request in #{repo} as [bot] (#{agent_info})...")
 
     # Add attribution footer to PR body
-    enhanced_body = body.to_s + attribution_footer
+    enhanced_body = normalize_github_markdown_body(body) + attribution_footer
 
     # Create PR using installation token (bot attribution)
     pr = client.create_pull_request(repo, base, head, title, enhanced_body, draft: draft || false)

--- a/app/mcp/tools/github_mark_pull_request_ready_for_review_tool.rb
+++ b/app/mcp/tools/github_mark_pull_request_ready_for_review_tool.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+class GithubMarkPullRequestReadyForReviewTool < ApplicationMCPTool
+  tool_name "github_mark_pull_request_ready_for_review"
+  description "Mark an existing GitHub draft pull request ready for review. Requires repository in 'owner/repo' format and pull request number."
+
+  property :repo, type: "string", description: "Repository in 'owner/repo' format. Defaults to the calling Botster session repo when available.", required: false
+  property :pr_number, type: "integer", description: "Pull request number", required: true
+
+  validates :repo, format: { with: /\A[\w\-\.]+\/[\w\-\.]+\z/, message: "must be in 'owner/repo' format" }
+  validates :pr_number, numericality: { only_integer: true, greater_than: 0 }
+
+  MARK_READY_MUTATION = <<~GRAPHQL.squish
+    mutation($id: ID!) {
+      markPullRequestReadyForReview(input: { pullRequestId: $id }) {
+        pullRequest {
+          number
+          isDraft
+          url
+        }
+      }
+    }
+  GRAPHQL
+
+  def perform
+    installation_id = ::Github::App.installation_id_for_repo(repo)
+    unless installation_id
+      report_error("GitHub App is not installed on #{repo}")
+      return
+    end
+
+    client = ::Github::App.installation_client(installation_id)
+    agent_info = botster_session_attribution
+    render(text: "Marking #{repo}##{pr_number} ready for review as [bot] (#{agent_info})...")
+
+    pr = client.pull_request(repo, pr_number.to_i)
+    if pr[:draft] == false
+      render(text: "✅ Pull request #{repo}##{pr_number} is already ready for review.")
+      return
+    end
+
+    node_id = pr[:node_id].presence
+    unless node_id
+      report_error("GitHub did not return a GraphQL node id for #{repo}##{pr_number}; cannot mark ready for review.")
+      return
+    end
+
+    response = client.post("/graphql", { query: MARK_READY_MUTATION, variables: { id: node_id } }.to_json)
+    response_hash = github_response_hash(response)
+    errors = response_hash[:errors]
+
+    if errors.present?
+      messages = Array(errors).filter_map { |error| error[:message] || error["message"] }
+      if messages.any? { |message| message.to_s.match?(/already.*ready|not.*draft/i) }
+        render(text: "✅ Pull request #{repo}##{pr_number} is already ready for review.")
+      else
+        report_error("Failed to mark pull request ready for review: #{messages.presence&.join('; ') || errors.inspect}")
+      end
+      return
+    end
+
+    pull_request = response_hash.dig(:data, :markPullRequestReadyForReview, :pullRequest) ||
+      response_hash.dig("data", "markPullRequestReadyForReview", "pullRequest") ||
+      {}
+
+    if pull_request[:isDraft] == false || pull_request["isDraft"] == false
+      url = pull_request[:url] || pull_request["url"] || pr[:html_url]
+      render(text: "✅ Pull request #{repo}##{pr_number} is ready for review.\n\n🔗 URL: #{url}")
+    else
+      report_error("GitHub did not confirm that #{repo}##{pr_number} is ready for review.")
+    end
+  rescue Octokit::Error => e
+    report_error("Failed to mark pull request ready for review: #{e.message}")
+  rescue => e
+    report_error("Error marking pull request ready for review: #{e.message}")
+  end
+
+  private
+
+  def github_response_hash(response)
+    response = response.to_h if response.respond_to?(:to_h)
+    response.is_a?(Hash) ? response : {}
+  end
+end

--- a/app/mcp/tools/github_update_issue_tool.rb
+++ b/app/mcp/tools/github_update_issue_tool.rb
@@ -33,7 +33,7 @@ class GithubUpdateIssueTool < ApplicationMCPTool
     update_options = {}
     update_options[:state] = state if state.present?
     update_options[:title] = title if title.present?
-    update_options[:body] = body if body.present?
+    update_options[:body] = normalize_github_markdown_body(body) if body.present?
     update_options[:labels] = labels.split(",").map(&:strip) if labels.present?
     update_options[:assignees] = assignees.split(",").map(&:strip) if assignees.present?
 

--- a/test/mcp/tools/github_tools_test.rb
+++ b/test/mcp/tools/github_tools_test.rb
@@ -221,6 +221,25 @@ class GithubCreateIssueToolTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes escaped newlines in issue body before creating issue" do
+    tool = GithubCreateIssueTool.new(repo: "owner/repo", title: "New issue", body: "Intro\\n\\n- item")
+    setup_tool_mocks(tool)
+
+    captured_body = nil
+    issue_data = @created_issue
+    client = Object.new
+    client.define_singleton_method(:create_issue) do |_repo, _title, body, **_kwargs|
+      captured_body = body
+      resource = OpenStruct.new(issue_data)
+      resource.define_singleton_method(:to_h) { issue_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "Intro\n\n- item\n\n_via test_", captured_body
+  end
+
   test "returns error when app not installed" do
     tool = GithubCreateIssueTool.new(repo: "owner/repo", title: "New issue", body: "Description")
     setup_tool_mocks(tool)
@@ -261,6 +280,45 @@ class GithubCommentIssueToolTest < ActiveSupport::TestCase
       tool.perform
       assert_nil tool.instance_variable_get(:@error)
     end
+  end
+
+  test "normalizes escaped newlines in comment body before adding comment" do
+    tool = GithubCommentIssueTool.new(repo: "owner/repo", issue_number: 123, body: "Intro\\n\\n- item")
+    setup_tool_mocks(tool)
+
+    captured_body = nil
+    comment_data = @comment
+    client = Object.new
+    client.define_singleton_method(:add_comment) do |_repo, _issue_number, body|
+      captured_body = body
+      resource = OpenStruct.new(comment_data)
+      resource.define_singleton_method(:to_h) { comment_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "Intro\n\n- item\n\n_via test_", captured_body
+  end
+
+  test "preserves escaped newline examples in already multiline comment body" do
+    body = "Intro\n\n```ruby\nputs \"Use \\n here\"\n```"
+    tool = GithubCommentIssueTool.new(repo: "owner/repo", issue_number: 123, body: body)
+    setup_tool_mocks(tool)
+
+    captured_body = nil
+    comment_data = @comment
+    client = Object.new
+    client.define_singleton_method(:add_comment) do |_repo, _issue_number, submitted_body|
+      captured_body = submitted_body
+      resource = OpenStruct.new(comment_data)
+      resource.define_singleton_method(:to_h) { comment_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "#{body}\n\n_via test_", captured_body
   end
 
   test "returns error when app not installed" do
@@ -406,6 +464,25 @@ class GithubUpdateIssueToolTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes escaped newlines in issue update body" do
+    tool = GithubUpdateIssueTool.new(repo: "owner/repo", issue_number: 123, body: "Intro\\n\\n- item")
+    setup_tool_mocks(tool)
+
+    captured_options = nil
+    issue_data = @updated_issue
+    client = Object.new
+    client.define_singleton_method(:update_issue) do |_repo, _issue_number, options|
+      captured_options = options
+      resource = OpenStruct.new(issue_data)
+      resource.define_singleton_method(:to_h) { issue_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "Intro\n\n- item", captured_options[:body]
+  end
+
   test "returns error when app not installed" do
     tool = GithubUpdateIssueTool.new(repo: "owner/repo", issue_number: 123, state: "closed")
     setup_tool_mocks(tool)
@@ -458,6 +535,31 @@ class GithubCreatePullRequestToolTest < ActiveSupport::TestCase
       tool.perform
       assert_nil tool.instance_variable_get(:@error)
     end
+  end
+
+  test "normalizes escaped newlines in pull request body before creating pull request" do
+    tool = GithubCreatePullRequestTool.new(
+      repo: "owner/repo",
+      title: "New feature",
+      head: "feature-branch",
+      base: "main",
+      body: "Intro\\n\\n- item"
+    )
+    setup_tool_mocks(tool)
+
+    captured_body = nil
+    pr_data = @created_pr
+    client = Object.new
+    client.define_singleton_method(:create_pull_request) do |_repo, _base, _head, _title, body, **_kwargs|
+      captured_body = body
+      resource = OpenStruct.new(pr_data)
+      resource.define_singleton_method(:to_h) { pr_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "Intro\n\n- item\n\n_via test_", captured_body
   end
 
   test "returns error when app not installed" do
@@ -756,6 +858,34 @@ class GithubCreatePullRequestReviewToolTest < ActiveSupport::TestCase
     end
   end
 
+  test "normalizes escaped newlines in review body and inline comments" do
+    tool = GithubCreatePullRequestReviewTool.new(
+      repo: "owner/repo",
+      pr_number: 49,
+      event: "COMMENT",
+      body: "Summary\\n\\n- item",
+      comments: [
+        { "path" => "app/models/user.rb", "line" => 15, "body" => "Inline\\n\\n- note" }
+      ]
+    )
+    setup_tool_mocks(tool)
+
+    captured_options = nil
+    review_data = @review_data
+    client = Object.new
+    client.define_singleton_method(:create_pull_request_review) do |_repo, _pr_number, **options|
+      captured_options = options
+      resource = OpenStruct.new(review_data)
+      resource.define_singleton_method(:to_h) { review_data }
+      resource
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_equal "Summary\n\n- item\n\n_via test_", captured_options[:body]
+    assert_equal "Inline\n\n- note", captured_options[:comments].first[:body]
+  end
+
   test "returns error when app not installed" do
     tool = GithubCreatePullRequestReviewTool.new(
       repo: "owner/repo", pr_number: 49, event: "APPROVE"
@@ -884,5 +1014,95 @@ class GithubCreatePullRequestReviewToolTest < ActiveSupport::TestCase
     with_installation_client(mock_client) { tool2.perform }
 
     assert_equal 1, api_call_count, "Retry should not call the GitHub API again"
+  end
+end
+
+class GithubMarkPullRequestReadyForReviewToolTest < ActiveSupport::TestCase
+  include MCPToolTestHelper
+
+  test "marks draft pull request ready for review with graphql mutation" do
+    tool = GithubMarkPullRequestReadyForReviewTool.new(repo: "owner/repo", pr_number: 49)
+    setup_tool_mocks(tool)
+
+    captured_path = nil
+    captured_payload = nil
+    client = Object.new
+    client.define_singleton_method(:pull_request) do |_repo, _pr_number|
+      { number: 49, draft: true, node_id: "PR_kwDOExample", html_url: "https://github.com/owner/repo/pull/49" }.with_indifferent_access
+    end
+    client.define_singleton_method(:post) do |path, payload|
+      captured_path = path
+      captured_payload = JSON.parse(payload)
+      {
+        data: {
+          markPullRequestReadyForReview: {
+            pullRequest: { number: 49, isDraft: false, url: "https://github.com/owner/repo/pull/49" }
+          }
+        }
+      }.with_indifferent_access
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_nil tool.instance_variable_get(:@error)
+    assert_equal "/graphql", captured_path
+    assert_includes captured_payload["query"], "markPullRequestReadyForReview"
+    assert_equal "PR_kwDOExample", captured_payload.dig("variables", "id")
+    rendered = tool.instance_variable_get(:@rendered)
+    assert rendered[:text]&.include?("ready for review")
+  end
+
+  test "does not call graphql when pull request is already ready for review" do
+    tool = GithubMarkPullRequestReadyForReviewTool.new(repo: "owner/repo", pr_number: 49)
+    setup_tool_mocks(tool)
+
+    post_called = false
+    client = Object.new
+    client.define_singleton_method(:pull_request) do |_repo, _pr_number|
+      { number: 49, draft: false, node_id: "PR_kwDOExample" }.with_indifferent_access
+    end
+    client.define_singleton_method(:post) do |*_args|
+      post_called = true
+      raise "GraphQL should not be called"
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    assert_not post_called
+    assert_nil tool.instance_variable_get(:@error)
+    rendered = tool.instance_variable_get(:@rendered)
+    assert rendered[:text]&.include?("already ready")
+  end
+
+  test "returns error when app not installed" do
+    tool = GithubMarkPullRequestReadyForReviewTool.new(repo: "owner/repo", pr_number: 49)
+    setup_tool_mocks(tool)
+
+    with_no_installation do
+      tool.perform
+      error = tool.instance_variable_get(:@error)
+      assert error&.include?("not installed")
+    end
+  end
+
+  test "returns error when github does not provide node id" do
+    tool = GithubMarkPullRequestReadyForReviewTool.new(repo: "owner/repo", pr_number: 49)
+    setup_tool_mocks(tool)
+
+    client = Object.new
+    client.define_singleton_method(:pull_request) do |_repo, _pr_number|
+      { number: 49, draft: true }.with_indifferent_access
+    end
+
+    with_installation_client(client) { tool.perform }
+
+    error = tool.instance_variable_get(:@error)
+    assert error&.include?("node id")
+  end
+
+  test "validates pr_number is positive" do
+    tool = GithubMarkPullRequestReadyForReviewTool.new(repo: "owner/repo", pr_number: 0)
+    assert_not tool.valid?
+    assert tool.errors[:pr_number].any?
   end
 end


### PR DESCRIPTION
Summary:
- Normalize escaped Markdown newline sequences at GitHub MCP body boundaries when the whole body has no real newline bytes.
- Preserve already-multiline Markdown, including legitimate literal \n examples in code blocks.
- Add github_mark_pull_request_ready_for_review using GitHub GraphQL markPullRequestReadyForReview through the installation Octokit client.

Verification:
- PARALLEL_WORKERS=1 bin/rails test test/mcp/tools/github_tools_test.rb -> 68 runs, 116 assertions, 0 failures, 0 errors, 0 skips

Pipeline:
- Ticket: ticket_1779300149_880514
- Run: run_1779300154_933189

Waiver:
- Botster MCP github_create_pull_request returned 'Session not found' twice. Human answered Project Pipelines question question_1779309238_760250 with: I'll waive it this time.