### PR TITLE
Source Botster Stack Delivery definitions and route TUI kit

### DIFF
--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -13,8 +13,11 @@ Device-level Botster development plugin for project/ticket workflows.
 
 The plugin is intentionally split across modules:
 
-- `init.lua` clears hot-reload module cache, registers tools, surfaces, and events.
+- `init.lua` clears hot-reload module cache, prunes legacy seed data, reconciles
+  package-owned definitions, then registers tools, surfaces, and events.
 - `project_pipelines/db.lua` owns the plugin SQLite schema.
+- `project_pipelines/source_definitions.lua` owns checked-in package pipeline
+  structure, prompts, stable IDs, and repository routing.
 - `project_pipelines/repo.lua` owns persistence and audit events.
 - `project_pipelines/entity_contract.lua` owns published entity type names and read-model field contracts.
 - `project_pipelines/entities.lua` owns plugin entity read models and publishes dynamic state to clients.
@@ -47,10 +50,16 @@ The plugin is intentionally split across modules:
 
 ## Pipeline Definitions
 
-The plugin does not seed default pipelines or sample tickets. Users and agents
-create reusable pipeline definitions explicitly through the GUI and MCP tools.
-Projects are the durable container for multi-phase or cross-target work; tickets
-remain one concrete unit of work in one spawn target.
+The plugin does not seed sample tickets or arbitrary default pipelines. Botster
+Stack Delivery is a narrow package-owned definition reconciled idempotently
+from `project_pipelines/source_definitions.lua`; users and agents create every
+other reusable pipeline explicitly through the GUI and MCP tools. Package-owned
+pipeline metadata, steps, transitions, prompts, and gates are read-only through
+public APIs. Step agent selection remains device-local operator policy: source
+values initialize a missing step, while later reconciliation preserves the
+operator's choice. Projects are the durable container for multi-phase or
+cross-target work; tickets remain one concrete unit of work in one spawn
+target.
 
 Pipeline MCP CRUD:
 
@@ -555,9 +564,14 @@ metadata explicitly. Merge agents for PR pipelines must open stacked PRs against
 
 State lives in the plugin database at the Botster device data root under `plugin-data/project-pipelines/db.sqlite`. The schema is additive-friendly, but non-additive changes need an explicit `version` bump and migration function in `project_pipelines_db.lua`.
 
-During the first load after the seedless pipeline change, the plugin performs a
-one-shot cleanup check for the old `massive_feature` seed pipeline and records a
-`pipeline.legacy_prune_checked` event so hot reloads do not repeat the cleanup.
+During startup, the plugin first performs the one-shot cleanup check for the old
+`massive_feature` seed pipeline and records a `pipeline.legacy_prune_checked`
+event so hot reloads do not repeat the cleanup. It then reconciles Botster Stack
+Delivery from `project_pipelines/source_definitions.lua` before registering
+entities, MCP tools, and surfaces. Reconciliation updates stable rows in place,
+preserves run history and device-local agent selections, removes graph drift,
+and is a no-op when the database already matches the checked-in source.
+User-owned definitions retain normal GUI and MCP CRUD behavior.
 
 ## Starting A Run
 

--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -55,11 +55,12 @@ Stack Delivery is a narrow package-owned definition reconciled idempotently
 from `project_pipelines/source_definitions.lua`; users and agents create every
 other reusable pipeline explicitly through the GUI and MCP tools. Package-owned
 pipeline metadata, steps, transitions, prompts, and gates are read-only through
-public APIs. Step agent selection remains device-local operator policy: source
-values initialize a missing step, while later reconciliation preserves the
-operator's choice. Projects are the durable container for multi-phase or
-cross-target work; tickets remain one concrete unit of work in one spawn
-target.
+public APIs. Its lifecycle is source-controlled too: archiving, retiring, or
+replacing Botster Stack Delivery requires changing the checked-in definition.
+Step agent selection remains device-local operator policy: source values
+initialize a missing step, while later reconciliation preserves the operator's
+choice. Projects are the durable container for multi-phase or cross-target work;
+tickets remain one concrete unit of work in one spawn target.
 
 Pipeline MCP CRUD:
 
@@ -571,7 +572,11 @@ Delivery from `project_pipelines/source_definitions.lua` before registering
 entities, MCP tools, and surfaces. Reconciliation updates stable rows in place,
 preserves run history and device-local agent selections, removes graph drift,
 and is a no-op when the database already matches the checked-in source.
-User-owned definitions retain normal GUI and MCP CRUD behavior.
+Historical steps and gates that no longer appear in source are retained when
+run or gate-result history still references them, with an audit event recording
+the skipped prune. User-owned definitions retain normal GUI and MCP CRUD
+behavior, and only user-owned definitions participate in implicit default
+selection when a caller omits `pipeline_id`.
 
 ## Starting A Run
 

--- a/catalog/templates/plugins/project-pipelines/init.lua
+++ b/catalog/templates/plugins/project-pipelines/init.lua
@@ -9,6 +9,7 @@ for _, module_name in ipairs({
     "project_pipelines.util",
     "project_pipelines.db",
     "project_pipelines.entity_contract",
+    "project_pipelines.source_definitions",
     "project_pipelines.repo",
     "project_pipelines.entities",
     "project_pipelines.engine",
@@ -38,6 +39,7 @@ local surface = require("project_pipelines.web.surface")
 local M = {}
 
 repo.prune_legacy_seed_data()
+repo.reconcile_sourced_definitions()
 engine.register_entities()
 notification_policy.register()
 mcp_tools.register()

--- a/catalog/templates/plugins/project-pipelines/init.lua
+++ b/catalog/templates/plugins/project-pipelines/init.lua
@@ -39,8 +39,15 @@ local surface = require("project_pipelines.web.surface")
 local M = {}
 
 repo.prune_legacy_seed_data()
-repo.reconcile_sourced_definitions()
+local reconciled_ok, reconciled = pcall(repo.reconcile_sourced_definitions)
+if not reconciled_ok then
+    log.warn("[project-pipelines] source reconciliation failed: " .. tostring(reconciled))
+    reconciled = false
+end
 engine.register_entities()
+if reconciled then
+    engine.publish_entity_snapshots()
+end
 notification_policy.register()
 mcp_tools.register()
 surface.register()

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/repo.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/repo.lua
@@ -1330,6 +1330,23 @@ local function insert_sourced_pipeline(definition, now)
     }
 end
 
+local function record_source_prune_skipped(definition, entity_type, entity_id, reason)
+    local payload = {
+        pipeline_id = definition.id,
+        entity_type = entity_type,
+        entity_id = entity_id,
+        reason = reason,
+        source_path = source_definitions.source_path(),
+    }
+    if not first(
+        "SELECT id FROM events WHERE kind = ? AND payload = ? LIMIT 1",
+        "pipeline.source_prune_skipped",
+        util.encode(payload))
+    then
+        M.append_event("pipeline.source_prune_skipped", { payload = payload })
+    end
+end
+
 local function reconcile_sourced_definition(definition)
     local now = util.now()
     local changed = false
@@ -1406,20 +1423,39 @@ local function reconcile_sourced_definition(definition)
         end
     end
 
-    -- Package authority owns the exact graph shape. These private deletes sit
-    -- below public history guards and cannot be reached through MCP or UI.
+    -- Package authority owns the exact graph shape, but historical rows remain
+    -- durable evidence. Drift with history stays visible instead of being
+    -- silently orphaned by the private reconciliation path.
     for _, step in ipairs(M.pipeline_steps(definition.id)) do
         for _, gate in ipairs(M.step_gates(step.id)) do
             if not gate_ids[gate.id] then
-                db:eval("DELETE FROM pipeline_gates WHERE id = ?", gate.id)
-                changed = true
+                local usage = first("SELECT COUNT(*) AS count FROM gate_results WHERE gate_id = ?", gate.id)
+                if usage and tonumber(usage.count or 0) > 0 then
+                    record_source_prune_skipped(
+                        definition,
+                        "pipeline_gate",
+                        gate.id,
+                        "existing gate result history")
+                else
+                    db:eval("DELETE FROM pipeline_gates WHERE id = ?", gate.id)
+                    changed = true
+                end
             end
         end
     end
     for _, step in ipairs(M.pipeline_steps(definition.id)) do
         if not step_ids[step.id] then
-            db:eval("DELETE FROM pipeline_steps WHERE id = ?", step.id)
-            changed = true
+            local usage = first("SELECT COUNT(*) AS count FROM run_steps WHERE step_id = ?", step.id)
+            if usage and tonumber(usage.count or 0) > 0 then
+                record_source_prune_skipped(
+                    definition,
+                    "pipeline_step",
+                    step.id,
+                    "existing run step history")
+            else
+                db:eval("DELETE FROM pipeline_steps WHERE id = ?", step.id)
+                changed = true
+            end
         end
     end
 
@@ -1441,16 +1477,16 @@ function M.reconcile_sourced_definitions()
             changed = reconcile_sourced_definition(definition) or changed
         end
     end)
-    if changed then
-        publish_entity_snapshot("pipeline")
-        publish_entity_snapshot("pipeline_step")
-        publish_entity_snapshot("pipeline_gate")
-    end
     return changed
 end
 
 function M.get_default_pipeline()
-    return first("SELECT * FROM pipelines WHERE archived_at IS NULL ORDER BY created_at ASC LIMIT 1")
+    for _, pipeline in ipairs(M.list_pipelines()) do
+        if not source_definitions.is_sourced_pipeline_id(pipeline.id) then
+            return pipeline
+        end
+    end
+    return nil
 end
 
 function M.pipeline_steps(pipeline_id)

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/repo.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/repo.lua
@@ -6,6 +6,7 @@
 -- @version 1.1.0
 
 local db = require("project_pipelines.db")
+local source_definitions = require("project_pipelines.source_definitions")
 local util = require("project_pipelines.util")
 
 local M = {}
@@ -73,6 +74,41 @@ local GATE_UPDATE_FIELDS = {
     required_fields = true,
     command = true,
 }
+
+local function sourced_definition_error()
+    error(
+        "Botster Stack Delivery structure is package-owned; edit the checked-in source at "
+        .. source_definitions.source_path())
+end
+
+local function sourced_step(step)
+    if not step then
+        return false
+    end
+    return source_definitions.pipeline_id_for_step(step.id) ~= nil
+        or source_definitions.is_sourced_pipeline_id(step.pipeline_id)
+end
+
+local function sourced_gate(gate)
+    if not gate then
+        return false
+    end
+    if source_definitions.step_id_for_gate(gate.id) ~= nil then
+        return true
+    end
+    return sourced_step(db.pipeline_steps:where{ id = gate.step_id })
+end
+
+local function assert_public_step_update_allowed(step, attrs)
+    if not sourced_step(step) then
+        return
+    end
+    for field, _value in pairs(attrs or {}) do
+        if field ~= "agent_name" then
+            sourced_definition_error()
+        end
+    end
+end
 
 local TICKET_UPDATE_FIELDS = {
     title = true,
@@ -1254,6 +1290,165 @@ function M.get_pipeline_definition(pipeline_id)
     return pipeline
 end
 
+local function exact_update(model, table_name, current, desired, fields, now)
+    local set = {}
+    local clear = {}
+    local changed = false
+    for _, field in ipairs(fields) do
+        if current[field] ~= desired[field] then
+            changed = true
+            if desired[field] == nil then
+                clear[#clear + 1] = field
+            else
+                set[field] = desired[field]
+            end
+        end
+    end
+    if not changed then
+        return false
+    end
+    set.updated_at = now
+    model:update{ where = { id = current.id }, set = set }
+    for _, field in ipairs(clear) do
+        db:eval("UPDATE " .. table_name .. " SET " .. field .. " = NULL WHERE id = ?", current.id)
+    end
+    return true
+end
+
+local function insert_sourced_pipeline(definition, now)
+    db.pipelines:insert{
+        id = definition.id,
+        name = definition.name,
+        description = definition.description,
+        merge_policy = definition.merge_policy,
+        version_label = definition.version_label,
+        archived_at = definition.archived_at,
+        replacement_pipeline_id = definition.replacement_pipeline_id,
+        supersedes_pipeline_id = definition.supersedes_pipeline_id,
+        created_at = now,
+        updated_at = now,
+    }
+end
+
+local function reconcile_sourced_definition(definition)
+    local now = util.now()
+    local changed = false
+    local step_ids = {}
+    local gate_ids = {}
+
+    local pipeline = M.get_pipeline(definition.id)
+    if not pipeline then
+        insert_sourced_pipeline(definition, now)
+        changed = true
+    else
+        changed = exact_update(
+            db.pipelines,
+            "pipelines",
+            pipeline,
+            definition,
+            source_definitions.pipeline_fields(),
+            now) or changed
+    end
+
+    -- Insert every missing step without transitions first. The second pass can
+    -- then converge links after all stable step IDs exist.
+    for _, source_step in ipairs(definition.steps or {}) do
+        step_ids[source_step.id] = true
+        if not M.get_step(source_step.id) then
+            insert_step({
+                id = source_step.id,
+                pipeline_id = definition.id,
+                position = source_step.position,
+                kind = source_step.kind,
+                name = source_step.name,
+                agent_name = source_step.agent_name,
+                prompt = source_step.prompt,
+                command = source_step.command,
+            }, now)
+            changed = true
+        end
+    end
+
+    for _, source_step in ipairs(definition.steps or {}) do
+        local step = M.get_step(source_step.id)
+        local desired = util.copy(source_step)
+        desired.pipeline_id = definition.id
+        desired.gates = nil
+        -- agent_name is insertion policy. Existing operator choices are never
+        -- reconciled from the package source.
+        desired.agent_name = nil
+        changed = exact_update(
+            db.pipeline_steps,
+            "pipeline_steps",
+            step,
+            desired,
+            source_definitions.step_fields(),
+            now) or changed
+
+        for _, source_gate in ipairs(source_step.gates or {}) do
+            gate_ids[source_gate.id] = true
+            local desired_gate = util.copy(source_gate)
+            desired_gate.step_id = source_step.id
+            desired_gate.required_fields = encode_required_fields(desired_gate.required_fields)
+            local gate = M.get_gate(source_gate.id)
+            if not gate then
+                insert_gate(desired_gate, now)
+                changed = true
+            else
+                changed = exact_update(
+                    db.pipeline_gates,
+                    "pipeline_gates",
+                    gate,
+                    desired_gate,
+                    source_definitions.gate_fields(),
+                    now) or changed
+            end
+        end
+    end
+
+    -- Package authority owns the exact graph shape. These private deletes sit
+    -- below public history guards and cannot be reached through MCP or UI.
+    for _, step in ipairs(M.pipeline_steps(definition.id)) do
+        for _, gate in ipairs(M.step_gates(step.id)) do
+            if not gate_ids[gate.id] then
+                db:eval("DELETE FROM pipeline_gates WHERE id = ?", gate.id)
+                changed = true
+            end
+        end
+    end
+    for _, step in ipairs(M.pipeline_steps(definition.id)) do
+        if not step_ids[step.id] then
+            db:eval("DELETE FROM pipeline_steps WHERE id = ?", step.id)
+            changed = true
+        end
+    end
+
+    if changed then
+        M.append_event("pipeline.source_reconciled", {
+            payload = {
+                pipeline_id = definition.id,
+                source_path = source_definitions.source_path(),
+            },
+        })
+    end
+    return changed
+end
+
+function M.reconcile_sourced_definitions()
+    local changed = false
+    with_transaction(function()
+        for _, definition in ipairs(source_definitions.definitions()) do
+            changed = reconcile_sourced_definition(definition) or changed
+        end
+    end)
+    if changed then
+        publish_entity_snapshot("pipeline")
+        publish_entity_snapshot("pipeline_step")
+        publish_entity_snapshot("pipeline_gate")
+    end
+    return changed
+end
+
 function M.get_default_pipeline()
     return first("SELECT * FROM pipelines WHERE archived_at IS NULL ORDER BY created_at ASC LIMIT 1")
 end
@@ -1270,6 +1465,9 @@ function M.update_pipeline(pipeline_id, attrs)
     local pipeline = M.get_pipeline(pipeline_id)
     if not pipeline then
         error("pipeline not found: " .. tostring(pipeline_id))
+    end
+    if source_definitions.is_sourced_pipeline_id(pipeline_id) then
+        sourced_definition_error()
     end
     local set = filter_update(attrs, PIPELINE_UPDATE_FIELDS)
     if not has_fields(set) then
@@ -1318,6 +1516,7 @@ function M.update_step(step_id, attrs)
     if not step then
         error("step not found: " .. tostring(step_id))
     end
+    assert_public_step_update_allowed(step, attrs)
     local set = filter_update(attrs, STEP_UPDATE_FIELDS)
     if not has_fields(set) then
         return step
@@ -1347,6 +1546,9 @@ function M.update_gate(gate_id, attrs)
     if not gate then
         error("gate not found: " .. tostring(gate_id))
     end
+    if sourced_gate(gate) then
+        sourced_definition_error()
+    end
     local set = filter_update(attrs, GATE_UPDATE_FIELDS)
     if not has_fields(set) then
         return decode_gate_row(gate)
@@ -1372,6 +1574,9 @@ end
 function M.create_pipeline(attrs)
     util.assert_present(attrs.id, "pipeline id")
     util.assert_present(attrs.name, "pipeline name")
+    if source_definitions.is_sourced_pipeline_id(attrs.id) then
+        sourced_definition_error()
+    end
     local now = util.now()
     local published_step_ids = {}
     local published_gate_ids = {}
@@ -1460,6 +1665,11 @@ end
 function M.create_step(attrs)
     util.assert_present(attrs.pipeline_id, "pipeline_id")
     util.assert_present(attrs.name, "step name")
+    if source_definitions.is_sourced_pipeline_id(attrs.pipeline_id)
+        or source_definitions.pipeline_id_for_step(attrs.id) ~= nil
+    then
+        sourced_definition_error()
+    end
     if not M.get_pipeline(attrs.pipeline_id) then
         error("pipeline not found: " .. tostring(attrs.pipeline_id))
     end
@@ -1492,6 +1702,9 @@ function M.delete_step(step_id)
     local step = M.get_step(step_id)
     if not step then
         return nil
+    end
+    if sourced_step(step) then
+        sourced_definition_error()
     end
     local usage = first("SELECT COUNT(*) AS count FROM run_steps WHERE step_id = ?", step_id)
     if usage and tonumber(usage.count or 0) > 0 then
@@ -1531,6 +1744,12 @@ end
 function M.create_gate(attrs)
     util.assert_present(attrs.step_id, "step_id")
     util.assert_present(attrs.prompt, "gate prompt")
+    if source_definitions.pipeline_id_for_step(attrs.step_id) ~= nil
+        or source_definitions.step_id_for_gate(attrs.id) ~= nil
+        or sourced_step(M.get_step(attrs.step_id))
+    then
+        sourced_definition_error()
+    end
     if not M.get_step(attrs.step_id) then
         error("step not found: " .. tostring(attrs.step_id))
     end
@@ -1546,6 +1765,9 @@ function M.delete_gate(gate_id)
     local gate = M.get_gate(gate_id)
     if not gate then
         return nil
+    end
+    if sourced_gate(gate) then
+        sourced_definition_error()
     end
     local usage = first("SELECT COUNT(*) AS count FROM gate_results WHERE gate_id = ?", gate_id)
     if usage and tonumber(usage.count or 0) > 0 then
@@ -1565,6 +1787,9 @@ function M.delete_pipeline(pipeline_id)
     local pipeline = M.get_pipeline(pipeline_id)
     if not pipeline then
         return nil
+    end
+    if source_definitions.is_sourced_pipeline_id(pipeline_id) then
+        sourced_definition_error()
     end
     local usage = first("SELECT COUNT(*) AS count FROM runs WHERE pipeline_id = ?", pipeline_id)
     if usage and tonumber(usage.count or 0) > 0 then

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/source_definitions.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/source_definitions.lua
@@ -1,0 +1,402 @@
+-- @template Project Pipelines
+-- @description Checked-in package-owned pipeline definitions
+-- @category plugins
+-- @dest plugins/project-pipelines/project_pipelines/source_definitions.lua
+-- @scope device
+-- @version 1.1.0
+
+local M = {}
+
+local SOURCE_PATH = "catalog/templates/plugins/project-pipelines/project_pipelines/source_definitions.lua"
+
+local ROUTES = {
+    { target = "botster-core", playbook = "botster-core-playbook" },
+    { target = "botster-hub", playbook = "botster-hub-playbook" },
+    { target = "botster-hub-client", playbook = "botster-hub-client-playbook" },
+    { target = "botster-web", playbook = "botster-web-playbook" },
+    { target = "botster-tui", playbook = "botster-tui-playbook" },
+    { target = "botster-tui-kit", playbook = "botster-tui-kit-playbook" },
+    { target = "botster-terminal-ghostty", playbook = "botster-terminal-ghostty-playbook" },
+    { target = "Project Pipelines package/plugin paths", playbook = "project-pipelines-playbook", prefix = "also load " },
+}
+
+local route_lines = {
+    "Repository routing (use the ticket target repository, never the ambient directory):",
+}
+for _, route in ipairs(ROUTES) do
+    route_lines[#route_lines + 1] = string.format(
+        "- %s -> %s[[%s]]",
+        route.target,
+        route.prefix or "",
+        route.playbook)
+end
+local ROUTING_PROMPT = table.concat(route_lines, "\n")
+
+local function routed_prompt(before_routing, after_routing)
+    return before_routing .. "\n\n" .. ROUTING_PROMPT .. "\n\n" .. after_routing
+end
+
+local definition = {
+    id = "botster_stack_delivery",
+    name = "Botster Stack Delivery",
+    description = "Repository-aware Botster delivery pipeline. Every run binds its ticket target to the exact Botster repository ownership charter, composes the generic and Botster role playbooks, and adds only the runtime, web, package, or Project Pipelines overlays implicated by the task and changed files. Replaces the generic Botster Delivery definition.",
+    merge_policy = "pr",
+    version_label = "Repository playbooks — 2026-07-28",
+    archived_at = nil,
+    replacement_pipeline_id = nil,
+    supersedes_pipeline_id = "botster_delivery",
+    steps = {
+        {
+            id = "botster_stack_plan",
+            position = 1,
+            kind = "agent",
+            name = "Plan",
+            agent_name = "codex",
+            prompt = routed_prompt(
+                [=[You are the Plan agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Resolve the ticket target_id to the authoritative target repository before planning; do not infer the repository from the process working directory.
+
+Load, in order:
+1. [[planner-playbook]]
+2. [[botster-planner-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. Targeted atomic notes and any task surface guidance implicated by the ticket.
+5. [[project-pipelines-playbook]] only when Project Pipelines package/plugin paths or workflow policy are in scope.]=],
+                [=[If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+Build the plan from the target repository's code, instructions, CI, and vault context. Keep repository ownership and cross-repository seams explicit. Register cross-repository prerequisites as dependencies against the dependency repository target rather than silently broadening this run.
+
+Your output must include:
+- Target repository and target_id
+- Repository playbook loaded
+- Other role/surface playbooks and atomic notes loaded
+- Context loaded
+- Scope and non-scope
+- Repository ownership boundaries and cross-repo dependencies
+- Assumptions and unknowns
+- Affected surfaces/files
+- Risks
+- Acceptance checks/tests, including downstream proof where the charter requires it
+- Vault gaps worth capturing]=]),
+            next_step_id = "botster_stack_plan_review",
+            gates = {
+                {
+                    id = "botster_stack_plan_gate",
+                    kind = "attestation",
+                    prompt = "Attach a repository-routed plan that identifies target repository/target_id, exact repository charter, additional playbooks/notes, scope and non-scope, ownership boundaries and cross-repo dependencies, assumptions/unknowns, affected surfaces/files, risks, acceptance checks/tests, and vault gaps.",
+                    required_fields = {
+                        "target_repository",
+                        "target_id",
+                        "repository_playbook",
+                        "playbooks_notes_loaded",
+                        "context_loaded",
+                        "scope",
+                        "ownership_boundaries_dependencies",
+                        "assumptions_unknowns",
+                        "affected_surfaces_files",
+                        "risks",
+                        "acceptance_checks_tests",
+                        "vault_gaps",
+                    },
+                },
+            },
+        },
+        {
+            id = "botster_stack_plan_review",
+            position = 2,
+            kind = "agent",
+            name = "Plan Review",
+            agent_name = "claude",
+            prompt = routed_prompt(
+                [=[You are the Plan Review agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Independently resolve target_id to the authoritative target repository and compare it with the planner's routing. Review the latest plan artifact and gate evidence.
+
+Load, in order:
+1. [[plan-reviewer-playbook]]
+2. [[botster-plan-reviewer-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. The same task surface guidance and targeted notes the plan should have used.
+5. [[project-pipelines-playbook]] only when Project Pipelines package/plugin paths or workflow policy are in scope.]=],
+                [=[If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+Reject a plan that targets the wrong repository, violates the charter's owns/does-not-own boundary, omits required downstream consumer proof, hides cross-repository dependencies, cites absent paths, or substitutes generic Botster guidance for the repository charter. Verify dependencies are registered against the correct repository target and available through the actual consumed artifact where relevant.
+
+Your output must include:
+- Approved, changes required, or blocked
+- Independently resolved target repository and target_id
+- Required repository charter and whether the plan loaded it
+- Missing context/playbooks
+- Architecture, ownership, scope, or cross-repo dependency issues
+- Missing risks/assumptions
+- Missing or weak acceptance checks and downstream proof]=]),
+            on_approved_step_id = "botster_stack_implement",
+            on_changes_requested_step_id = "botster_stack_plan",
+            on_blocked_step_id = "botster_stack_plan",
+            gates = {
+                {
+                    id = "botster_stack_plan_review_gate",
+                    kind = "review_clear",
+                    prompt = "Approve only when target routing is independently verified, the exact repository charter was applied, repository ownership and cross-repo dependencies are correct, and acceptance checks include every local and downstream gate required by the charter. Changes required or blocked returns the run to Plan.",
+                    required_fields = {},
+                },
+            },
+        },
+        {
+            id = "botster_stack_implement",
+            position = 3,
+            kind = "agent",
+            name = "Implement",
+            agent_name = "codex",
+            prompt = routed_prompt(
+                [=[You are the Implement agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Resolve target_id to the authoritative target repository and verify the approved plan used the same routing before editing.
+
+Load, in order:
+1. [[implementer-playbook]]
+2. [[botster-implementer-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. Targeted atomic notes for the approved files/symbols and affected surfaces.
+5. [[project-pipelines-playbook]] only when Project Pipelines package/plugin paths or workflow policy are in scope.]=],
+                [=[If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+State the repository and playbook constraints you are applying before edits. Work only in the run worktree for the routed target. Follow the approved plan and keep code inside the charter's ownership boundary. Cross-repository work requires separately registered tickets/runs against those repository targets. Use repository-owned test wrappers and add downstream-shaped proof wherever the charter requires it.
+
+Before requesting Review, commit the work, link the PR when required, and persist an implementation report artifact.
+
+Your report must include:
+- Target repository and target_id
+- Repository playbook and other playbooks/notes applied
+- Files changed
+- Ownership boundaries preserved
+- Cross-repo dependencies or separately routed work
+- Deviations from plan
+- Tests and downstream proof run
+- Unverified behavior or residual risk
+- Missing vault guidance discovered]=]),
+            next_step_id = "botster_stack_review",
+            gates = {
+                {
+                    id = "botster_stack_implement_gate",
+                    kind = "attestation",
+                    prompt = "Attach implementation evidence with target repository/target_id, repository charter and other guidance applied, files changed, ownership boundaries preserved, cross-repo routing, deviations, tests/downstream proof, unverified behavior/residual risk, and missing vault guidance.",
+                    required_fields = {
+                        "target_repository",
+                        "target_id",
+                        "repository_playbook",
+                        "playbooks_notes_applied",
+                        "files_changed",
+                        "ownership_boundaries_preserved",
+                        "cross_repo_routing",
+                        "deviations_from_plan",
+                        "tests_downstream_proof",
+                        "unverified_behavior_or_residual_risk",
+                        "missing_vault_guidance",
+                    },
+                },
+            },
+        },
+        {
+            id = "botster_stack_review",
+            position = 4,
+            kind = "agent",
+            name = "Review",
+            agent_name = "claude",
+            prompt = routed_prompt(
+                [=[You are the Review agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Resolve target_id independently, inspect the linked PR/branch and full changed-file set, and review the actual diff.
+
+Load, in order:
+1. [[reviewer-playbook]]
+2. [[botster-reviewer-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. Every changed-surface overlay that applies:
+   - runtime/actors/lifecycle/PTY/transport -> [[botster-runtime-reviewer-playbook]]
+   - Ionic React/browser/UiNode/Restty -> [[botster-web-reviewer-playbook]]
+   - packages/plugins/manifests/capabilities -> [[botster-package-reviewer-playbook]]
+   - Project Pipelines engine/schema/tools/prompts/surfaces -> [[botster-pipeline-reviewer-playbook]] and [[project-pipelines-playbook]]
+5. Targeted atomic notes derived from changed files and symbols.]=],
+                [=[If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+Do not load unrelated surface overlays. Review repository ownership, public seams, downstream consumers, local gates, and cross-repo dependency registration. Reject changes that put policy or contracts in the wrong repository, lack consumer proof, leave old paths alive, or use lighter checks than the charter requires.
+
+Submit structured findings first, ordered by severity. Your output must include:
+- Independently resolved target repository and target_id
+- Repository charter loaded
+- Changed-surface overlays and targeted notes loaded
+- Findings with file/line references where possible
+- Ownership/public seam/downstream consumer assessment
+- Open questions or assumptions
+- Test gaps and residual risk
+- Vault coverage and missing repeated guidance]=]),
+            on_approved_step_id = "botster_stack_verify",
+            on_changes_requested_step_id = "botster_stack_implement",
+            on_blocked_step_id = "botster_stack_implement",
+            gates = {
+                {
+                    id = "botster_stack_review_gate",
+                    kind = "review_clear",
+                    prompt = "Approve only when Review independently verifies repository routing, applies the exact ownership charter plus every implicated changed-surface overlay, reports findings first, checks public seams/downstream consumers and cross-repo routing, and leaves no blocker/high finding open.",
+                    required_fields = {},
+                },
+            },
+        },
+        {
+            id = "botster_stack_verify",
+            position = 5,
+            kind = "agent",
+            name = "Verify",
+            agent_name = "codex",
+            prompt = routed_prompt(
+                [=[You are the Verify agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Independently resolve target_id, inspect the committed diff and implementation report, and recheck every review finding against the live run worktree.
+
+Load, in order:
+1. [[verifier-playbook]]
+2. [[botster-verifier-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. Every changed-surface overlay that applies:
+   - runtime/actors/lifecycle/PTY/transport -> [[botster-runtime-verifier-playbook]]
+   - Ionic React/browser/UiNode/Restty -> [[botster-web-verifier-playbook]]
+   - packages/plugins/manifests/capabilities -> [[botster-package-verifier-playbook]]
+   - Project Pipelines engine/schema/tools/prompts/surfaces -> [[botster-pipeline-verifier-playbook]] and [[project-pipelines-playbook]]
+5. Targeted atomic notes derived from changed files, symbols, and review findings.]=],
+                [=[If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+Run the exact repository-owned gates from the charter and applicable overlays. Prove public contract changes through real downstream consumers, subprocess/live harnesses, generated artifacts, or conformance evidence as required. Do not treat crate-local tests, source regexes, unrun commands, stale artifacts, or status-only finding resolution as verification.
+
+If verification exposes a gap, submit a changes-required/blocked review with a durable finding and route back to Implement.
+
+Your output must include:
+- Independently resolved target repository and target_id
+- Repository charter, surface overlays, and targeted notes loaded
+- Exact commands and results
+- Behavior and production/downstream path each command proves
+- Review findings resolved or still open
+- Cross-repository consumer proof
+- Unverified behavior
+- Remaining risk
+- Vault gaps worth capturing]=]),
+            on_changes_requested_step_id = "botster_stack_implement",
+            on_blocked_step_id = "botster_stack_implement",
+            gates = {
+                {
+                    id = "botster_stack_verify_gate",
+                    kind = "attestation",
+                    prompt = "Attach verification evidence with target repository/target_id, repository charter and overlays loaded, exact commands/results, behavior and production/downstream proof, finding status, cross-repo consumer proof, unverified behavior, remaining risk, and vault gaps.",
+                    required_fields = {
+                        "target_repository",
+                        "target_id",
+                        "repository_playbook",
+                        "surface_overlays_notes",
+                        "commands_run",
+                        "results",
+                        "behavior_production_path_proved",
+                        "review_findings_status",
+                        "cross_repo_consumer_proof",
+                        "unverified_behavior",
+                        "remaining_risk",
+                        "vault_gaps",
+                    },
+                },
+            },
+        },
+    },
+}
+
+local pipeline_fields = {
+    "name",
+    "description",
+    "merge_policy",
+    "version_label",
+    "archived_at",
+    "replacement_pipeline_id",
+    "supersedes_pipeline_id",
+}
+
+local step_fields = {
+    "pipeline_id",
+    "position",
+    "kind",
+    "name",
+    "prompt",
+    "command",
+    "next_step_id",
+    "on_approved_step_id",
+    "on_changes_requested_step_id",
+    "on_blocked_step_id",
+}
+
+local gate_fields = {
+    "step_id",
+    "kind",
+    "prompt",
+    "required_fields",
+    "command",
+}
+
+local sourced_steps = {}
+local sourced_gates = {}
+for _, step in ipairs(definition.steps) do
+    sourced_steps[step.id] = definition.id
+    for _, gate in ipairs(step.gates or {}) do
+        sourced_gates[gate.id] = step.id
+    end
+end
+
+local function copy(value)
+    if type(value) ~= "table" then
+        return value
+    end
+    local out = {}
+    for key, item in pairs(value) do
+        out[key] = copy(item)
+    end
+    return out
+end
+
+function M.definitions()
+    return { copy(definition) }
+end
+
+function M.routes()
+    return copy(ROUTES)
+end
+
+function M.routing_prompt()
+    return ROUTING_PROMPT
+end
+
+function M.source_path()
+    return SOURCE_PATH
+end
+
+function M.pipeline_fields()
+    return copy(pipeline_fields)
+end
+
+function M.step_fields()
+    return copy(step_fields)
+end
+
+function M.gate_fields()
+    return copy(gate_fields)
+end
+
+function M.is_sourced_pipeline_id(pipeline_id)
+    return pipeline_id == definition.id
+end
+
+function M.pipeline_id_for_step(step_id)
+    return sourced_steps[step_id]
+end
+
+function M.step_id_for_gate(gate_id)
+    return sourced_gates[gate_id]
+end
+
+return M

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/web/screens/pipelines.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/web/screens/pipelines.lua
@@ -412,7 +412,8 @@ local function sourced_pipeline_fields(pipeline)
         ui.text{ text = pipeline.description or "", size = "xs" },
         ui.text{ text = "Merge policy: " .. tostring(pipeline.merge_policy or "direct"), size = "xs", tone = "muted" },
         ui.text{
-            text = "Structural changes come from " .. source_definitions.source_path(),
+            text = "Structure, prompts, and lifecycle changes (including archive or retirement) come from "
+                .. source_definitions.source_path(),
             size = "xs",
             tone = "muted",
         },

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/web/screens/pipelines.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/web/screens/pipelines.lua
@@ -6,6 +6,7 @@
 -- @version 1.1.0
 
 local repo = require("project_pipelines.repo")
+local source_definitions = require("project_pipelines.source_definitions")
 local view = require("project_pipelines.web.ui")
 local actions = require("project_pipelines.web.actions")
 
@@ -327,6 +328,97 @@ local function edit_step(step, steps, state)
     return view.panel{ ui.stack{ direction = "vertical", gap = "3", children = children } }
 end
 
+local function sourced_gate(gate)
+    local children = {
+        view.row{
+            view.badge(gate.kind, "muted"),
+            ui.text{ text = gate.id, size = "xs", tone = "muted" },
+        },
+        ui.text{ text = gate.prompt or "", size = "xs" },
+    }
+    if gate.command and gate.command ~= "" then
+        table.insert(children, ui.text{ text = gate.command, size = "xs", tone = "muted" })
+    end
+    return view.panel{ ui.stack{ direction = "vertical", gap = "2", children = children } }
+end
+
+local function sourced_step(step, state)
+    local children = {
+        view.row{
+            view.badge(step.position, "muted"),
+            ui.text{ text = step.name, size = "sm", weight = "semibold" },
+            view.badge(step.kind, "muted"),
+        },
+        ui.text{ text = step.prompt or "", size = "xs" },
+    }
+
+    if step.kind == "agent" then
+        table.insert(children, ui.select{
+            id = "step-" .. step.id .. "-agent",
+            label = "Selected agent",
+            placeholder = step.agent_name or "Select agent",
+            options = view.agent_options(step.agent_name),
+            on_change = view.field_action("project_pipelines.update_step_field", {
+                step_id = step.id,
+                field = "agent_name",
+            }),
+        })
+        table.insert(children, ui.text{
+            text = "Agent selection is device-local and is preserved when package-owned structure is reconciled.",
+            size = "xs",
+            tone = "muted",
+        })
+        local agent_error = feedback_error(state, step.id, "agent_name")
+        if agent_error then
+            table.insert(children, ui.text{ text = agent_error, size = "xs", tone = "danger" })
+        end
+    elseif step.command and step.command ~= "" then
+        table.insert(children, ui.text{ text = step.command, size = "xs", tone = "muted" })
+    end
+
+    table.insert(children, ui.text{ text = "Transitions", size = "xs", weight = "semibold" })
+    for _, transition in ipairs({
+        { field = "next_step_id", label = "Default next step" },
+        { field = "on_approved_step_id", label = "On review approved" },
+        { field = "on_changes_requested_step_id", label = "On changes requested" },
+        { field = "on_blocked_step_id", label = "On blocked" },
+    }) do
+        if step[transition.field] and step[transition.field] ~= "" then
+            table.insert(children, ui.text{
+                text = transition.label .. ": " .. step[transition.field],
+                size = "xs",
+                tone = "muted",
+            })
+        end
+    end
+
+    local gates = repo.step_gates(step.id)
+    if #gates > 0 then
+        table.insert(children, ui.text{ text = "Gates", size = "xs", weight = "semibold" })
+        for _, gate in ipairs(gates) do
+            table.insert(children, sourced_gate(gate))
+        end
+    end
+
+    return view.panel{ ui.stack{ direction = "vertical", gap = "3", children = children } }
+end
+
+local function sourced_pipeline_fields(pipeline)
+    return view.panel{ ui.stack{ direction = "vertical", gap = "2", children = {
+        view.row{
+            view.badge("Package-owned", "accent"),
+            view.badge("Read-only structure", "muted"),
+        },
+        ui.text{ text = pipeline.description or "", size = "xs" },
+        ui.text{ text = "Merge policy: " .. tostring(pipeline.merge_policy or "direct"), size = "xs", tone = "muted" },
+        ui.text{
+            text = "Structural changes come from " .. source_definitions.source_path(),
+            size = "xs",
+            tone = "muted",
+        },
+    } } }
+end
+
 function M.edit(view_state, ctx)
     local params = view_state and view_state.params or {}
     local pipeline = repo.get_pipeline(params.pipeline_id)
@@ -347,18 +439,19 @@ function M.edit(view_state, ctx)
         table.insert(meta, view.badge("archived", "muted"))
     end
 
+    local is_sourced = source_definitions.is_sourced_pipeline_id(pipeline.id)
     local children = {
         view.page_header{
-            title = "Edit Pipeline",
+            title = is_sourced and "Pipeline Definition" or "Edit Pipeline",
             back_id = "pipeline-" .. pipeline.id .. "-back",
             back_path = ctx.path("/pipelines"),
             meta = meta,
         },
-        edit_pipeline_fields(pipeline, state),
+        is_sourced and sourced_pipeline_fields(pipeline) or edit_pipeline_fields(pipeline, state),
         ui.text{ text = "Steps", size = "md", weight = "semibold" },
     }
     for _, step in ipairs(steps) do
-        table.insert(children, edit_step(step, steps, state))
+        table.insert(children, is_sourced and sourced_step(step, state) or edit_step(step, steps, state))
     end
 
     return ui.stack{ direction = "vertical", gap = "4", children = children }

--- a/cli/tests/github_plugin_template_test.rs
+++ b/cli/tests/github_plugin_template_test.rs
@@ -493,6 +493,7 @@ fn catalog_plugin_project_pipelines_template_catalog_entry_is_a_multi_file_plugi
             "plugins/project-pipelines/project_pipelines/mcp.lua",
             "plugins/project-pipelines/project_pipelines/notification_policy.lua",
             "plugins/project-pipelines/project_pipelines/repo.lua",
+            "plugins/project-pipelines/project_pipelines/source_definitions.lua",
             "plugins/project-pipelines/project_pipelines/util.lua",
             "plugins/project-pipelines/project_pipelines/web/actions.lua",
             "plugins/project-pipelines/project_pipelines/web/screens/home.lua",
@@ -984,7 +985,7 @@ fn catalog_plugin_project_pipelines_entity_publish_snapshots_and_deltas_use_plug
         .from_value(value)
         .expect("project pipelines entities result json");
 
-    assert_eq!(result["registrations"].as_array().unwrap().len(), 18);
+    assert_eq!(result["registrations"].as_array().unwrap().len(), 19);
     assert!(result["registrations"]
         .as_array()
         .unwrap()
@@ -1399,10 +1400,7 @@ fn catalog_plugin_github_event_routing_emits_lifecycle_through_parent_hub() {
         result["parent_requests"][0]["event"],
         json!("pr_review_submitted")
     );
-    assert_eq!(
-        result["parent_requests"][0]["data"]["pr_number"],
-        json!(42)
-    );
+    assert_eq!(result["parent_requests"][0]["data"]["pr_number"], json!(42));
     assert_eq!(result["local_emits"], json!(0));
     assert_eq!(result["acked"], json!(true));
 }

--- a/cli/tests/plugin_worker_runtime_test.rs
+++ b/cli/tests/plugin_worker_runtime_test.rs
@@ -1785,3 +1785,71 @@ fn plugin_owned_mcp_handlers_run_in_plugin_worker_vm() {
         .eval::<bool>()
         .unwrap();
 }
+
+#[test]
+fn project_pipelines_worker_init_serves_sourced_stack_definition_through_public_mcp() {
+    // SAFETY: The focused integration filter runs this test in isolation. The
+    // worker resolves repository Lua modules and persists into a temporary
+    // device data root.
+    let tmp = TempDir::new().unwrap();
+    unsafe {
+        std::env::set_var(
+            "BOTSTER_LUA_PATH",
+            std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lua"),
+        );
+        std::env::set_var("BOTSTER_CONFIG_DIR", tmp.path());
+    }
+
+    let init_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .join("catalog/templates/plugins/project-pipelines/init.lua");
+    let runtime = LuaRuntime::new().unwrap();
+    runtime
+        .lua()
+        .load(format!(
+            r#"
+            _G.hub = {{
+                hub_id = function() return "hub-test" end,
+                server_id = function() return "hub-test" end,
+                detect_repo = function() return "Tonksthebear/trybotster" end,
+            }}
+            _G.mcp = require("lib.mcp")
+            require("lib.plugin_db").install()
+
+            local loader = require("hub.loader")
+            local ok, err = loader.load_plugin(
+                {init_path},
+                "project-pipelines",
+                {{ source = "device" }})
+            assert(ok, tostring(err))
+
+            local content, tool_err = require("lib.mcp").call_tool(
+                "project_pipelines_get_pipeline",
+                {{ pipeline_id = "botster_stack_delivery" }},
+                {{ session_uuid = "sourced-definition-smoke" }})
+            assert(tool_err == nil, tostring(tool_err))
+            assert(content and content[1] and content[1].text, "missing MCP content")
+            local response = json.decode(content[1].text)
+            assert(response.ok == true)
+            assert(response.result.id == "botster_stack_delivery")
+            assert(response.result.version_label == "Repository playbooks — 2026-07-28")
+            assert(#response.result.steps == 5)
+            for _, step in ipairs(response.result.steps) do
+                assert(step.prompt:find(
+                    "- botster-tui-kit -> [[botster-tui-kit-playbook]]",
+                    1,
+                    true))
+            end
+            return true
+            "#,
+            init_path = serde_json::to_string(&init_path.to_string_lossy()).unwrap(),
+        ))
+        .eval::<bool>()
+        .unwrap();
+
+    drop(runtime);
+    unsafe {
+        std::env::remove_var("BOTSTER_CONFIG_DIR");
+    }
+}

--- a/cli/tests/plugin_worker_runtime_test.rs
+++ b/cli/tests/plugin_worker_runtime_test.rs
@@ -1788,16 +1788,15 @@ fn plugin_owned_mcp_handlers_run_in_plugin_worker_vm() {
 
 #[test]
 fn project_pipelines_worker_init_serves_sourced_stack_definition_through_public_mcp() {
-    // SAFETY: The focused integration filter runs this test in isolation. The
-    // worker resolves repository Lua modules and persists into a temporary
-    // device data root.
+    // SAFETY: This file's existing test convention sets BOTSTER_LUA_PATH so
+    // worker VMs resolve repository modules. The device data root is scoped to
+    // this Lua runtime below, avoiding another process-global environment var.
     let tmp = TempDir::new().unwrap();
     unsafe {
         std::env::set_var(
             "BOTSTER_LUA_PATH",
             std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("lua"),
         );
-        std::env::set_var("BOTSTER_CONFIG_DIR", tmp.path());
     }
 
     let init_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -1814,8 +1813,12 @@ fn project_pipelines_worker_init_serves_sourced_stack_definition_through_public_
                 server_id = function() return "hub-test" end,
                 detect_repo = function() return "Tonksthebear/trybotster" end,
             }}
+            _G.config = {{
+                data_dir = function() return {data_dir} end,
+            }}
             _G.mcp = require("lib.mcp")
             require("lib.plugin_db").install()
+            require("lib.commands").register("plugin_entity_publish", function() return {{}} end)
 
             local loader = require("hub.loader")
             local ok, err = loader.load_plugin(
@@ -1844,12 +1847,10 @@ fn project_pipelines_worker_init_serves_sourced_stack_definition_through_public_
             return true
             "#,
             init_path = serde_json::to_string(&init_path.to_string_lossy()).unwrap(),
+            data_dir = serde_json::to_string(&tmp.path().to_string_lossy()).unwrap(),
         ))
         .eval::<bool>()
         .unwrap();
 
     drop(runtime);
-    unsafe {
-        std::env::remove_var("BOTSTER_CONFIG_DIR");
-    }
 }

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -4661,12 +4661,13 @@ fn catalog_plugin_project_pipelines_init_prunes_then_reconciles_before_registrat
             package.preload["project_pipelines.repo"] = function()
               return {{
                 prune_legacy_seed_data = function() record("prune") end,
-                reconcile_sourced_definitions = function() record("reconcile") end,
+                reconcile_sourced_definitions = function() record("reconcile"); return true end,
               }}
             end
             package.preload["project_pipelines.engine"] = function()
               return {{
                 register_entities = function() record("entities") end,
+                publish_entity_snapshots = function() record("snapshots") end,
                 reconcile_agent_sessions = function() end,
               }}
             end
@@ -4685,7 +4686,7 @@ fn catalog_plugin_project_pipelines_init_prunes_then_reconciles_before_registrat
             hooks = nil
 
             assert(loadfile({init_path}))()
-            assert(table.concat(calls, ",") == "prune,reconcile,entities,notifications,mcp,surface")
+            assert(table.concat(calls, ",") == "prune,reconcile,entities,snapshots,notifications,mcp,surface")
             return "ok"
             "#,
             plugin_dir = plugin_dir.display(),
@@ -4694,6 +4695,69 @@ fn catalog_plugin_project_pipelines_init_prunes_then_reconciles_before_registrat
         ))
         .eval()
         .expect("Project Pipelines init should reconcile source before registrations");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_reconcile_failure_keeps_registrations_available() {
+    let lua = Lua::new();
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let init_path = plugin_dir.join("init.lua");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+            local calls = {{}}
+            local warnings = {{}}
+            local function record(name) calls[#calls + 1] = name end
+
+            package.preload["project_pipelines.repo"] = function()
+              return {{
+                prune_legacy_seed_data = function() record("prune") end,
+                reconcile_sourced_definitions = function()
+                  record("reconcile")
+                  error("database is locked")
+                end,
+              }}
+            end
+            package.preload["project_pipelines.engine"] = function()
+              return {{
+                register_entities = function() record("entities") end,
+                publish_entity_snapshots = function() record("snapshots") end,
+                reconcile_agent_sessions = function() end,
+              }}
+            end
+            package.preload["project_pipelines.github_integration"] = function() return {{}} end
+            package.preload["project_pipelines.notification_policy"] = function()
+              return {{ register = function() record("notifications") end }}
+            end
+            package.preload["project_pipelines.mcp"] = function()
+              return {{ register = function() record("mcp") end }}
+            end
+            package.preload["project_pipelines.web.surface"] = function()
+              return {{ register = function() record("surface") end }}
+            end
+            log = {{
+              info = function() end,
+              warn = function(message) warnings[#warnings + 1] = message end,
+            }}
+            events = nil
+            hooks = nil
+
+            assert(loadfile({init_path}))()
+            assert(table.concat(calls, ",") == "prune,reconcile,entities,notifications,mcp,surface")
+            assert(#warnings == 1)
+            assert(warnings[1]:find("source reconciliation failed", 1, true))
+            assert(warnings[1]:find("database is locked", 1, true))
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display(),
+            init_path =
+                serde_json::to_string(&init_path.to_string_lossy()).expect("encode init path"),
+        ))
+        .eval()
+        .expect("Project Pipelines registrations should survive reconciliation failure");
 
     assert_eq!(result, "ok");
 }
@@ -4782,6 +4846,8 @@ fn catalog_plugin_project_pipelines_sourced_workbench_keeps_only_device_agent_co
             assert(copy:find("Package-owned", 1, true))
             assert(copy:find("Read-only structure", 1, true))
             assert(copy:find("device-local", 1, true))
+            assert(copy:find("lifecycle changes", 1, true))
+            assert(copy:find("archive or retirement", 1, true))
             assert(copy:find("source_definitions.lua", 1, true))
             return "ok"
             "#,
@@ -4849,6 +4915,7 @@ fn catalog_plugin_project_pipelines_sourced_definition_reconciles_real_sqlite_an
             assert(imported.archived_at == nil)
             assert(imported.replacement_pipeline_id == nil)
             assert(#imported.steps == 5)
+            assert(repo.get_default_pipeline() == nil)
 
             local expected_agents = {
               botster_stack_plan = "codex",
@@ -4949,7 +5016,6 @@ fn catalog_plugin_project_pipelines_sourced_definition_reconciles_real_sqlite_an
               created_at = 1,
               updated_at = 1,
             }
-
             repo.create_pipeline{
               id = "operator-pipeline",
               name = "Operator Pipeline",
@@ -4957,6 +5023,7 @@ fn catalog_plugin_project_pipelines_sourced_definition_reconciles_real_sqlite_an
               merge_policy = "direct",
             }
             local unrelated_before = repo.get_pipeline("operator-pipeline")
+            assert(repo.get_default_pipeline().id == "operator-pipeline")
 
             assert(repo.reconcile_sourced_definitions() == true)
             local event_count = db:eval(
@@ -5085,6 +5152,78 @@ fn catalog_plugin_project_pipelines_sourced_definition_reconciles_real_sqlite_an
         )
         .eval()
         .expect("sourced definition should round-trip and reconcile through real plugin.db");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_sourced_reconcile_preserves_historical_graph_drift() {
+    let temp = TempDir::new().expect("temp data dir");
+    let lua = project_pipelines_db_lua(temp.path());
+    let result: String = lua
+        .load(
+            r#"
+            local repo = require("project_pipelines.repo")
+            local db = require("project_pipelines.db")
+
+            assert(repo.reconcile_sourced_definitions() == true)
+            db.pipeline_steps:insert{
+              id = "historical-source-step",
+              pipeline_id = "botster_stack_delivery",
+              position = 99,
+              kind = "agent",
+              name = "Historical",
+              prompt = "historical",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.pipeline_gates:insert{
+              id = "historical-source-gate",
+              step_id = "historical-source-step",
+              kind = "attestation",
+              prompt = "historical",
+              required_fields = "[\"proof\"]",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.run_steps:insert{
+              id = "historical-run-step",
+              run_id = "historical-run",
+              step_id = "historical-source-step",
+              sequence = 1,
+              status = "done",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.gate_results:insert{
+              id = "historical-gate-result",
+              run_id = "historical-run",
+              run_step_id = "historical-run-step",
+              step_id = "historical-source-step",
+              gate_id = "historical-source-gate",
+              status = "passed",
+              created_at = 1,
+            }
+
+            assert(repo.reconcile_sourced_definitions() == false)
+            assert(repo.get_step("historical-source-step") ~= nil)
+            assert(repo.get_gate("historical-source-gate") ~= nil)
+            assert(db.run_steps:where{ id = "historical-run-step" }.step_id == "historical-source-step")
+            assert(db.gate_results:where{ id = "historical-gate-result" }.gate_id == "historical-source-gate")
+            local skipped = db:eval(
+              "SELECT COUNT(*) AS count FROM events WHERE kind = ?",
+              "pipeline.source_prune_skipped")[1].count
+            assert(skipped == 2)
+            assert(repo.reconcile_sourced_definitions() == false)
+            local skipped_after = db:eval(
+              "SELECT COUNT(*) AS count FROM events WHERE kind = ?",
+              "pipeline.source_prune_skipped")[1].count
+            assert(skipped_after == skipped)
+            return "ok"
+            "#,
+        )
+        .eval()
+        .expect("sourced reconciliation should preserve graph rows referenced by history");
 
     assert_eq!(result, "ok");
 }

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -10,13 +10,59 @@
 use std::path::PathBuf;
 
 use botster::lua::primitives::log;
-use mlua::Lua;
+use mlua::{Lua, LuaOptions, StdLib, Table};
+use tempfile::TempDir;
 
 fn project_root_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .parent()
         .expect("cli has repo parent")
         .to_path_buf()
+}
+
+fn project_pipelines_db_lua(data_dir: &std::path::Path) -> Lua {
+    let lua =
+        unsafe { Lua::unsafe_new_with(StdLib::ALL_SAFE | StdLib::FFI, LuaOptions::default()) };
+    botster::lua::primitives::fs::register(&lua).expect("register fs");
+    botster::lua::primitives::log::register(&lua).expect("register log");
+    botster::lua::primitives::json::register(&lua).expect("register json");
+
+    let cli_lua = project_root_dir().join("cli/lua");
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let package: Table = lua.globals().get("package").expect("package table");
+    let current_path: String = package.get("path").expect("package.path");
+    package
+        .set(
+            "path",
+            format!(
+                "{}/?.lua;{}/?/init.lua;{}/lib/?.lua;{}/vendor/?.lua;{}/vendor/?/init.lua;{}/?.lua;{}/?/init.lua;{}",
+                cli_lua.display(),
+                cli_lua.display(),
+                cli_lua.display(),
+                cli_lua.display(),
+                cli_lua.display(),
+                plugin_dir.display(),
+                plugin_dir.display(),
+                current_path
+            ),
+        )
+        .expect("set package.path");
+
+    lua.load(format!(
+        r#"
+        config = {{ data_dir = function() return {data_dir} end }}
+        hooks = {{ on = function() end }}
+        events = {{ on = function() end }}
+        local plugin_db = require("lib.plugin_db")
+        plugin_db._reset_for_tests()
+        plugin_db.install()
+        _loading_plugin_name = "project-pipelines"
+        "#,
+        data_dir = serde_json::to_string(&data_dir.to_string_lossy()).expect("encode data dir"),
+    ))
+    .exec()
+    .expect("install real plugin.db");
+    lua
 }
 
 #[test]
@@ -4596,6 +4642,449 @@ fn catalog_plugin_project_pipelines_start_run_rejects_archived_pipelines() {
         ))
         .eval()
         .expect("project pipelines start_run should reject archived pipelines");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_init_prunes_then_reconciles_before_registration() {
+    let lua = Lua::new();
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let init_path = plugin_dir.join("init.lua");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+            local calls = {{}}
+            local function record(name) calls[#calls + 1] = name end
+
+            package.preload["project_pipelines.repo"] = function()
+              return {{
+                prune_legacy_seed_data = function() record("prune") end,
+                reconcile_sourced_definitions = function() record("reconcile") end,
+              }}
+            end
+            package.preload["project_pipelines.engine"] = function()
+              return {{
+                register_entities = function() record("entities") end,
+                reconcile_agent_sessions = function() end,
+              }}
+            end
+            package.preload["project_pipelines.github_integration"] = function() return {{}} end
+            package.preload["project_pipelines.notification_policy"] = function()
+              return {{ register = function() record("notifications") end }}
+            end
+            package.preload["project_pipelines.mcp"] = function()
+              return {{ register = function() record("mcp") end }}
+            end
+            package.preload["project_pipelines.web.surface"] = function()
+              return {{ register = function() record("surface") end }}
+            end
+            log = {{ info = function() end, warn = function() end }}
+            events = nil
+            hooks = nil
+
+            assert(loadfile({init_path}))()
+            assert(table.concat(calls, ",") == "prune,reconcile,entities,notifications,mcp,surface")
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display(),
+            init_path =
+                serde_json::to_string(&init_path.to_string_lossy()).expect("encode init path"),
+        ))
+        .eval()
+        .expect("Project Pipelines init should reconcile source before registrations");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_sourced_workbench_keeps_only_device_agent_controls() {
+    let lua = Lua::new();
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+
+            local definition = require("project_pipelines.source_definitions").definitions()[1]
+            local steps = definition.steps
+            local gates = {{}}
+            for _, step in ipairs(steps) do
+              gates[step.id] = step.gates
+            end
+
+            package.loaded["project_pipelines.repo"] = {{
+              get_pipeline = function(id)
+                assert(id == definition.id)
+                return definition
+              end,
+              pipeline_steps = function(id)
+                assert(id == definition.id)
+                return steps
+              end,
+              step_gates = function(id)
+                return gates[id] or {{}}
+              end,
+            }}
+            package.loaded["project_pipelines.web.actions"] = {{
+              feedback = function() return {{}} end,
+            }}
+            package.loaded["project_pipelines.web.ui"] = {{
+              page_header = function(opts) opts.type = "page_header"; return opts end,
+              panel = function(child) return {{ type = "panel", children = child }} end,
+              row = function(...) return {{ type = "row", children = {{...}} }} end,
+              badge = function(text) return {{ type = "badge", text = text }} end,
+              field_action = function(_id, params) return {{ params = params }} end,
+              agent_options = function(selected) return {{ {{ value = selected, label = selected }} }} end,
+            }}
+            ui = setmetatable({{
+              action = function(id, params) return {{ id = id, params = params }} end,
+              stack = function(opts) opts.type = "stack"; return opts end,
+            }}, {{
+              __index = function(_table, kind)
+                return function(opts)
+                  opts = opts or {{}}
+                  opts.type = kind
+                  return opts
+                end
+              end,
+            }})
+
+            local screen = require("project_pipelines.web.screens.pipelines")
+            local tree = screen.edit({{ params = {{ pipeline_id = definition.id }} }}, {{
+              path = function(path) return path end,
+            }})
+
+            local selects = {{}}
+            local structural_controls = 0
+            local text = {{}}
+            local function walk(node)
+              if type(node) ~= "table" then return end
+              if node.type == "select" then selects[#selects + 1] = node end
+              if node.type == "textarea" or node.type == "text_input" or node.type == "checkbox" then
+                structural_controls = structural_controls + 1
+              end
+              if node.text then text[#text + 1] = tostring(node.text) end
+              for _, child in pairs(node) do
+                if type(child) == "table" then walk(child) end
+              end
+            end
+            walk(tree)
+
+            assert(structural_controls == 0)
+            assert(#selects == 5)
+            for _, select in ipairs(selects) do
+              assert(select.label == "Selected agent")
+              assert(select.on_change.params.field == "agent_name")
+            end
+            local copy = table.concat(text, "\n")
+            assert(copy:find("Package-owned", 1, true))
+            assert(copy:find("Read-only structure", 1, true))
+            assert(copy:find("device-local", 1, true))
+            assert(copy:find("source_definitions.lua", 1, true))
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display()
+        ))
+        .eval()
+        .expect("sourced workbench should render package structure read-only");
+
+    assert_eq!(result, "ok");
+}
+
+#[test]
+fn catalog_plugin_project_pipelines_sourced_definition_reconciles_real_sqlite_and_guards_public_crud(
+) {
+    let temp = TempDir::new().expect("temp data dir");
+    let lua = project_pipelines_db_lua(temp.path());
+    let result: String = lua
+        .load(
+            r#"
+            local source = require("project_pipelines.source_definitions")
+            local repo = require("project_pipelines.repo")
+            local db = require("project_pipelines.db")
+
+            local definitions = source.definitions()
+            assert(#definitions == 1)
+            local expected = definitions[1]
+            assert(expected.id == "botster_stack_delivery")
+            assert(expected.name == "Botster Stack Delivery")
+            assert(expected.merge_policy == "pr")
+            assert(expected.version_label == "Repository playbooks — 2026-07-28")
+            assert(expected.supersedes_pipeline_id == "botster_delivery")
+            assert(expected.archived_at == nil)
+            assert(expected.replacement_pipeline_id == nil)
+
+            local routes = source.routes()
+            assert(#routes == 8)
+            local expected_routes = {
+              ["botster-core"] = "botster-core-playbook",
+              ["botster-hub"] = "botster-hub-playbook",
+              ["botster-hub-client"] = "botster-hub-client-playbook",
+              ["botster-web"] = "botster-web-playbook",
+              ["botster-tui"] = "botster-tui-playbook",
+              ["botster-tui-kit"] = "botster-tui-kit-playbook",
+              ["botster-terminal-ghostty"] = "botster-terminal-ghostty-playbook",
+              ["Project Pipelines package/plugin paths"] = "project-pipelines-playbook",
+            }
+            for _, route in ipairs(routes) do
+              assert(expected_routes[route.target] == route.playbook)
+              expected_routes[route.target] = nil
+            end
+            assert(next(expected_routes) == nil)
+            for _, step in ipairs(expected.steps) do
+              assert(step.prompt:find("- botster-tui-kit -> [[botster-tui-kit-playbook]]", 1, true))
+              assert(not step.prompt:find("[[botster-core-playbook]] [[botster-hub-playbook]]", 1, true))
+            end
+
+            assert(repo.get_pipeline(expected.id) == nil)
+            assert(repo.reconcile_sourced_definitions() == true)
+            local imported = repo.get_pipeline_definition(expected.id)
+            assert(imported.name == expected.name)
+            assert(imported.description == expected.description)
+            assert(imported.merge_policy == expected.merge_policy)
+            assert(imported.version_label == expected.version_label)
+            assert(imported.supersedes_pipeline_id == expected.supersedes_pipeline_id)
+            assert(imported.archived_at == nil)
+            assert(imported.replacement_pipeline_id == nil)
+            assert(#imported.steps == 5)
+
+            local expected_agents = {
+              botster_stack_plan = "codex",
+              botster_stack_plan_review = "claude",
+              botster_stack_implement = "codex",
+              botster_stack_review = "claude",
+              botster_stack_verify = "codex",
+            }
+            local gate_count = 0
+            for index, step in ipairs(imported.steps) do
+              local source_step = expected.steps[index]
+              assert(step.id == source_step.id)
+              assert(step.pipeline_id == expected.id)
+              assert(step.position == source_step.position)
+              assert(step.kind == source_step.kind)
+              assert(step.name == source_step.name)
+              assert(step.agent_name == expected_agents[step.id])
+              assert(step.prompt == source_step.prompt)
+              assert(step.command == source_step.command)
+              assert(step.next_step_id == source_step.next_step_id)
+              assert(step.on_approved_step_id == source_step.on_approved_step_id)
+              assert(step.on_changes_requested_step_id == source_step.on_changes_requested_step_id)
+              assert(step.on_blocked_step_id == source_step.on_blocked_step_id)
+              assert(#step.gates == #source_step.gates)
+              gate_count = gate_count + #step.gates
+              local gate = step.gates[1]
+              local source_gate = source_step.gates[1]
+              assert(gate.id == source_gate.id)
+              assert(gate.step_id == source_step.id)
+              assert(gate.kind == source_gate.kind)
+              assert(gate.prompt == source_gate.prompt)
+              assert(gate.command == source_gate.command)
+              assert(#gate.required_fields == #source_gate.required_fields)
+              for field_index, field in ipairs(source_gate.required_fields) do
+                assert(gate.required_fields[field_index] == field)
+              end
+            end
+            assert(gate_count == 5)
+
+            for index, step in ipairs(imported.steps) do
+              local selected = "device-agent-" .. tostring(index)
+              if index == 1 then
+                repo.update_step(step.id, { agent_name = selected })
+              else
+                repo.update_step_agent(step.id, selected)
+              end
+              expected_agents[step.id] = selected
+            end
+
+            local before_mixed = repo.get_step("botster_stack_plan")
+            local ok_mixed, err_mixed = pcall(repo.update_step, before_mixed.id, {
+              agent_name = "must-not-apply",
+              prompt = "must-not-apply",
+            })
+            assert(ok_mixed == false)
+            assert(tostring(err_mixed):find(source.source_path(), 1, true))
+            local after_mixed = repo.get_step(before_mixed.id)
+            assert(after_mixed.agent_name == before_mixed.agent_name)
+            assert(after_mixed.prompt == before_mixed.prompt)
+
+            db.pipelines:update{
+              where = { id = expected.id },
+              set = { name = "Stale Stack", version_label = "stale", archived_at = 123 },
+            }
+            db.pipeline_steps:update{
+              where = { id = "botster_stack_plan" },
+              set = { position = 99, prompt = "stale prompt" },
+            }
+            db.pipeline_gates:update{
+              where = { id = "botster_stack_plan_gate" },
+              set = { prompt = "stale gate", required_fields = "[\"stale\"]" },
+            }
+            db.pipeline_steps:insert{
+              id = "source-extra-step",
+              pipeline_id = expected.id,
+              position = 99,
+              kind = "agent",
+              name = "Extra",
+              prompt = "extra",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.pipeline_gates:insert{
+              id = "source-extra-gate",
+              step_id = "source-extra-step",
+              kind = "attestation",
+              prompt = "extra",
+              required_fields = "[\"extra\"]",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.run_steps:insert{
+              id = "history-run-step",
+              run_id = "history-run",
+              step_id = "botster_stack_plan",
+              sequence = 1,
+              status = "done",
+              created_at = 1,
+              updated_at = 1,
+            }
+
+            repo.create_pipeline{
+              id = "operator-pipeline",
+              name = "Operator Pipeline",
+              description = "untouched",
+              merge_policy = "direct",
+            }
+            local unrelated_before = repo.get_pipeline("operator-pipeline")
+
+            assert(repo.reconcile_sourced_definitions() == true)
+            local event_count = db:eval(
+              "SELECT COUNT(*) AS count FROM events WHERE kind = ?",
+              "pipeline.source_reconciled")[1].count
+            assert(repo.reconcile_sourced_definitions() == false)
+            local event_count_after = db:eval(
+              "SELECT COUNT(*) AS count FROM events WHERE kind = ?",
+              "pipeline.source_reconciled")[1].count
+            assert(event_count_after == event_count)
+            assert(repo.get_step("source-extra-step") == nil)
+            assert(repo.get_gate("source-extra-gate") == nil)
+            local history = db.run_steps:where{ id = "history-run-step" }
+            assert(history.step_id == "botster_stack_plan")
+
+            local converged = repo.get_pipeline_definition(expected.id)
+            assert(converged.name == expected.name)
+            assert(converged.version_label == expected.version_label)
+            assert(converged.archived_at == nil)
+            assert(converged.steps[1].position == 1)
+            assert(converged.steps[1].prompt == expected.steps[1].prompt)
+            assert(converged.steps[1].gates[1].prompt == expected.steps[1].gates[1].prompt)
+            for _, step in ipairs(converged.steps) do
+              assert(step.agent_name == expected_agents[step.id])
+            end
+            local unrelated_after = repo.get_pipeline("operator-pipeline")
+            assert(unrelated_after.name == unrelated_before.name)
+            assert(unrelated_after.description == unrelated_before.description)
+            assert(unrelated_after.updated_at == unrelated_before.updated_at)
+
+            db.tickets:insert{
+              id = "tui-kit-ticket",
+              target_id = "tgt_3dfae49c02454037bf13554f552baf7f",
+              title = "TUI kit routing proof",
+              description = "downstream fixture",
+              status = "open",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.runs:insert{
+              id = "tui-kit-run",
+              ticket_id = "tui-kit-ticket",
+              pipeline_id = expected.id,
+              status = "active",
+              current_step_id = "botster_stack_plan",
+              current_run_step_id = "history-run-step",
+              target_id = "tgt_3dfae49c02454037bf13554f552baf7f",
+              created_at = 1,
+              updated_at = 1,
+            }
+            db.run_steps:update{
+              where = { id = "history-run-step" },
+              set = { run_id = "tui-kit-run" },
+            }
+
+            local handlers = {}
+            mcp = {
+              tool = function(name, _spec, handler) handlers[name] = handler end,
+              prompt = function() end,
+            }
+            package.loaded["project_pipelines.entities"] = {}
+            package.loaded["project_pipelines.notification_policy"] = {}
+            package.loaded["lib.hub"] = { get = function() return {} end }
+            package.loaded["lib.agent"] = {}
+            package.loaded["lib.config_resolver"] = { list_agents = function() return {} end }
+            package.loaded["project_pipelines.engine"] = nil
+            package.loaded["project_pipelines.mcp"] = nil
+            require("project_pipelines.mcp").register()
+
+            local served = handlers.project_pipelines_get_pipeline{
+              pipeline_id = expected.id,
+            }
+            assert(served.ok == true)
+            assert(#served.result.steps == 5)
+            for _, step in ipairs(served.result.steps) do
+              assert(step.prompt:find("- botster-tui-kit -> [[botster-tui-kit-playbook]]", 1, true))
+            end
+            local context = handlers.project_pipelines_current_context(
+              { run_id = "tui-kit-run" },
+              { session_uuid = "fixture-session" })
+            assert(context.ok == true)
+            assert(context.result.ticket.target_id == "tgt_3dfae49c02454037bf13554f552baf7f")
+            assert(context.result.run.target_id == "tgt_3dfae49c02454037bf13554f552baf7f")
+            assert(context.result.current_step.id == "botster_stack_plan")
+            assert(context.result.current_step.prompt:find(
+              "- botster-tui-kit -> [[botster-tui-kit-playbook]]", 1, true))
+
+            local function rejects(fn)
+              local ok, err = pcall(fn)
+              assert(ok == false)
+              assert(tostring(err):find(source.source_path(), 1, true))
+            end
+            rejects(function() repo.create_pipeline{ id = expected.id, name = "Duplicate" } end)
+            rejects(function() repo.update_pipeline(expected.id, { name = "Changed" }) end)
+            rejects(function() repo.delete_pipeline(expected.id) end)
+            rejects(function() repo.create_step{ pipeline_id = expected.id, name = "Changed" } end)
+            rejects(function() repo.update_step("botster_stack_plan", { prompt = "Changed" }) end)
+            rejects(function() repo.delete_step("botster_stack_plan") end)
+            rejects(function() repo.create_gate{ step_id = "botster_stack_plan", prompt = "Changed", required_fields = { "x" } } end)
+            rejects(function() repo.update_gate("botster_stack_plan_gate", { prompt = "Changed" }) end)
+            rejects(function() repo.delete_gate("botster_stack_plan_gate") end)
+
+            repo.update_pipeline("operator-pipeline", { name = "Mutable" })
+            local mutable_step = repo.create_step{
+              id = "operator-step",
+              pipeline_id = "operator-pipeline",
+              name = "Operator Step",
+              kind = "agent",
+              prompt = "before",
+            }
+            repo.update_step(mutable_step.id, { prompt = "after" })
+            local mutable_gate = repo.create_gate{
+              id = "operator-gate",
+              step_id = mutable_step.id,
+              kind = "attestation",
+              prompt = "before",
+              required_fields = { "proof" },
+            }
+            repo.update_gate(mutable_gate.id, { prompt = "after" })
+            repo.delete_gate(mutable_gate.id)
+            repo.delete_step(mutable_step.id)
+            repo.delete_pipeline("operator-pipeline")
+
+            return "ok"
+            "#,
+        )
+        .eval()
+        .expect("sourced definition should round-trip and reconcile through real plugin.db");
 
     assert_eq!(result, "ok");
 }


### PR DESCRIPTION
## Summary

- source Botster Stack Delivery from a checked-in package definition
- reconcile package-owned structure at startup while preserving device-local agent selection
- render sourced pipeline structure read-only in the workbench
- add the missing botster-tui-kit repository route to every role prompt
- prove the production plugin-worker/public MCP/current-context path
- preserve historical graph rows during source convergence and record idempotent skipped-prune audit events
- keep Project Pipelines tools available when reconciliation fails, then publish changed snapshots after entity registration
- keep the opinionated sourced workflow out of implicit default selection

## Verification

- `GIT_DIR=/private/tmp/botster-ghostty-no-git ./test.sh --integration -- project_pipelines` — pass (53 Project Pipelines tests, 5 catalog tests, and the real plugin-worker test)
- `GIT_DIR=/private/tmp/botster-ghostty-no-git ./test.sh --integration -- project_pipelines_worker_init` — pass
- `cargo fmt --check` — pass
- `git diff --cached --check` — pass before commit
- `./test.sh` — Project Pipelines suites pass; repository-wide run has one reproducible pre-existing failure in `agent_session_lookups_proxy_to_parent_hub_inside_plugin_worker`. The failing test file is byte-identical to `origin/main` (blob `bf333fb353119e9674816f026efbe02f9ca8ec6f`) and this PR does not touch its runtime surface.

## Scope

Target: `Tonksthebear/trybotster` / `tgt_83619444571645afa5507374e36036e2`

No cross-repository files changed.

The branch is rebased onto `07e3230a`.
