### PR TITLE
Forward linked PR comments to pipeline stewards

### DIFF
--- a/app/models/integrations/github/message.rb
+++ b/app/models/integrations/github/message.rb
@@ -6,7 +6,7 @@ module Integrations
       self.table_name = "github_messages"
 
       validates :event_type, presence: true, inclusion: {
-        in: %w[github_mention agent_cleanup pull_request pull_request_review],
+        in: %w[github_mention agent_cleanup pull_request pull_request_review pull_request_comment],
         message: "%{value} is not a valid event type"
       }
       validates :repo, presence: true

--- a/app/models/integrations/github/webhooks/base_handler.rb
+++ b/app/models/integrations/github/webhooks/base_handler.rb
@@ -85,6 +85,15 @@ module Integrations
             payload: payload
           )
         end
+
+        def create_pull_request_comment_lifecycle_message(repo:, pr_number:, payload:)
+          Integrations::Github::Message.create!(
+            event_type: "pull_request_comment",
+            repo: repo,
+            issue_number: pr_number,
+            payload: payload
+          )
+        end
       end
     end
   end

--- a/app/models/integrations/github/webhooks/issue_comment_handler.rb
+++ b/app/models/integrations/github/webhooks/issue_comment_handler.rb
@@ -5,7 +5,12 @@ module Integrations
     module Webhooks
       class IssueCommentHandler < BaseHandler
         def call
-          return unless processable?
+          return unless processable_comment?
+
+          create_pr_comment_lifecycle_message if pr_comment?
+
+          return unless mentioned_trybotster?(comment_body)
+          return unless collaborator?(comment_author)
 
           Rails.logger.info "Processing @trybotster mention in #{repo_full_name}##{issue_number}"
 
@@ -29,14 +34,33 @@ module Integrations
 
         private
 
-        def processable?
+        def processable_comment?
           return false unless %w[created edited].include?(action)
           return false if comment_body.blank?
           return false if bot_author?(comment_author)
-          return false unless mentioned_trybotster?(comment_body)
-          return false unless collaborator?(comment_author)
 
           true
+        end
+
+        def create_pr_comment_lifecycle_message
+          create_pull_request_comment_lifecycle_message(
+            repo: repo_full_name,
+            pr_number: issue_number,
+            payload: {
+              action: action,
+              repo: repo_full_name,
+              pr_number: issue_number,
+              pr_url: issue_url,
+              comment_id: comment_id,
+              comment_url: comment_url,
+              comment_html_url: comment_html_url,
+              comment_body: comment_body,
+              comment_author: comment_author,
+              created_at: comment_created_at,
+              updated_at: comment_updated_at,
+              installation_id: installation_id
+            }
+          )
         end
 
         def resolve_target
@@ -89,6 +113,22 @@ module Integrations
 
         def issue_url
           payload.dig("issue", "html_url")
+        end
+
+        def comment_url
+          payload.dig("comment", "url")
+        end
+
+        def comment_html_url
+          payload.dig("comment", "html_url")
+        end
+
+        def comment_created_at
+          payload.dig("comment", "created_at")
+        end
+
+        def comment_updated_at
+          payload.dig("comment", "updated_at")
         end
 
         def pr_comment?

--- a/catalog/templates/plugins/github/event_routing.lua
+++ b/catalog/templates/plugins/github/event_routing.lua
@@ -11,6 +11,7 @@ local Agent = require("lib.agent")
 local Hub = require("lib.hub")
 local state = require("hub.state")
 local routing_state = state.get("github.event_routing", {})
+local GITHUB_FORWARD_MARKER = "👀"
 
 local function github_workspace_name(repo, issue_number, branch_name)
     if issue_number then
@@ -42,10 +43,10 @@ local function format_notification(payload)
     if prompt then
         return string.format(
             "=== NEW MENTION (automated notification) ===\n\n%s\n\n==================",
-            prompt
+            GITHUB_FORWARD_MARKER .. " " .. prompt
         )
     end
-    return "=== NEW MENTION (automated notification) ===\nNew mention\n=================="
+    return "=== NEW MENTION (automated notification) ===\n" .. GITHUB_FORWARD_MARKER .. " New mention\n=================="
 end
 
 local function notify_agent(agent, payload)
@@ -163,10 +164,63 @@ local function emit_pr_review_submitted(event_repo, message, payload)
     return true, false
 end
 
+local function pr_comment_payload(message, payload)
+    local repo = message.repo
+        or payload.repo
+        or payload.repository_full_name
+        or (payload.repository and payload.repository.full_name)
+    local number = payload.pr_number
+        or payload.pull_request_number
+        or payload.issue_number
+        or payload.number
+    local action = message.action or payload.action
+    local event_type = message.event_type or payload.event_type
+
+    if event_type ~= "pull_request_comment" or (action ~= "created" and action ~= "edited") or not number then
+        return nil
+    end
+
+    return {
+        provider = "github",
+        repo = repo,
+        pr_number = tonumber(number),
+        pr_url = payload.pr_url or payload.html_url,
+        comment_id = payload.comment_id,
+        comment_url = payload.comment_html_url or payload.comment_url,
+        comment_api_url = payload.comment_url,
+        comment_body = payload.comment_body or payload.body,
+        comment_author = payload.comment_author or payload.author,
+        action = action,
+        created_at = payload.created_at,
+        updated_at = payload.updated_at,
+        raw_event_type = event_type,
+    }
+end
+
+local function emit_pr_comment(event_repo, message, payload)
+    local event = pr_comment_payload(message, payload)
+    if not event then
+        return false, false
+    end
+    event.repo = event.repo or event_repo
+    if not event.repo then
+        return true, false
+    end
+    if events and events.emit then
+        local ok, err = pcall(events.emit, "pr_comment", event)
+        if ok then
+            return true, true
+        end
+        log.warn("GitHub: failed to emit pr_comment event: " .. tostring(err))
+    end
+    return true, false
+end
+
 local function is_pr_lifecycle_message(message, payload)
     local event_type = tostring(message.event_type or payload.event_type or "")
     return event_type == "pull_request"
         or event_type == "pull_request_review"
+        or event_type == "pull_request_comment"
         or event_type:find("^pr_") ~= nil
         or payload.pull_request ~= nil
         or payload.pr_number ~= nil
@@ -177,9 +231,10 @@ local function handle_message(default_repo, message, channel_id)
     local event_repo = message.repo or default_repo
     local pr_merged_event = emit_pr_merged(event_repo, message, payload)
     local pr_review_event = emit_pr_review_submitted(event_repo, message, payload)
-    local pr_lifecycle_event = pr_merged_event or pr_review_event
+    local pr_comment_event = emit_pr_comment(event_repo, message, payload)
+    local pr_lifecycle_event = pr_merged_event or pr_review_event or pr_comment_event
 
-    if pr_lifecycle_event and is_pr_lifecycle_message(message, payload) and not (payload.prompt or payload.context or payload.comment_body) then
+    if pr_lifecycle_event and is_pr_lifecycle_message(message, payload) then
         action_cable.perform(channel_id, "ack", { id = message.id })
         return
     end

--- a/catalog/templates/plugins/project-pipelines/init.lua
+++ b/catalog/templates/plugins/project-pipelines/init.lua
@@ -73,6 +73,16 @@ if events and events.on then
             log.warn("[project-pipelines] pr_review_submitted handler failed: " .. tostring(err))
         end
     end)
+
+    if _G.__project_pipelines_pr_comment_sub and events.off then
+        pcall(events.off, _G.__project_pipelines_pr_comment_sub)
+    end
+    _G.__project_pipelines_pr_comment_sub = events.on("pr_comment", function(data)
+        local ok, err = pcall(github_integration.handle_pr_comment, data)
+        if not ok then
+            log.warn("[project-pipelines] pr_comment handler failed: " .. tostring(err))
+        end
+    end)
 end
 
 if hooks and hooks.on then

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
@@ -14,6 +14,14 @@ local Agent = require("lib.agent")
 
 local OWNER = "project-pipelines"
 local SURFACE = "pipelines"
+local GITHUB_FORWARD_MARKER = "👀"
+
+local function github_forwarded(text)
+    if util.is_blank(text) then
+        return GITHUB_FORWARD_MARKER
+    end
+    return GITHUB_FORWARD_MARKER .. " " .. tostring(text)
+end
 
 local function lua_pattern_escape(value)
     return tostring(value):gsub("([^%w])", "%%%1")
@@ -325,7 +333,7 @@ local function spawn_step_agent(run, step, opts)
         "If you are reviewing, check correctness, regressions, architecture fit, missing tests, documentation gaps, overcomplication, hidden assumptions, dead code, deprecated code paths, and unwired implementation. Do not accept pre-existing failures as a blanket excuse; require exact evidence that a failure is unrelated or send the work back. Call project_pipelines_submit_review with findings or approval.",
     }, "\n\n")
     if not util.is_blank(opts.extra_prompt) then
-        role_prompt = role_prompt .. "\n\n" .. tostring(opts.extra_prompt)
+        role_prompt = role_prompt .. "\n\n" .. github_forwarded(opts.extra_prompt)
     end
 
     if existing and existing.agent_session_uuid and Agent.get(existing.agent_session_uuid) then
@@ -1045,7 +1053,7 @@ end
 local function pr_review_extra_prompt(ticket, link, event)
     local state = tostring(event.state or "commented")
     local lines = {
-        "A GitHub PR review was submitted for this ticket's linked PR.",
+        github_forwarded("A GitHub PR review was submitted for this ticket's linked PR."),
         "Review state: " .. state,
         "PR: " .. tostring(event.pr_url or link.pr_url or (tostring(link.repo) .. "#" .. tostring(link.pr_number))),
     }
@@ -1069,7 +1077,7 @@ end
 local function pr_steward_review_prompt(ticket, link, event)
     local state = tostring(event.state or "commented")
     local lines = {
-        "A GitHub PR review was submitted for a PR you steward for this Project Pipelines ticket.",
+        github_forwarded("A GitHub PR review was submitted for a PR you steward for this Project Pipelines ticket."),
         "Ticket: " .. tostring(ticket and (ticket.title or ticket.id) or link.ticket_id),
         "Review state: " .. state,
         "PR: " .. tostring(event.pr_url or link.pr_url or (tostring(link.repo) .. "#" .. tostring(link.pr_number))),
@@ -1087,6 +1095,28 @@ local function pr_steward_review_prompt(ticket, link, event)
     lines[#lines + 1] = "You are an orchestrator, not the implementer. Do not implement PR feedback yourself, and do not answer architecture/product questions from your own judgment alone when an existing ticket agent has relevant context."
     lines[#lines + 1] = "If the feedback is informational, answer on the PR using the GitHub MCP tools after checking the appropriate ticket context. If the human asked or said something through the PR, ask clarifying follow-up questions and provide answers on that PR thread instead of switching to project_pipelines_ask_human. If it needs code changes, delegate to the existing implementer with Botster MCP messaging tools such as list_hubs, post_message, and notify_session, and route the pipeline back to implementation when needed. If it is architectural/product reasoning, delegate to the existing planner or other context-owning ticket agent and synthesize their answer back to the PR. Use Project Pipelines human questions only for non-PR-originated decisions or when a durable pipeline-level waiver/decision record is required in addition to the PR reply."
     lines[#lines + 1] = "Do not create a new PR or new ticket run for ordinary PR review revisions. Keep the existing linked PR as the delivery envelope."
+    return table.concat(lines, "\n\n")
+end
+
+local function pr_steward_comment_prompt(ticket, link, event)
+    local action = tostring(event.action or "created")
+    local lines = {
+        github_forwarded("A GitHub PR conversation comment was " .. action .. " on a PR you steward for this Project Pipelines ticket."),
+        "Ticket: " .. tostring(ticket and (ticket.title or ticket.id) or link.ticket_id),
+        "PR: " .. tostring(event.pr_url or link.pr_url or (tostring(link.repo) .. "#" .. tostring(link.pr_number))),
+    }
+    if not util.is_blank(event.comment_url) then
+        lines[#lines + 1] = "Comment: " .. tostring(event.comment_url)
+    end
+    if not util.is_blank(event.comment_author) then
+        lines[#lines + 1] = "Author: " .. tostring(event.comment_author)
+    end
+    if not util.is_blank(event.comment_body) then
+        lines[#lines + 1] = "Comment body:\n" .. tostring(event.comment_body)
+    end
+    lines[#lines + 1] = "You are the PR steward. Triage this through project_pipelines_current_context and project_pipelines_get_ticket before acting."
+    lines[#lines + 1] = "If the human asked or said something through the PR, answer on that PR thread using the GitHub MCP tools after checking the appropriate ticket context. If it needs code changes, delegate to the existing implementer with Botster MCP messaging tools such as list_hubs, post_message, and notify_session, and route the pipeline back to implementation when needed."
+    lines[#lines + 1] = "Do not create a new PR or new ticket run for ordinary PR conversation comments. Keep the existing linked PR as the delivery envelope."
     return table.concat(lines, "\n\n")
 end
 
@@ -1130,7 +1160,7 @@ local function notify_merge_agent_of_pr_review(ticket, run, link, event)
         Hub.get():notify(session_uuid, {
             source = OWNER,
             title = state == "changes_requested" and "PR changes requested" or (state == "approved" and "PR approved" or "PR review submitted"),
-            body = "GitHub PR review feedback is ready for PR steward triage on ticket " .. tostring(ticket.title or ticket.id) .. ".",
+            body = github_forwarded("GitHub PR review feedback is ready for PR steward triage on ticket " .. tostring(ticket.title or ticket.id) .. "."),
             action = {
                 kind = "mcp_tool",
                 name = "project_pipelines_current_context",
@@ -1145,6 +1175,56 @@ local function notify_merge_agent_of_pr_review(ticket, run, link, event)
             pr_link_id = link.id,
             session_uuid = session_uuid,
             review_state = state,
+            delivered = ok,
+            error = ok and nil or tostring(err),
+        },
+    })
+    if ok then
+        return { session_uuid = session_uuid, prompted = true }
+    end
+    return nil
+end
+
+local function notify_merge_agent_of_pr_comment(ticket, run, link, event)
+    local session_uuid = live_merge_agent(ticket.id)
+    if util.is_blank(session_uuid) then
+        return nil
+    end
+    local instructions = pr_steward_comment_prompt(ticket, link, event)
+    local ok, err = pcall(function()
+        Hub.get():post(session_uuid, {
+            type = "task",
+            from_agent_id = OWNER,
+            from_label = "Project Pipelines",
+            payload = {
+                run_id = run.id,
+                ticket_id = ticket.id,
+                pr_link_id = link.id,
+                source_event = "pr_comment",
+                comment_id = event.comment_id,
+                comment_action = event.action,
+                instructions = instructions,
+            },
+        })
+        Hub.get():notify(session_uuid, {
+            source = OWNER,
+            title = "PR comment " .. tostring(event.action or "created"),
+            body = github_forwarded("GitHub PR conversation comment is ready for PR steward triage on ticket " .. tostring(ticket.title or ticket.id) .. "."),
+            action = {
+                kind = "mcp_tool",
+                name = "project_pipelines_current_context",
+                params = { run_id = run.id },
+            },
+        })
+    end)
+    repo.append_event("ticket.pr_comment_steward_prompted", {
+        run_id = run.id,
+        ticket_id = ticket.id,
+        payload = {
+            pr_link_id = link.id,
+            session_uuid = session_uuid,
+            comment_id = event.comment_id,
+            comment_action = event.action,
             delivered = ok,
             error = ok and nil or tostring(err),
         },
@@ -1250,6 +1330,46 @@ function M.handle_pr_review_submitted(link, event)
 
     refresh_surfaces()
     return { ok = true, status = "reactivated", ticket = ticket, run = repo.get_run(run.id), step = step, run_step = repo.get_run_step_visit(visit.id), agent = agent }
+end
+
+function M.handle_pr_comment(link, event)
+    link = link or {}
+    event = event or {}
+    local ticket = repo.get_ticket(link.ticket_id)
+    local run = link.run_id and repo.get_run(link.run_id) or nil
+    if not run and ticket then
+        run = repo.latest_ticket_run(ticket.id)
+    end
+    if not ticket or not run then
+        return { ok = false, reason = "missing_ticket_or_run" }
+    end
+
+    repo.append_event("ticket.pr_comment", {
+        run_id = run.id,
+        ticket_id = ticket.id,
+        payload = {
+            pr_link_id = link.id,
+            provider = link.provider,
+            repo = link.repo,
+            pr_number = link.pr_number,
+            pr_url = event.pr_url or link.pr_url,
+            comment_id = event.comment_id,
+            comment_url = event.comment_url,
+            comment_author = event.comment_author,
+            comment_body = event.comment_body,
+            action = event.action,
+            created_at = event.created_at,
+            updated_at = event.updated_at,
+        },
+    })
+
+    local steward = notify_merge_agent_of_pr_comment(ticket, run, link, event)
+    refresh_surfaces()
+    if steward then
+        return { ok = true, status = "steward_prompted", ticket = ticket, run = run, pr_steward = steward }
+    end
+
+    return { ok = true, status = "recorded", reason = "no_steward", ticket = ticket, run = run }
 end
 
 function M.start_run(params)

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/github_integration.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/github_integration.lua
@@ -96,4 +96,24 @@ function M.handle_pr_review_submitted(event)
     return result
 end
 
+function M.handle_pr_comment(event)
+    event = event or {}
+    if util.is_blank(event.repo) or util.is_blank(event.pr_number) then
+        return { ok = false, reason = "missing_repo_or_pr_number" }
+    end
+
+    local link = repo.find_pr_link{
+        provider = normalize_provider(event.provider),
+        repo = event.repo,
+        pr_number = event.pr_number,
+    }
+    if not link then
+        return { ok = false, reason = "pr_not_linked" }
+    end
+
+    local result = engine.handle_pr_comment(link, event)
+    result.pr_link = link
+    return result
+end
+
 return M

--- a/cli/tests/github_plugin_template_test.rs
+++ b/cli/tests/github_plugin_template_test.rs
@@ -889,6 +889,7 @@ fn catalog_plugin_github_event_routing_template_notifies_matching_agent_before_c
 
             assert(#notifications == 1)
             assert(notifications[1]:match("Please inspect this"))
+            assert(notifications[1]:match("👀"))
             assert(creates == 0)
             assert(deletes == 0)
             assert(acked == true)
@@ -975,4 +976,95 @@ fn catalog_plugin_github_event_routing_emits_pr_review_submitted() {
         json!("changes_requested")
     );
     assert_eq!(result["emitted"][0]["event"]["reviewer"], json!("reviewer"));
+}
+
+#[test]
+fn catalog_plugin_github_event_routing_emits_pr_comment_and_does_not_spawn_agent() {
+    let template_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("catalog/templates/plugins/github/event_routing.lua");
+    let template_path = template_path.to_str().unwrap();
+
+    let lua = create_lua_vm();
+
+    let result: JsonValue = lua
+        .load(format!(
+            r#"
+            local emitted = {{}}
+            local acked = false
+            local callback = nil
+            local find_calls = 0
+            local create_calls = 0
+
+            package.loaded["lib.agent"] = {{
+              find_by_workspace = function()
+                find_calls = find_calls + 1
+                return {{}}
+              end,
+            }}
+            package.loaded["hub.state"] = {{ get = function() return {{}} end }}
+            package.loaded["lib.hub"] = {{
+              get = function()
+                return {{
+                  create_agent = function()
+                    create_calls = create_calls + 1
+                  end,
+                }}
+              end,
+            }}
+            events = {{
+              emit = function(name, event)
+                emitted[#emitted + 1] = {{ name = name, event = event }}
+                return 1
+              end,
+            }}
+            action_cable = {{
+              connect = function() return "conn-1" end,
+              subscribe = function(_, _, _, cb)
+                callback = cb
+                return "chan-1"
+              end,
+              perform = function(_, action, data)
+                if action == "ack" and data.id == 10 then acked = true end
+              end,
+              close = function() end,
+            }}
+
+            local routing = dofile("{template_path}")
+            routing.start("owner/repo")
+            callback({{
+              id = 10,
+              event_type = "pull_request_comment",
+              repo = "owner/repo",
+              payload = {{
+                action = "created",
+                repo = "owner/repo",
+                pr_number = 42,
+                pr_url = "https://github.com/owner/repo/pull/42",
+                comment_id = 456,
+                comment_html_url = "https://github.com/owner/repo/pull/42#issuecomment-456",
+                comment_body = "Can this be clearer?",
+                comment_author = "reviewer",
+                created_at = "2026-05-20T12:00:00Z",
+                updated_at = "2026-05-20T12:00:00Z",
+              }},
+            }}, "chan-1")
+
+            assert(acked == true)
+            assert(find_calls == 0)
+            assert(create_calls == 0)
+            return {{ emitted = emitted, find_calls = find_calls, create_calls = create_calls }}
+            "#
+        ))
+        .eval()
+        .and_then(|value: Value| lua.from_value(value))
+        .expect("GitHub event routing should emit PR comments without generic agent fallback");
+
+    assert_eq!(result["emitted"][0]["name"], json!("pr_comment"));
+    assert_eq!(result["emitted"][0]["event"]["repo"], json!("owner/repo"));
+    assert_eq!(result["emitted"][0]["event"]["pr_number"], json!(42));
+    assert_eq!(result["emitted"][0]["event"]["comment_body"], json!("Can this be clearer?"));
+    assert_eq!(result["find_calls"], json!(0));
+    assert_eq!(result["create_calls"], json!(0));
 }

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -1056,6 +1056,7 @@ fn catalog_plugin_project_pipelines_routes_pr_review_to_live_merge_steward() {
             assert(posted.message.type == "task")
             assert(posted.message.payload.source_event == "pr_review_submitted")
             assert(posted.message.payload.review_state == "changes_requested")
+            assert(posted.message.payload.instructions:match("👀"))
             assert(posted.message.payload.instructions:match("Please fix the failing path%."))
             assert(posted.message.payload.instructions:match("You are an orchestrator, not the implementer"))
             assert(posted.message.payload.instructions:match("Do not implement PR feedback yourself"))
@@ -1066,6 +1067,7 @@ fn catalog_plugin_project_pipelines_routes_pr_review_to_live_merge_steward() {
             assert(posted.message.payload.instructions:match("notify_session"))
             assert(notified.session_uuid == "sess-merge")
             assert(notified.notification.title == "PR changes requested")
+            assert(notified.notification.body:match("👀"))
             assert(notified.notification.action.name == "project_pipelines_current_context")
             assert(events[1].kind == "ticket.pr_review_submitted")
             assert(events[2].kind == "ticket.pr_review_steward_prompted")
@@ -1075,6 +1077,246 @@ fn catalog_plugin_project_pipelines_routes_pr_review_to_live_merge_steward() {
         ))
         .eval()
         .expect("PR review changes should route to the live merge steward");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_routes_pr_comment_to_live_merge_steward() {
+    let lua = Lua::new();
+    log::register(&lua).expect("register log");
+    botster::lua::primitives::json::register(&lua).expect("register json");
+
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+
+            local events = {{}}
+            local posted = nil
+            local notified = nil
+
+            package.loaded["lib.agent"] = {{
+              get = function(session_uuid)
+                if session_uuid == "sess-merge" then
+                  return {{ info = function() return {{ session_uuid = session_uuid }} end }}
+                end
+                return nil
+              end,
+            }}
+            package.loaded["lib.hub"] = {{
+              get = function()
+                return {{
+                  post = function(_, session_uuid, message)
+                    posted = {{ session_uuid = session_uuid, message = message }}
+                  end,
+                  notify = function(_, session_uuid, notification)
+                    notified = {{ session_uuid = session_uuid, notification = notification }}
+                  end,
+                }}
+              end,
+            }}
+            package.loaded["project_pipelines.notification_policy"] = {{
+              notify_phase_transition = function() end,
+            }}
+            package.loaded["project_pipelines.entities"] = {{
+              register = function() end,
+              publish_snapshots = function() end,
+            }}
+            package.loaded["project_pipelines.repo"] = {{
+              find_pr_link = function(attrs)
+                assert(attrs.provider == "github")
+                assert(attrs.repo == "owner/repo")
+                assert(attrs.pr_number == 42)
+                return {{
+                  id = "pr-1",
+                  provider = "github",
+                  repo = "owner/repo",
+                  pr_number = 42,
+                  pr_url = "https://github.com/owner/repo/pull/42",
+                  ticket_id = "ticket-1",
+                  run_id = "run-1",
+                  status = "open",
+                }}
+              end,
+              get_ticket = function(ticket_id)
+                assert(ticket_id == "ticket-1")
+                return {{ id = "ticket-1", title = "Ship review loop", status = "open", target_id = "target-1" }}
+              end,
+              get_run = function(run_id)
+                assert(run_id == "run-1")
+                return {{ id = "run-1", ticket_id = "ticket-1", pipeline_id = "pipeline-1", status = "done", target_id = "target-1", current_step_id = false, current_run_step_id = false }}
+              end,
+              latest_ticket_run = function() error("linked run should be used") end,
+              ticket_events = function(ticket_id, kind)
+                assert(ticket_id == "ticket-1")
+                if kind == "ticket.merge_agent_linked" then
+                  return {{ {{ payload = "{{\"session_uuid\":\"sess-merge\"}}" }} }}
+                end
+                return {{}}
+              end,
+              pipeline_steps = function()
+                error("PR comment steward path must not inspect implementation steps")
+              end,
+              create_run_step_visit = function()
+                error("PR comment steward path must not create an implementation visit")
+              end,
+              update_run = function()
+                error("PR comment steward path must not reactivate the run directly")
+              end,
+              append_event = function(kind, event)
+                events[#events + 1] = {{ kind = kind, event = event }}
+              end,
+            }}
+
+            local integration = require("project_pipelines.github_integration")
+            local response = integration.handle_pr_comment({{
+              provider = "github",
+              repo = "owner/repo",
+              pr_number = 42,
+              pr_url = "https://github.com/owner/repo/pull/42",
+              comment_id = 456,
+              comment_url = "https://github.com/owner/repo/pull/42#issuecomment-456",
+              comment_author = "reviewer",
+              comment_body = "Can this be clearer?",
+              action = "created",
+              created_at = "2026-05-20T12:00:00Z",
+            }})
+
+            assert(response.ok == true)
+            assert(response.status == "steward_prompted")
+            assert(response.pr_steward.session_uuid == "sess-merge")
+            assert(posted.session_uuid == "sess-merge")
+            assert(posted.message.type == "task")
+            assert(posted.message.payload.source_event == "pr_comment")
+            assert(posted.message.payload.comment_id == 456)
+            assert(posted.message.payload.instructions:match("👀"))
+            assert(posted.message.payload.instructions:match("Can this be clearer%?"))
+            assert(posted.message.payload.instructions:match("answer on that PR thread"))
+            assert(notified.session_uuid == "sess-merge")
+            assert(notified.notification.body:match("👀"))
+            assert(notified.notification.action.name == "project_pipelines_current_context")
+            assert(events[1].kind == "ticket.pr_comment")
+            assert(events[2].kind == "ticket.pr_comment_steward_prompted")
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display()
+        ))
+        .eval()
+        .expect("PR comments should route to the live merge steward");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_records_pr_comment_without_merge_steward() {
+    let lua = Lua::new();
+    log::register(&lua).expect("register log");
+
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+
+            local events = {{}}
+            local posted = nil
+            local notified = nil
+
+            package.loaded["lib.agent"] = {{
+              get = function() return nil end,
+            }}
+            package.loaded["lib.hub"] = {{
+              get = function()
+                return {{
+                  post = function(_, session_uuid, message)
+                    posted = {{ session_uuid = session_uuid, message = message }}
+                  end,
+                  notify = function(_, session_uuid, notification)
+                    notified = {{ session_uuid = session_uuid, notification = notification }}
+                  end,
+                }}
+              end,
+            }}
+            package.loaded["project_pipelines.notification_policy"] = {{
+              notify_phase_transition = function() error("PR comment without steward must not transition phase") end,
+            }}
+            package.loaded["project_pipelines.entities"] = {{
+              register = function() end,
+              publish_snapshots = function() end,
+            }}
+            package.loaded["project_pipelines.repo"] = {{
+              find_pr_link = function(attrs)
+                assert(attrs.provider == "github")
+                assert(attrs.repo == "owner/repo")
+                assert(attrs.pr_number == 42)
+                return {{
+                  id = "pr-1",
+                  provider = "github",
+                  repo = "owner/repo",
+                  pr_number = 42,
+                  pr_url = "https://github.com/owner/repo/pull/42",
+                  ticket_id = "ticket-1",
+                  run_id = "run-1",
+                  status = "open",
+                }}
+              end,
+              get_ticket = function(ticket_id)
+                assert(ticket_id == "ticket-1")
+                return {{ id = "ticket-1", title = "Ship review loop", status = "open", target_id = "target-1" }}
+              end,
+              get_run = function(run_id)
+                assert(run_id == "run-1")
+                return {{ id = "run-1", ticket_id = "ticket-1", pipeline_id = "pipeline-1", status = "done", target_id = "target-1", current_step_id = false, current_run_step_id = false }}
+              end,
+              latest_ticket_run = function() error("linked run should be used") end,
+              ticket_events = function(ticket_id, kind)
+                assert(ticket_id == "ticket-1")
+                assert(kind == "ticket.merge_agent_linked" or kind == "ticket.merge_requested")
+                return {{}}
+              end,
+              pipeline_steps = function()
+                error("PR comment without steward must not inspect implementation steps")
+              end,
+              create_run_step_visit = function()
+                error("PR comment without steward must not create an implementation visit")
+              end,
+              update_run = function()
+                error("PR comment without steward must not mutate the run")
+              end,
+              latest_step_session = function()
+                error("PR comment without steward must not look up implementation sessions")
+              end,
+              append_event = function(kind, event)
+                events[#events + 1] = {{ kind = kind, event = event }}
+              end,
+            }}
+
+            local integration = require("project_pipelines.github_integration")
+            local response = integration.handle_pr_comment({{
+              provider = "github",
+              repo = "owner/repo",
+              pr_number = 42,
+              comment_id = 456,
+              comment_body = "Can this be clearer?",
+              action = "created",
+            }})
+
+            assert(response.ok == true)
+            assert(response.status == "recorded")
+            assert(response.reason == "no_steward")
+            assert(posted == nil)
+            assert(notified == nil)
+            assert(#events == 1)
+            assert(events[1].kind == "ticket.pr_comment")
+            assert(events[1].event.payload.comment_id == 456)
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display()
+        ))
+        .eval()
+        .expect("PR comments without a steward should be recorded only");
 
     assert_eq!(result, "ok");
 }
@@ -1208,6 +1450,7 @@ fn catalog_plugin_project_pipelines_falls_back_to_existing_implementer_when_no_m
             assert(response.status == "reactivated")
             assert(response.agent.reused == true)
             assert(posted.session_uuid == "sess-impl")
+            assert(posted.message.payload.instructions:match("👀"))
             assert(posted.message.payload.instructions:match("Please fix the failing path%."))
             assert(notified.notification.title == "PR changes requested")
             assert(#visits == 1)

--- a/test/controllers/github/webhooks_controller_test.rb
+++ b/test/controllers/github/webhooks_controller_test.rb
@@ -240,7 +240,7 @@ module Github
       body, signature = sign_webhook_payload(payload)
 
       with_stubbed_github do
-        assert_difference "Integrations::Github::Message.count", 1 do
+        assert_difference "Integrations::Github::Message.count", 2 do
           post "/github/webhooks",
             params: body,
             headers: {
@@ -251,9 +251,62 @@ module Github
         end
       end
 
-      message = Integrations::Github::Message.last
+      message = Integrations::Github::Message.where(event_type: "github_mention").last
       assert_equal 100, message.issue_number
       assert_equal true, message.payload["is_pr"]
+    end
+
+    test "issue_comment on PR without mention creates PR comment lifecycle message" do
+      payload = {
+        action: "created",
+        issue: {
+          number: 100,
+          title: "Test PR",
+          body: "PR body without issue link",
+          html_url: "https://github.com/test/repo/pull/100",
+          pull_request: { url: "https://api.github.com/repos/test/repo/pulls/100" }
+        },
+        comment: {
+          id: 888,
+          url: "https://api.github.com/repos/test/repo/issues/comments/888",
+          html_url: "https://github.com/test/repo/pull/100#issuecomment-888",
+          body: "Can this be clearer?",
+          created_at: "2026-05-20T12:00:00Z",
+          updated_at: "2026-05-20T12:00:00Z",
+          user: { login: "reviewer" }
+        },
+        repository: {
+          full_name: "test/repo"
+        },
+        installation: {
+          id: 12345
+        }
+      }
+
+      body, signature = sign_webhook_payload(payload)
+
+      assert_difference "Integrations::Github::Message.count", 1 do
+        post "/github/webhooks",
+          params: body,
+          headers: {
+            "Content-Type" => "application/json",
+            "X-GitHub-Event" => "issue_comment",
+            "X-Hub-Signature-256" => signature
+          }
+      end
+
+      message = Integrations::Github::Message.last
+      assert_equal "pull_request_comment", message.event_type
+      assert_equal "test/repo", message.repo
+      assert_equal 100, message.issue_number
+      assert_equal "created", message.payload["action"]
+      assert_equal 100, message.payload["pr_number"]
+      assert_equal "https://github.com/test/repo/pull/100", message.payload["pr_url"]
+      assert_equal 888, message.payload["comment_id"]
+      assert_equal "https://github.com/test/repo/pull/100#issuecomment-888", message.payload["comment_html_url"]
+      assert_equal "Can this be clearer?", message.payload["comment_body"]
+      assert_equal "reviewer", message.payload["comment_author"]
+      assert_equal "2026-05-20T12:00:00Z", message.payload["created_at"]
     end
 
     test "issue_comment on PR with linked issue routes to issue" do
@@ -285,7 +338,7 @@ module Github
         }) do
           body, signature = sign_webhook_payload(payload)
 
-          assert_difference "Integrations::Github::Message.count", 1 do
+          assert_difference "Integrations::Github::Message.count", 2 do
             post "/github/webhooks",
               params: body,
               headers: {
@@ -295,7 +348,7 @@ module Github
               }
           end
 
-          message = Integrations::Github::Message.last
+          message = Integrations::Github::Message.where(event_type: "github_mention").last
           assert_equal 50, message.issue_number, "Should route to linked issue #50"
           assert_equal false, message.payload["is_pr"], "Should be marked as issue, not PR"
 

--- a/test/models/integrations/github/message_test.rb
+++ b/test/models/integrations/github/message_test.rb
@@ -178,6 +178,16 @@ class Integrations::Github::MessageTest < ActiveSupport::TestCase
     assert_includes message.errors[:event_type], "invalid_type is not a valid event type"
   end
 
+  test "allows pull_request_comment event type" do
+    message = Integrations::Github::Message.new(
+      event_type: "pull_request_comment",
+      repo: "test/repo",
+      payload: { repo: "test/repo", pr_number: 1, comment_id: 123 }
+    )
+
+    assert message.valid?
+  end
+
   test "validates repo presence" do
     message = Integrations::Github::Message.new(
       event_type: "github_mention",


### PR DESCRIPTION
## Summary

Fixes Project Pipelines handling for standalone GitHub PR conversation comments on linked PRs.

- Rails records non-bot created/edited PR `issue_comment` webhooks as `pull_request_comment` lifecycle messages even without `@trybotster`.
- GitHub plugin routing emits terminal `pr_comment` lifecycle events and fences them from generic agent creation, including when comment body fields are present.
- Project Pipelines subscribes to `pr_comment`, resolves linked PRs, records `ticket.pr_comment`, and forwards live steward tasks/notifications with the 👀 marker. No-steward comments are recorded-only.
- Existing GitHub-origin review/forwarding prompts touched by this path now include the 👀 marker.

## Verification

Clean branch `project-pipelines/ticket_1779306633_570660-pr` was cherry-picked onto `origin/main` as commit `f7848999`.

- `bin/rails test test/controllers/github/webhooks_controller_test.rb test/models/integrations/github/message_test.rb` - 44 runs, 188 assertions, 0 failures
- `cd cli && ./test.sh --integration -- catalog_plugin_github_event_routing_emits_pr_comment_and_does_not_spawn_agent` - 1 matching test passed
- `cd cli && ./test.sh --integration -- catalog_plugin_project_pipelines_routes_pr_comment_to_live_merge_steward` - 1 matching test passed
- `cd cli && ./test.sh --integration -- catalog_plugin_project_pipelines_records_pr_comment_without_merge_steward` - 1 matching test passed
- `cd cli && ./test.sh --integration -- catalog_plugin_project_pipelines_routes_pr_review_to_live_merge_steward` - 1 matching test passed
- `git diff --check origin/main...HEAD` - clean

Ticket: ticket_1779306633_570660
Run: run_1779306640_322044