### PR TITLE
ci: Zig 0.16.0 for Ghostty vendored builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -292,7 +292,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
@@ -254,7 +254,7 @@ jobs:
       - name: Set up Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
- Bump `mlugg/setup-zig` from 0.15.2 to **0.16.0** in CI and release workflows.
- Fixes post-#202 `build-cli` failure: Botster now requires Zig 0.16.0 for vendored Ghostty.

## Notes
- `scan_js` / `scan_ruby` failures on main predate this (react-router audit / brakeman exit 5) and are unchanged here.

## Test plan
- [ ] CI build-cli green on this PR