### PR TITLE
fix(project-pipelines): plan loop hygiene and colon-free worktrees

### DIFF
--- a/app/frontend/vendor/chunk-ft7p00j6.js
+++ b/app/frontend/vendor/chunk-ft7p00j6.js
@@ -14543,13 +14543,18 @@ class MouseController {
   button = 0;
   flags = { 1000: false, 1002: false, 1003: false };
   x10Event = false;
+  pendingWheelPx = 0;
   sendReply;
   positionToCell;
   positionToPixel;
+  getCellHeight;
+  getRows;
   constructor(options) {
     this.sendReply = options.sendReply;
     this.positionToCell = options.positionToCell;
     this.positionToPixel = options.positionToPixel;
+    this.getCellHeight = options.getCellHeight ?? (() => 20);
+    this.getRows = options.getRows ?? (() => 24);
   }
   setReplySink(fn) {
     this.sendReply = fn;
@@ -14559,6 +14564,11 @@ class MouseController {
   }
   setPositionToPixel(fn) {
     this.positionToPixel = fn;
+  }
+  setCellMetrics(getCellHeight, getRows) {
+    this.getCellHeight = getCellHeight;
+    if (getRows)
+      this.getRows = getRows;
   }
   setMode(mode) {
     this.mode = mode;
@@ -14570,6 +14580,7 @@ class MouseController {
       this.enabled = false;
       this.format = "x10";
       this.motion = "none";
+      this.pendingWheelPx = 0;
     } else {
       this.enabled = this.x10Event || this.flags[1000] || this.flags[1002] || this.flags[1003];
       if (this.flags[1003])
@@ -14628,6 +14639,7 @@ class MouseController {
     this.enabled = false;
     this.pressed = false;
     this.button = 0;
+    this.pendingWheelPx = 0;
     const bit = (n) => (bits & 1 << n) !== 0;
     this.x10Event = bit(0);
     this.flags[1000] = bit(1);
@@ -14704,11 +14716,24 @@ class MouseController {
       return this.sendMouse(code, col, row, pixel, false);
     }
     if (kind === "wheel") {
-      const steps = wheelReportSteps(event);
-      if (steps === 0)
+      const cellH = Math.max(1, this.getCellHeight() || 20);
+      const rows = Math.max(1, this.getRows() || 24);
+      const dyPx = wheelDeltaPixels(event, cellH, rows);
+      if (!dyPx)
         return false;
-      const code = (steps < 0 ? 64 : 65) + mods;
-      return this.sendMouse(code, col, row, pixel, false);
+      this.pendingWheelPx += dyPx;
+      if (Math.abs(this.pendingWheelPx) < cellH) {
+        return true;
+      }
+      const amount = this.pendingWheelPx / cellH;
+      const rawSteps = Math.trunc(amount);
+      this.pendingWheelPx -= rawSteps * cellH;
+      if (!rawSteps)
+        return true;
+      const maxSteps = Math.max(1, Math.min(rows, 24));
+      const n = Math.min(Math.abs(rawSteps), maxSteps);
+      const code = (rawSteps < 0 ? 64 : 65) + mods;
+      return this.sendMouseRepeated(code, col, row, pixel, n);
     }
     return false;
   }
@@ -14736,40 +14761,61 @@ class MouseController {
     return mod;
   }
   sendMouse(code, col, row, pixel, release) {
+    const seq = this.encodeMouse(code, col, row, pixel, release);
+    if (!seq)
+      return false;
+    this.sendReply(seq);
+    return true;
+  }
+  sendMouseRepeated(code, col, row, pixel, count) {
+    if (count <= 0)
+      return false;
+    const one = this.encodeMouse(code, col, row, pixel, false);
+    if (!one)
+      return false;
+    if (count === 1) {
+      this.sendReply(one);
+      return true;
+    }
+    this.sendReply(one.repeat(count));
+    return true;
+  }
+  encodeMouse(code, col, row, pixel, release) {
     if (this.format === "x10") {
       if (col > 223 || row > 223)
-        return false;
+        return null;
       const cb = 32 + code;
       const cx = 32 + col;
       const cy = 32 + row;
-      this.sendReply(`\x1B[M${String.fromCharCode(cb, cx, cy)}`);
-      return true;
+      return `\x1B[M${String.fromCharCode(cb, cx, cy)}`;
     }
     if (this.format === "utf8") {
       const cb = String.fromCharCode(32 + code);
       const cx = String.fromCodePoint(32 + col);
       const cy = String.fromCodePoint(32 + row);
-      this.sendReply(`\x1B[M${cb}${cx}${cy}`);
-      return true;
+      return `\x1B[M${cb}${cx}${cy}`;
     }
     if (this.format === "urxvt") {
-      this.sendReply(`\x1B[${32 + code};${col};${row}M`);
-      return true;
+      return `\x1B[${32 + code};${col};${row}M`;
     }
     const suffix = release ? "m" : "M";
     if (this.format === "sgr_pixels" && pixel) {
-      this.sendReply(`\x1B[<${code};${pixel.x};${pixel.y}${suffix}`);
-      return true;
+      return `\x1B[<${code};${pixel.x};${pixel.y}${suffix}`;
     }
-    this.sendReply(`\x1B[<${code};${col};${row}${suffix}`);
-    return true;
+    return `\x1B[<${code};${col};${row}${suffix}`;
   }
 }
-function wheelReportSteps(event, _maxSteps = 1) {
+function wheelDeltaPixels(event, cellH, rows) {
   const dy = event.deltaY;
   if (!dy || !Number.isFinite(dy))
     return 0;
-  return dy < 0 ? -1 : 1;
+  const h = Math.max(1, cellH || 20);
+  const r = Math.max(1, rows || 24);
+  if (event.deltaMode === 1)
+    return dy * h;
+  if (event.deltaMode === 2)
+    return dy * r * h;
+  return dy;
 }
 
 // src/input/output/csi.ts
@@ -15352,7 +15398,9 @@ function createInputHandler(options = {}) {
   const mouse = new MouseController({
     sendReply: replySink,
     positionToCell,
-    positionToPixel: positionToPixel ?? undefined
+    positionToPixel: positionToPixel ?? undefined,
+    getCellHeight: options.getCellHeight,
+    getRows: options.getRows
   });
   const filter = new OutputFilter({
     getCursorPosition: cursorProvider,
@@ -67223,6 +67271,8 @@ function createResttyApp(options) {
     },
     positionToCell: positionToCell2,
     positionToPixel,
+    getCellHeight: () => Math.max(1, gridState.cellH || 20),
+    getRows: () => Math.max(1, gridState.rows || 24),
     getDefaultColors: () => ({
       fg: floatsToRgb(defaultFg),
       bg: floatsToRgb(defaultBg),

--- a/app/frontend/vendor/chunk-xpzqfsq4.js
+++ b/app/frontend/vendor/chunk-xpzqfsq4.js
@@ -14707,14 +14707,8 @@ class MouseController {
       const steps = wheelReportSteps(event);
       if (steps === 0)
         return false;
-      const codeBase = steps < 0 ? 64 : 65;
-      const n = Math.abs(steps);
-      let sent = false;
-      for (let i = 0;i < n; i += 1) {
-        if (this.sendMouse(codeBase + mods, col, row, pixel, false))
-          sent = true;
-      }
-      return sent;
+      const code = (steps < 0 ? 64 : 65) + mods;
+      return this.sendMouse(code, col, row, pixel, false);
     }
     return false;
   }
@@ -14771,20 +14765,11 @@ class MouseController {
     return true;
   }
 }
-function wheelReportSteps(event, maxSteps = 8) {
+function wheelReportSteps(event, _maxSteps = 1) {
   const dy = event.deltaY;
   if (!dy || !Number.isFinite(dy))
     return 0;
-  const sign = dy < 0 ? -1 : 1;
-  let abs;
-  if (event.deltaMode === 1) {
-    abs = Math.max(1, Math.round(Math.abs(dy)));
-  } else if (event.deltaMode === 2) {
-    abs = Math.max(1, Math.round(Math.abs(dy) * 24));
-  } else {
-    abs = Math.max(1, Math.round(Math.abs(dy) / 40));
-  }
-  return sign * Math.min(abs, maxSteps);
+  return dy < 0 ? -1 : 1;
 }
 
 // src/input/output/csi.ts

--- a/app/frontend/vendor/restty.js
+++ b/app/frontend/vendor/restty.js
@@ -8,7 +8,7 @@ import {
   isBuiltinThemeName,
   listBuiltinThemeNames,
   parseGhosttyTheme
-} from "./chunk-xpzqfsq4.js";
+} from "./chunk-ft7p00j6.js";
 export {
   parseGhosttyTheme,
   listBuiltinThemeNames,

--- a/app/frontend/vendor/restty.js
+++ b/app/frontend/vendor/restty.js
@@ -8,7 +8,7 @@ import {
   isBuiltinThemeName,
   listBuiltinThemeNames,
   parseGhosttyTheme
-} from "./chunk-cs9jx8b9.js";
+} from "./chunk-xpzqfsq4.js";
 export {
   parseGhosttyTheme,
   listBuiltinThemeNames,

--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -52,6 +52,18 @@ create reusable pipeline definitions explicitly through the GUI and MCP tools.
 Projects are the durable container for multi-phase or cross-target work; tickets
 remain one concrete unit of work in one spawn target.
 
+When a live hub already has `botster_stack_delivery`, plugin load refreshes the
+Plan and Plan Review prompts if `pipelines.version_label` differs from the
+catalog revision in `project_pipelines/stack_delivery.lua`. Operator-chosen
+`agent_name` values are preserved. No operator SQL is required for that refresh.
+
+## Worktree Hygiene
+
+On step activation and agent link, the engine restores a tracked `.gitignore`
+from `HEAD` only when the working copy is empty or missing. It never truncates
+`.gitignore`. Command gates that run under a path containing `:` set a
+colon-free `CARGO_TARGET_DIR` so macOS Cargo/DYLD path joining does not fail.
+
 Pipeline MCP CRUD:
 
 - `project_pipelines_create_pipeline`

--- a/catalog/templates/plugins/project-pipelines/init.lua
+++ b/catalog/templates/plugins/project-pipelines/init.lua
@@ -12,6 +12,7 @@ for _, module_name in ipairs({
     "project_pipelines.repo",
     "project_pipelines.entities",
     "project_pipelines.engine",
+    "project_pipelines.stack_delivery",
     "project_pipelines.github_integration",
     "project_pipelines.notification_policy",
     "project_pipelines.mcp",
@@ -30,6 +31,7 @@ end
 
 local repo = require("project_pipelines.repo")
 local engine = require("project_pipelines.engine")
+local stack_delivery = require("project_pipelines.stack_delivery")
 local github_integration = require("project_pipelines.github_integration")
 local notification_policy = require("project_pipelines.notification_policy")
 local mcp_tools = require("project_pipelines.mcp")
@@ -38,6 +40,12 @@ local surface = require("project_pipelines.web.surface")
 local M = {}
 
 repo.prune_legacy_seed_data()
+local ok_prompts, prompt_result = pcall(stack_delivery.reconcile)
+if ok_prompts and prompt_result and prompt_result.refreshed then
+    log.info("[project-pipelines] refreshed botster_stack_delivery prompts to " .. tostring(prompt_result.revision))
+elseif not ok_prompts then
+    log.warn("[project-pipelines] stack delivery prompt refresh failed: " .. tostring(prompt_result))
+end
 engine.register_entities()
 notification_policy.register()
 mcp_tools.register()

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
@@ -90,6 +90,79 @@ local function live_ticket_worktree(ticket_id)
     return nil, nil, nil, nil
 end
 
+-- Invoke parent-owned command gates through the Hub facade. Workers do not
+-- expose hub.run_command_gate on the isolated global hub table.
+local function invoke_run_command_gate(opts)
+    local hub_obj = Hub.get()
+    if hub_obj and type(hub_obj.run_command_gate) == "function" then
+        return hub_obj:run_command_gate(opts)
+    end
+    if type(hub) == "table" and type(hub.run_command_gate) == "function" then
+        return hub.run_command_gate(opts)
+    end
+    error("run_command_gate unavailable: Hub facade and hub global are both nil")
+end
+
+-- Restore tracked .gitignore from HEAD only when the working copy is empty or
+-- missing while HEAD still has content. Never truncate. Never overwrite a
+-- non-empty intentional edit.
+local function ensure_gitignore_hygiene(cwd, context)
+    if util.is_blank(cwd) then
+        return
+    end
+    local request_id = string.format(
+        "%s:hygiene:gitignore:%s:%s",
+        OWNER,
+        tostring((context and context.run_id) or "none"),
+        tostring(os.time())
+    )
+    -- shell: restore only when tracked and working copy is empty/missing
+    local command = table.concat({
+        "if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then exit 0; fi",
+        "if ! git cat-file -e HEAD:.gitignore 2>/dev/null; then exit 0; fi",
+        "if [ ! -s .gitignore ]; then git checkout HEAD -- .gitignore; fi",
+    }, "; ")
+    local ok, err = pcall(function()
+        invoke_run_command_gate{
+            request_id = request_id,
+            command = command,
+            cwd = cwd,
+            timeout_secs = 30,
+            context = {
+                owner_plugin = OWNER,
+                operation = "gitignore_hygiene",
+                run_id = context and context.run_id or nil,
+                ticket_id = context and context.ticket_id or nil,
+            },
+        }
+    end)
+    if not ok then
+        log.warn("[project-pipelines] gitignore hygiene failed: " .. tostring(err))
+    end
+end
+
+local function cargo_target_dir_for(cwd)
+    if util.is_blank(cwd) or not tostring(cwd):find(":", 1, true) then
+        return nil
+    end
+    local tmp = os.getenv("TMPDIR") or os.getenv("TMP") or "/tmp"
+    local slug = tostring(cwd):gsub("[^%w]+", "-"):gsub("^%-", ""):gsub("%-$", "")
+    if #slug > 48 then
+        slug = slug:sub(1, 48)
+    end
+    if util.is_blank(slug) then
+        slug = "pipeline"
+    end
+    return tmp:gsub("/+$", "") .. "/botster-cargo-target/" .. slug
+end
+
+local function ensure_worktree_hygiene(cwd, context)
+    if util.is_blank(cwd) then
+        return
+    end
+    ensure_gitignore_hygiene(cwd, context)
+end
+
 local M = {}
 
 function M.register_entities()
@@ -905,9 +978,17 @@ local function run_command_step(run, step)
         return nil, "could not resolve a filesystem path for command step (target_id=" .. tostring(run.target_id) .. ")"
     end
 
+    ensure_worktree_hygiene(target_path, { run_id = run.id, ticket_id = run.ticket_id })
+
+    local env = nil
+    local cargo_target = cargo_target_dir_for(target_path)
+    if cargo_target then
+        env = { CARGO_TARGET_DIR = cargo_target }
+    end
+
     local request_id = string.format("%s:%s:%s:command:%s", OWNER, run.id, step.id, command_gate and command_gate.id or "step")
     local ok, result = pcall(function()
-        return hub.run_command_gate{
+        local opts = {
             request_id = request_id,
             command = command,
             cwd = target_path,
@@ -920,6 +1001,10 @@ local function run_command_step(run, step)
                 gate_id = command_gate and command_gate.id or nil,
             },
         }
+        if env then
+            opts.env = env
+        end
+        return invoke_run_command_gate(opts)
     end)
 
     if not ok then
@@ -928,7 +1013,12 @@ local function run_command_step(run, step)
     repo.append_event("step.command_started", {
         run_id = run.id,
         ticket_id = run.ticket_id,
-        payload = { step_id = step.id, command = command, request_id = request_id },
+        payload = {
+            step_id = step.id,
+            command = command,
+            request_id = request_id,
+            cargo_target_dir = cargo_target,
+        },
     })
     return result, nil
 end
@@ -1052,6 +1142,13 @@ function M.activate_step(run, step, options)
         step = step,
         run_step = visit,
     })
+
+    -- Hygiene on activation when a live ticket worktree already exists.
+    -- Never truncate .gitignore; restore from HEAD only when empty/missing.
+    local live_path = live_ticket_worktree(run.ticket_id)
+    if not util.is_blank(live_path) then
+        ensure_worktree_hygiene(live_path, { run_id = run.id, ticket_id = run.ticket_id })
+    end
 
     if step.kind == "agent" then
         local created, err = spawn_step_agent(repo.get_run(run.id), step, options.spawn_options)
@@ -1819,6 +1916,19 @@ function M.handle_agent_created(info)
             request_id = request_id,
         },
     })
+    local worktree_path = info.worktree_path or metadata.worktree_path
+    if util.is_blank(worktree_path) then
+        local session = Agent.get(session_uuid)
+        if session and session.info then
+            local ok, session_info = pcall(session.info, session)
+            if ok and session_info then
+                worktree_path = session_info.worktree_path
+            end
+        end
+    end
+    if not util.is_blank(worktree_path) then
+        ensure_worktree_hygiene(worktree_path, { run_id = run.id, ticket_id = run.ticket_id })
+    end
     refresh_surfaces()
 end
 

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/stack_delivery.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/stack_delivery.lua
@@ -1,0 +1,190 @@
+-- @template Project Pipelines
+-- @description Botster Stack Delivery prompt source and safe live refresh
+-- @category plugins
+-- @dest plugins/project-pipelines/project_pipelines/stack_delivery.lua
+-- @scope device
+-- @version 1.1.0
+
+local repo = require("project_pipelines.repo")
+
+local M = {}
+
+-- Bump when Plan / Plan Review ceremony text changes. Live hubs refresh only
+-- when botster_stack_delivery.version_label differs from this revision.
+local PROMPT_REVISION = "plan-loop-hygiene/2026-08-10.1"
+local PIPELINE_ID = "botster_stack_delivery"
+local PLAN_STEP_ID = "botster_stack_plan"
+local PLAN_REVIEW_STEP_ID = "botster_stack_plan_review"
+
+local PLAN_PROMPT = [[You are the Plan agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Resolve the ticket target_id to the authoritative target repository before planning; do not infer the repository from the process working directory.
+
+Load, in order:
+1. [[planner-playbook]]
+2. [[botster-planner-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. Targeted atomic notes and any task surface guidance implicated by the ticket.
+5. [[project-pipelines-playbook]] only when Project Pipelines package/plugin paths or workflow policy are in scope.
+
+Repository routing (use the ticket target repository, never the ambient directory):
+- botster-core -> [[botster-core-playbook]]
+- botster-hub -> [[botster-hub-playbook]]
+- botster-hub-client -> [[botster-hub-client-playbook]]
+- botster-web -> [[botster-web-playbook]]
+- botster-workspaces -> [[botster-workspaces-playbook]]
+- botster-tui -> [[botster-tui-playbook]]
+- botster-tui-kit -> [[botster-tui-kit-playbook]]
+- botster-terminal-ghostty -> [[botster-terminal-ghostty-playbook]]
+- Project Pipelines package/plugin paths -> also load [[project-pipelines-playbook]]
+
+If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+Build the plan from the target repository's code, instructions, CI, and vault context. Keep repository ownership and cross-repository seams explicit. Register cross-repository prerequisites as dependencies against the dependency repository target rather than silently broadening this run.
+
+## Completion evidence (required)
+When you complete this Plan step, gate evidence MUST include all of:
+- plan_uri
+- artifact_id (from project_pipelines_add_artifact)
+- checklist_id
+- target_id
+- target_repository
+Never submit a URI alone when an artifact exists. Plan Review rejects URI-only evidence that omits artifact_id even when the plan is product-sound.
+
+## Vault checklist
+Create exactly one vault checklist for this Plan visit. If a vault checklist already exists for this ticket or run, skip duplicates and record the skip reason in gate evidence.
+
+## Worktree hygiene (before gates)
+1. If tracked `.gitignore` is empty or missing while HEAD has content, restore with `git checkout HEAD -- .gitignore`. Never truncate `.gitignore`.
+2. If the worktree path contains `:`, set `CARGO_TARGET_DIR` to a colon-free directory (for example under `$TMPDIR`) before cargo or script gates.
+
+## Consumer tickets after Hub session-type eligibility parent
+When this ticket is a consumer of Hub session-type eligibility work:
+- Inject parent pins via list_session_types_for_target + spawn Option A.
+- Require hub ≥ parent merge / hub-test-support 0.1.26 / conf 33 when that is the parent.
+- Require live proof, not soft residual.
+- Do not filter by client target_id equality.
+
+Your output must include:
+- Target repository and target_id
+- Repository playbook loaded
+- Other role/surface playbooks and atomic notes loaded
+- Context loaded
+- Scope and non-scope
+- Repository ownership boundaries and cross-repo dependencies
+- Assumptions and unknowns
+- Affected surfaces/files
+- Risks
+- Acceptance checks/tests, including downstream proof where the charter requires it
+- Vault gaps worth capturing
+
+## Runtime-teardown class (when applicable)
+If this ticket involves WebRTC/peer lifecycle, SessionIo/ClientWorker teardown, multi-peer ownership, CPU/battery/FD spin, or terminal-state vs live-runtime divergence:
+- Load [[botster runtime teardown lenses]]
+- Answer every required field in that note (isolation, bounds, late-message matrix, production-path proof, ownership identity, sibling/fail-closed policy)
+- Record those answers in the plan artifact and gate evidence under playbooks/notes loaded and acceptance checks
+Do not load that note for ordinary UI, copy, docs-only, or single-field client tickets. Keep one Plan → Implement path; do not dual-pipeline for planner variety.
+
+Keep live Hub pin / charter live proof, request-race / SPA request-state proof, and independent base re-verification requirements intact. Do not weaken those product proofs for process hygiene.]]
+
+local PLAN_REVIEW_PROMPT = [[You are the Plan Review agent for a repository-specific Botster Stack Delivery run.
+
+Start with project_pipelines_current_context. Independently resolve target_id to the authoritative target repository and compare it with the planner's routing. Review the latest plan artifact and gate evidence.
+
+Load, in order:
+1. [[plan-reviewer-playbook]]
+2. [[botster-plan-reviewer-playbook]]
+3. The exact repository ownership charter from the routing map below.
+4. The same task surface guidance and targeted notes the plan should have used.
+5. [[project-pipelines-playbook]] only when Project Pipelines package/plugin paths or workflow policy are in scope.
+
+Repository routing (use the ticket target repository, never the ambient directory):
+- botster-core -> [[botster-core-playbook]]
+- botster-hub -> [[botster-hub-playbook]]
+- botster-hub-client -> [[botster-hub-client-playbook]]
+- botster-web -> [[botster-web-playbook]]
+- botster-workspaces -> [[botster-workspaces-playbook]]
+- botster-tui -> [[botster-tui-playbook]]
+- botster-tui-kit -> [[botster-tui-kit-playbook]]
+- botster-terminal-ghostty -> [[botster-terminal-ghostty-playbook]]
+- Project Pipelines package/plugin paths -> also load [[project-pipelines-playbook]]
+
+If the target repository cannot be mapped confidently, ask the human and do not substitute a generic Botster checklist or load every repository charter.
+
+## Severity routing (throughput hygiene)
+Classify findings before choosing a verdict:
+
+| Class | Verdict |
+|-------|---------|
+| Product / charter / wrong repo / weak live proof | changes_required or blocked |
+| Process-only missing artifact_id when artifact + artifact.added already exist | approve if product is sound, or auto-fix evidence — do not full re-Plan |
+| Infra dirt (empty gitignore, colon path) | hygiene restore / engine fix, not product re-plan |
+
+Do not send process or infra thrash back through a full Plan loop when product findings are sound.
+
+## Keep (do not weaken)
+- Live Hub pin / charter live proof
+- Request-race / SPA request-state proof
+- Independent Plan Review base re-verification
+- Runtime-teardown class checks only when applicable
+
+Reject a plan that targets the wrong repository, violates the charter's owns/does-not-own boundary, omits required downstream consumer proof, hides cross-repository dependencies, cites absent paths, or substitutes generic Botster guidance for the repository charter. Verify dependencies are registered against the correct repository target and available through the actual consumed artifact where relevant.
+
+Your output must include:
+- Approved, changes required, or blocked
+- Independently resolved target repository and target_id
+- Required repository charter and whether the plan loaded it
+- Missing context/playbooks
+- Architecture, ownership, scope, or cross-repo dependency issues
+- Missing risks/assumptions
+- Missing or weak acceptance checks and downstream proof
+- Severity class for each finding (product, process, or infra)
+
+## Runtime-teardown class (when applicable)
+When the ticket matches runtime-teardown class, require [[botster runtime teardown lenses]] answers in the plan. Reject or changes_required if the plan only map-removes state, treats a terminal file as live proof, omits an ownership-creating late-message surface, allows unbounded control-plane hang on close, or leaves sibling sacrifice unstated and untested. Do not force teardown-lens fields on non-class tickets.]]
+
+function M.prompt_revision()
+    return PROMPT_REVISION
+end
+
+--- Refresh botster_stack_delivery Plan and Plan Review prompts when revision drifts.
+-- Safe when the pipeline is absent (no-op). Preserves operator-chosen agent_name values.
+function M.reconcile()
+    local pipeline = repo.get_pipeline(PIPELINE_ID)
+    if not pipeline then
+        return { refreshed = false, reason = "pipeline_absent" }
+    end
+    if pipeline.version_label == PROMPT_REVISION then
+        return { refreshed = false, reason = "already_current", revision = PROMPT_REVISION }
+    end
+
+    local plan_step = repo.get_step(PLAN_STEP_ID)
+    local review_step = repo.get_step(PLAN_REVIEW_STEP_ID)
+    if not plan_step or not review_step then
+        return { refreshed = false, reason = "steps_missing" }
+    end
+
+    local ok_plan, err_plan = pcall(repo.update_step, PLAN_STEP_ID, { prompt = PLAN_PROMPT })
+    if not ok_plan then
+        return { refreshed = false, reason = "plan_update_failed", error = tostring(err_plan) }
+    end
+    local ok_review, err_review = pcall(repo.update_step, PLAN_REVIEW_STEP_ID, { prompt = PLAN_REVIEW_PROMPT })
+    if not ok_review then
+        return { refreshed = false, reason = "plan_review_update_failed", error = tostring(err_review) }
+    end
+    local ok_pipe, err_pipe = pcall(repo.update_pipeline, PIPELINE_ID, { version_label = PROMPT_REVISION })
+    if not ok_pipe then
+        return { refreshed = false, reason = "pipeline_label_failed", error = tostring(err_pipe) }
+    end
+
+    repo.append_event("pipeline.stack_delivery_prompts_refreshed", {
+        payload = {
+            pipeline_id = PIPELINE_ID,
+            revision = PROMPT_REVISION,
+            previous_version_label = pipeline.version_label,
+        },
+    })
+    return { refreshed = true, revision = PROMPT_REVISION }
+end
+
+return M

--- a/cli/lua/lib/hub.lua
+++ b/cli/lua/lib/hub.lua
@@ -275,6 +275,19 @@ function Hub._handle_worker_parent_request(payload)
         return { result = { ok = true } }
     end
 
+    if kind == "run_command_gate" then
+        if type(hub) ~= "table" or type(hub.run_command_gate) ~= "function" then
+            return { error = "worker parent hub run_command_gate unavailable: hub.run_command_gate missing" }
+        end
+        local ok, err = pcall(function()
+            return hub.run_command_gate(payload.opts or {})
+        end)
+        if not ok then
+            return { error = tostring(err) }
+        end
+        return { result = { ok = true } }
+    end
+
     if kind == "send_message" then
         return { result = local_hub:send_message(payload.agent_id, payload.text, payload.session) }
     end
@@ -798,6 +811,29 @@ function Hub:prepare_plugin_command(opts)
 
     local result = remote_request(self, {
         type = "prepare_plugin_command",
+        opts = opts,
+    }, 10000)
+    if result.error then
+        error(result.error)
+    end
+    return result.result or { ok = true }
+end
+
+--- Queue a one-shot non-PTY command gate on this hub.
+-- Completion is delivered asynchronously through `command_gate_completed`.
+-- Plugin workers must use this facade; the isolated worker-global `hub` table
+-- does not expose `run_command_gate`.
+function Hub:run_command_gate(opts)
+    opts = copy_table(opts or {})
+    if self._is_local then
+        if type(hub) ~= "table" or type(hub.run_command_gate) ~= "function" then
+            error("Hub:run_command_gate unavailable: hub.run_command_gate is nil")
+        end
+        return hub.run_command_gate(opts)
+    end
+
+    local result = remote_request(self, {
+        type = "run_command_gate",
         opts = opts,
     }, 10000)
     if result.error then

--- a/cli/src/agent/mod.rs
+++ b/cli/src/agent/mod.rs
@@ -187,8 +187,12 @@ impl Agent {
     /// Format: `{repo-safe}-{branch-name}` (slashes replaced with dashes).
     #[must_use]
     pub fn agent_id(&self) -> String {
-        let repo_safe = self.repo.replace('/', "-");
-        format!("{}-{}", repo_safe, self.branch_name.replace('/', "-"))
+        let repo_safe = crate::git::path_component_safe(&self.repo);
+        format!(
+            "{}-{}",
+            repo_safe,
+            crate::git::path_component_safe(&self.branch_name)
+        )
     }
 
     // =========================================================================

--- a/cli/src/git.rs
+++ b/cli/src/git.rs
@@ -19,6 +19,33 @@ pub struct WorktreeManager {
     base_dir: PathBuf,
 }
 
+/// Sanitize a string for use as a single filesystem path component.
+///
+/// Replaces path separators and characters that break nested tools (notably
+/// `:` on macOS DYLD path lists when Cargo injects `target/deps`) with `-`.
+/// Collapses repeated dashes and trims leading/trailing dashes.
+// Rust guideline compliant 2024-12 (M-DOCUMENTED-MAGIC / path safety)
+pub fn path_component_safe(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    for ch in name.chars() {
+        match ch {
+            '/' | '\\' | ':' | '@' | '|' | '<' | '>' | '*' | '?' | '"' => out.push('-'),
+            c if c.is_control() || c.is_whitespace() => out.push('-'),
+            c => out.push(c),
+        }
+    }
+    let collapsed = out
+        .split('-')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("-");
+    if collapsed.is_empty() {
+        "repo".to_string()
+    } else {
+        collapsed
+    }
+}
+
 impl WorktreeManager {
     /// Creates a new worktree manager with the specified base directory.
     pub fn new(base_dir: PathBuf) -> Self {
@@ -177,8 +204,8 @@ impl WorktreeManager {
         base_ref: Option<&str>,
     ) -> Result<PathBuf> {
         let repo_name = repo_name_for_root(repo_path)?;
-        let repo_safe = repo_name.replace('/', "-");
-        let sanitized_branch = branch_name.replace('/', "-");
+        let repo_safe = path_component_safe(&repo_name);
+        let sanitized_branch = path_component_safe(branch_name);
         let worktree_path = self
             .base_dir
             .join(format!("{}-{}", repo_safe, sanitized_branch));
@@ -274,7 +301,7 @@ impl WorktreeManager {
 
     /// Creates or reuses a git worktree for the given repo and issue (clone from GitHub)
     pub fn create_worktree(&self, repo: &str, issue_number: u32) -> Result<PathBuf> {
-        let repo_safe = repo.replace('/', "-");
+        let repo_safe = path_component_safe(repo);
         fs::create_dir_all(&self.base_dir)?;
 
         let clone_dir = self.base_dir.join(&repo_safe);
@@ -380,7 +407,7 @@ impl WorktreeManager {
 
     /// Lists all existing worktrees for a repo
     pub fn list_worktrees(&self, repo: &str) -> Result<Vec<String>> {
-        let repo_safe = repo.replace('/', "-");
+        let repo_safe = path_component_safe(repo);
         let clone_dir = self.base_dir.join(&repo_safe);
 
         if !clone_dir.exists() {
@@ -403,7 +430,7 @@ impl WorktreeManager {
         issue_number: u32,
     ) -> Result<Option<(PathBuf, String)>> {
         let (repo_path, repo_name) = Self::detect_current_repo()?;
-        let repo_safe = repo_name.replace('/', "-");
+        let repo_safe = path_component_safe(&repo_name);
         let branch_name = format!("botster-issue-{}", issue_number);
         let worktree_path = self.base_dir.join(format!("{}-{}", repo_safe, branch_name));
 
@@ -458,7 +485,7 @@ impl WorktreeManager {
 
     /// Prunes all stale worktrees for a repo
     pub fn prune_stale_worktrees(&self, repo: &str) -> Result<()> {
-        let repo_safe = repo.replace('/', "-");
+        let repo_safe = path_component_safe(repo);
         let clone_dir = self.base_dir.join(&repo_safe);
 
         if clone_dir.exists() {
@@ -609,7 +636,7 @@ impl WorktreeManager {
         // Detect the current repo
         let (repo_path, repo_name) = Self::detect_current_repo()?;
 
-        let repo_safe = repo_name.replace('/', "-");
+        let repo_safe = path_component_safe(&repo_name);
         let branch_name = format!("botster-issue-{}", issue_number);
         let worktree_path = self
             .base_dir
@@ -920,6 +947,20 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let manager = WorktreeManager::new(temp_dir.path().to_path_buf());
         assert!(manager.base_dir.to_str().is_some());
+    }
+
+    #[test]
+    fn path_component_safe_strips_colon_and_at() {
+        // SSH-style remotes and owner/repo paths must not keep ':' (DYLD) or '@'.
+        assert_eq!(
+            path_component_safe("git@github.com:trybotster/botster-tui"),
+            "git-github.com-trybotster-botster-tui"
+        );
+        assert_eq!(
+            path_component_safe("owner/repo"),
+            "owner-repo"
+        );
+        assert!(!path_component_safe("git@github.com:x/y").contains(':'));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Stop Plan↔Plan Review thrash from process/infra noise while keeping product proof bars.
- Restore empty tracked `.gitignore` from HEAD on step activation; never truncate.
- Sanitize worktree path components so directories do not contain `:` (Cargo/macOS DYLD).
- Call command gates through `Hub:run_command_gate` (worker-safe) instead of nil `hub.run_command_gate`.
- Auto-refresh `botster_stack_delivery` Plan / Plan Review prompts on plugin load when `version_label` drifts.

## Changes
1. **cli/src/git.rs** — `path_component_safe` for worktree/clone directory names.
2. **cli/lua/lib/hub.lua** — `Hub:run_command_gate` + worker-parent proxy.
3. **catalog project-pipelines** — engine hygiene, CARGO_TARGET_DIR when path has `:`, stack_delivery prompt reconcile.

## Install dual-write
Catalog is source of truth. After merge/reload:

```bash
rsync -a --delete \
  catalog/templates/plugins/project-pipelines/ \
  ~/.botster-dev/plugins/project-pipelines/
```

Already synced to `~/.botster-dev/plugins/project-pipelines/` for dogfood. Reload the plugin so `stack_delivery.reconcile` refreshes Plan prompts in plugin DB.

Hub facade + path sanitize need a hub binary built from this branch (or lua path pointing at this tree).

## Test plan
- [x] `cli/test.sh --unit path_component_safe`
- [x] Smoke grep installed engine for `invoke_run_command_gate`, gitignore hygiene, `CARGO_TARGET_DIR`, `artifact_id`
- [ ] Reload project-pipelines on dogfood hub; confirm log line for prompt refresh when version_label differs
- [ ] New agent worktree path has no `:` for SSH remotes
- [ ] Empty tracked `.gitignore` restored on step activation without truncating non-empty edits

## Residual human steps
1. Restart/reload dogfood hub with this branch’s hub.lua + git path fix.
2. Confirm `botster_stack_delivery.version_label` is `plan-loop-hygiene/2026-08-10.1` after plugin load.
3. Do not edit `/Users/jasonconigliari/Projects/botster-project-pipelines` for this monorepo fix.