### PR TITLE
fix(project-pipelines): fail-closed ticket deps at step activation

### DIFF
--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -191,15 +191,13 @@ and ticket ids, title/status when available, an operator prompt, and either:
 - `reason = "unavailable_ticket"` when the left-joined ticket or its status is
   unavailable.
 
-The preflight runs before completing the source visit, emitting
-`step.completed` or an override event, creating the target visit, changing run
-pointers, notifying, resolving command execution, requesting a worktree or
-session, or spawning/linking an agent. Direct activation re-checks immediately
-before those target side effects so a dependency block cannot leave a half-
-activated target. When a residual second check still finds open blockers after
-the source visit was completed, advance returns top-level `ok = false` with
-`reason = "ticket_dependencies"` rather than a successful advance that nests a
-blocked activation. `start_run` returns the same typed blocked shape
+The preflight decision covers the full transition before durable mutation.
+`request_step_advance` activates the target step before completing the source
+visit, so a dependency block leaves the source visit active and never emits
+`step.completed`. Direct activation re-checks immediately before target side
+effects (visit, run pointer, `step.activated`, notify, spawn). `retry_step_agent`
+makes the same decision twice immediately before retry mutations and does not
+re-check after those mutations. `start_run` returns the typed blocked shape
 (`ok = false`, `status = "blocked"`, `reason = "ticket_dependencies"`,
 `unmet_dependencies` with each `depends_on_ticket_id`) and does not create a run.
 A final advance with no target step still completes the run and follows its merge

--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -194,14 +194,17 @@ and ticket ids, title/status when available, an operator prompt, and either:
 The preflight runs before completing the source visit, emitting
 `step.completed` or an override event, creating the target visit, changing run
 pointers, notifying, resolving command execution, requesting a worktree or
-session, or spawning/linking an agent. When a residual second check still finds
-open blockers after the source visit was completed, advance returns top-level
-`ok = false` with `reason = "ticket_dependencies"` rather than a successful
-advance that nests a blocked activation. `start_run` raises
-`ticket dependencies must close before starting a run: ...` before creating the
-run (same shared helper). A final advance with no target step still completes the
-run and follows its merge policy; dependency gating applies to target-step
-activation, not run completion or merge.
+session, or spawning/linking an agent. Direct activation re-checks immediately
+before those target side effects so a dependency block cannot leave a half-
+activated target. When a residual second check still finds open blockers after
+the source visit was completed, advance returns top-level `ok = false` with
+`reason = "ticket_dependencies"` rather than a successful advance that nests a
+blocked activation. `start_run` returns the same typed blocked shape
+(`ok = false`, `status = "blocked"`, `reason = "ticket_dependencies"`,
+`unmet_dependencies` with each `depends_on_ticket_id`) and does not create a run.
+A final advance with no target step still completes the run and follows its merge
+policy; dependency gating applies to target-step activation, not run completion
+or merge.
 
 Closing or removing a dependency never activates work automatically. The
 operator must explicitly advance or retry again. A dependency added after the

--- a/catalog/templates/plugins/project-pipelines/README.md
+++ b/catalog/templates/plugins/project-pipelines/README.md
@@ -174,12 +174,11 @@ Agents should call `project_pipelines_current_context` first. The context includ
 Agents submit evidence with `project_pipelines_submit_gate`, reviews with `project_pipelines_submit_review`, artifacts with `project_pipelines_add_artifact`, and move the run with `project_pipelines_request_step_advance`. If gates are not satisfied, advancement returns structured unmet gate prompts.
 
 Ticket ordering dependencies are an unconditional activation preflight. The
-engine reads the normalized rows returned by
-`repo.ticket_dependencies(ticket_id)` every time it advances to a target step,
-directly activates a step, returns PR review feedback to implementation, or
-retries the current agent step. Every referenced ticket must have
-`status = "closed"`; there is no step-level or forced-transition override for
-open dependencies.
+engine uses one shared helper over the normalized rows returned by
+`repo.ticket_dependencies(ticket_id)` for `start_run`, advance to a target step,
+direct activation, PR review reactivation, agent retry, and a last-line defense
+inside agent spawn. Every referenced ticket must have `status = "closed"`; there
+is no step-level or forced-transition override for open dependencies.
 
 A blocked attempt returns `ok = false`, `status = "blocked"`,
 `reason = "ticket_dependencies"`, and `unmet_dependencies`. It also appends one
@@ -195,10 +194,13 @@ and ticket ids, title/status when available, an operator prompt, and either:
 The preflight runs before completing the source visit, emitting
 `step.completed` or an override event, creating the target visit, changing run
 pointers, notifying, resolving command execution, requesting a worktree or
-session, or spawning/linking an agent. `start_run` keeps its earlier contract:
-it raises `ticket dependencies must close before starting a run: ...` before
-creating the run. A final advance with no target step still completes the run
-and follows its merge policy; dependency gating applies to target-step
+session, or spawning/linking an agent. When a residual second check still finds
+open blockers after the source visit was completed, advance returns top-level
+`ok = false` with `reason = "ticket_dependencies"` rather than a successful
+advance that nests a blocked activation. `start_run` raises
+`ticket dependencies must close before starting a run: ...` before creating the
+run (same shared helper). A final advance with no target step still completes the
+run and follows its merge policy; dependency gating applies to target-step
 activation, not run completion or merge.
 
 Closing or removing a dependency never activates work automatically. The

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
@@ -2159,36 +2159,73 @@ function M.request_step_advance(params, context)
         })
     end
 
-    if active_visit_id then
-        repo.update_run_step_visit(active_visit_id, { status = "done", completed_at = util.now() })
-    else
-        repo.update_run_step(run.id, step.id, { status = "done", completed_at = util.now() })
+    local function complete_source_visit()
+        if active_visit_id then
+            repo.update_run_step_visit(active_visit_id, { status = "done", completed_at = util.now() })
+        else
+            repo.update_run_step(run.id, step.id, { status = "done", completed_at = util.now() })
+        end
+        repo.append_event("step.completed", {
+            run_id = run.id,
+            ticket_id = run.ticket_id,
+            payload = {
+                step_id = step.id,
+                run_step_id = active_visit_id,
+                summary = params.summary,
+                evidence = params.evidence or {},
+            },
+        })
     end
-    repo.append_event("step.completed", {
-        run_id = run.id,
-        ticket_id = run.ticket_id,
-        payload = { step_id = step.id, run_step_id = active_visit_id, summary = params.summary, evidence = params.evidence or {} },
-    })
-    local updated = repo.get_run(run.id)
-    local activation = M.activate_step(updated, next_step)
-    -- Do not report top-level success when target activation is dependency-blocked
-    -- (TOCTOU after the preflight check, or any residual fail-closed path).
-    if activation and activation.ok == false and activation.reason == "ticket_dependencies" then
+
+    -- Target activation runs before source completion so a dependency block cannot
+    -- leave the source visit done while the target is refused.
+    if next_step then
+        local activation = M.activate_step(run, next_step)
+        if activation and activation.ok == false and activation.reason == "ticket_dependencies" then
+            return {
+                ok = false,
+                status = "blocked",
+                reason = "ticket_dependencies",
+                step = step,
+                next_step = next_step,
+                target_step = next_step,
+                source = activation.source or "activate_step",
+                unmet_dependencies = activation.unmet_dependencies,
+                activation = activation,
+                run = repo.get_run(run.id),
+            }
+        end
+        complete_source_visit()
+        if activation and activation.ok == false then
+            return {
+                ok = false,
+                status = activation.status or "blocked",
+                completed_step = step,
+                next_step = next_step,
+                activation = activation,
+                run = repo.get_run(run.id),
+                error = activation.error,
+            }
+        end
         return {
-            ok = false,
-            status = "blocked",
-            reason = "ticket_dependencies",
-            step = step,
+            ok = true,
             completed_step = step,
             next_step = next_step,
-            target_step = next_step,
-            source = activation.source or "activate_step",
-            unmet_dependencies = activation.unmet_dependencies,
             activation = activation,
             run = repo.get_run(run.id),
         }
     end
-    return { ok = true, completed_step = step, next_step = next_step, activation = activation, run = repo.get_run(run.id) }
+
+    -- Final advance (no target step): complete the run / merge path.
+    complete_source_visit()
+    local activation = M.activate_step(repo.get_run(run.id), nil)
+    return {
+        ok = true,
+        completed_step = step,
+        next_step = nil,
+        activation = activation,
+        run = repo.get_run(run.id),
+    }
 end
 
 function M.retry_step_agent(params, context)
@@ -2236,6 +2273,8 @@ function M.retry_step_agent(params, context)
         error("no run step visit found for current step")
     end
 
+    -- Final dependency decision covers the full retry transition before any
+    -- durable mutation (status flip, session clear, retry event, spawn).
     local blocked = dependency_block(run, {
         step_id = step.id,
         run_step_id = visit.id,
@@ -2248,6 +2287,23 @@ function M.retry_step_agent(params, context)
         blocked.run_step = visit
         return blocked
     end
+    blocked = dependency_block(run, {
+        step_id = step.id,
+        run_step_id = visit.id,
+        target_step_id = step.id,
+        source = "retry_step_agent",
+    })
+    if blocked then
+        blocked.step = step
+        blocked.run = run
+        blocked.run_step = visit
+        return blocked
+    end
+
+    local prior_status = run.status
+    local prior_visit_status = visit.status
+    local prior_session = visit.agent_session_uuid
+    local prior_started_at = visit.started_at
 
     repo.update_run(run.id, { status = "active", current_step_id = step.id, current_run_step_id = visit.id })
     repo.update_run_step_visit(visit.id, {
@@ -2266,22 +2322,27 @@ function M.retry_step_agent(params, context)
         },
     })
 
+    -- Deps already decided above; do not re-check after mutation (would leave
+    -- half-applied retry state without restoring source fields).
     local created, err = spawn_step_agent(repo.get_run(run.id), step, {
-        dependency_source = "retry_step_agent",
+        skip_dependency_check = true,
     })
     if err then
-        if type(err) == "table" and err.reason == "ticket_dependencies" then
-            err.step = step
-            err.run = repo.get_run(run.id)
-            err.run_step = repo.get_run_step_visit(visit.id)
-            return err
-        end
         repo.update_run(run.id, { status = "blocked" })
         repo.update_run_step_visit(visit.id, { status = "blocked" })
         repo.append_event("step.spawn_failed", {
             run_id = run.id,
             ticket_id = run.ticket_id,
-            payload = { step_id = step.id, run_step_id = visit.id, retry = true, error = err },
+            payload = {
+                step_id = step.id,
+                run_step_id = visit.id,
+                retry = true,
+                error = err,
+                prior_status = prior_status,
+                prior_visit_status = prior_visit_status,
+                prior_session = prior_session,
+                prior_started_at = prior_started_at,
+            },
         })
         return { ok = false, status = "blocked", run = repo.get_run(run.id), step = step, run_step = repo.get_run_step_visit(visit.id), error = err }
     end

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
@@ -429,23 +429,22 @@ local function spawn_step_agent(run, step, opts)
         return nil, "target_id is required before spawning agent steps"
     end
 
-    -- Last-line defense: refuse create_agent / re-prompt even if a caller
-    -- bypassed activation preflight. Primary gate remains activate/advance/retry.
-    local blocked = dependency_block(run, {
-        step_id = step.id,
-        run_step_id = run.current_run_step_id,
-        target_step_id = step.id,
-        source = "spawn_step_agent",
-    })
-    if blocked then
-        local names = {}
-        for _, entry in ipairs(blocked.unmet_dependencies) do
-            names[#names + 1] = (entry.depends_on_title or entry.depends_on_ticket_id)
-                .. " ("
-                .. tostring(entry.depends_on_status or entry.reason or "open")
-                .. ")"
+    -- Last-line defense for callers that already mutated state (retry) or that
+    -- skip activate preflight. Returns a structured dependency block (not a
+    -- plain string) so callers preserve reason=ticket_dependencies + ids.
+    -- activate_step runs this check before target side effects when
+    -- skip_dependency_check is not set; after side effects it passes
+    -- skip_dependency_check=true so a race cannot leave a half-activated target.
+    if opts.skip_dependency_check ~= true then
+        local blocked = dependency_block(run, {
+            step_id = step.id,
+            run_step_id = run.current_run_step_id,
+            target_step_id = step.id,
+            source = opts.dependency_source or "spawn_step_agent",
+        })
+        if blocked then
+            return nil, blocked
         end
-        return nil, "ticket dependencies must close before spawning: " .. table.concat(names, ", ")
     end
 
     local ticket = repo.get_ticket(run.ticket_id)
@@ -1580,14 +1579,30 @@ function M.activate_step(run, step, options)
     end
 
     options = options or {}
+    local source = options.source or "activate_step"
     local blocked = dependency_block(run, {
         step_id = run.current_step_id,
         run_step_id = run.current_run_step_id,
         target_step_id = step.id,
-        source = options.source or "activate_step",
+        source = source,
     })
     if blocked then
         return blocked
+    end
+
+    -- Final fail-closed check immediately before any target side effects so a
+    -- spawn-time dependency block cannot leave a visit, run pointer change,
+    -- step.activated event, or phase notification.
+    if step.kind == "agent" or step.kind == "command" then
+        blocked = dependency_block(run, {
+            step_id = run.current_step_id,
+            run_step_id = run.current_run_step_id,
+            target_step_id = step.id,
+            source = source,
+        })
+        if blocked then
+            return blocked
+        end
     end
 
     local now = util.now()
@@ -1618,8 +1633,20 @@ function M.activate_step(run, step, options)
     end
 
     if step.kind == "agent" then
-        local created, err = spawn_step_agent(repo.get_run(run.id), step, options.spawn_options)
+        local spawn_options = {}
+        for key, value in pairs(options.spawn_options or {}) do
+            spawn_options[key] = value
+        end
+        -- Deps already cleared immediately above; do not re-check after side
+        -- effects (that path would leave a half-activated target).
+        spawn_options.skip_dependency_check = true
+        local created, err = spawn_step_agent(repo.get_run(run.id), step, spawn_options)
         if err then
+            -- Structured dependency blocks should not reach here after the
+            -- pre-side-effect check; preserve them if a caller mis-wires spawn.
+            if type(err) == "table" and err.reason == "ticket_dependencies" then
+                return err
+            end
             repo.update_run(run.id, { status = "blocked" })
             repo.update_run_step_visit(visit.id, { status = "blocked" })
             repo.append_event("step.spawn_failed", {
@@ -1992,18 +2019,17 @@ function M.start_run(params)
     if util.is_blank(ticket.target_id) then
         error("ticket target_id is required before starting a run")
     end
-    -- Same authority as activate/advance/retry/spawn: unmet_ticket_dependencies
-    -- over normalized ticket_dependencies rows (not a divergent SQL filter).
+    -- Same authority as activate/advance/retry/spawn: unmet_ticket_dependencies.
+    -- Public MCP must receive a typed blocked result that names dependency ticket ids.
     local blockers = unmet_ticket_dependencies(params.ticket_id)
     if #blockers > 0 then
-        local names = {}
-        for _, blocker in ipairs(blockers) do
-            names[#names + 1] = (blocker.depends_on_title or blocker.depends_on_ticket_id)
-                .. " ("
-                .. tostring(blocker.depends_on_status or blocker.reason or "open")
-                .. ")"
-        end
-        error("ticket dependencies must close before starting a run: " .. table.concat(names, ", "))
+        return {
+            ok = false,
+            status = "blocked",
+            reason = "ticket_dependencies",
+            source = "start_run",
+            unmet_dependencies = blockers,
+        }
     end
     local pipeline = repo.get_pipeline(pipeline_id)
     if not pipeline then
@@ -2240,8 +2266,16 @@ function M.retry_step_agent(params, context)
         },
     })
 
-    local created, err = spawn_step_agent(repo.get_run(run.id), step)
+    local created, err = spawn_step_agent(repo.get_run(run.id), step, {
+        dependency_source = "retry_step_agent",
+    })
     if err then
+        if type(err) == "table" and err.reason == "ticket_dependencies" then
+            err.step = step
+            err.run = repo.get_run(run.id)
+            err.run_step = repo.get_run_step_visit(visit.id)
+            return err
+        end
         repo.update_run(run.id, { status = "blocked" })
         repo.update_run_step_visit(visit.id, { status = "blocked" })
         repo.append_event("step.spawn_failed", {

--- a/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
+++ b/catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua
@@ -359,6 +359,67 @@ function M.context_for(run_id, session_uuid)
     }
 end
 
+-- Shared fail-closed ticket-dependency preflight for activation, advance, retry,
+-- start_run, and last-line spawn defense. Reads normalized
+-- repo.ticket_dependencies rows (depends_on_status from LEFT JOIN).
+local function unmet_ticket_dependencies(ticket_id)
+    local unmet = {}
+    local dependencies = repo.ticket_dependencies(ticket_id)
+    for _, dependency in ipairs(dependencies) do
+        if dependency.depends_on_status ~= "closed" then
+            local unavailable = util.is_blank(dependency.depends_on_status)
+            local reason = unavailable and "unavailable_ticket" or "open_ticket"
+            local label = dependency.depends_on_title or dependency.depends_on_ticket_id
+            local prompt
+            if unavailable then
+                prompt = "Restore or remove unavailable dependency ticket " .. tostring(dependency.depends_on_ticket_id) .. " before continuing."
+            else
+                prompt = "Close dependency ticket " .. tostring(label) .. " (" .. tostring(dependency.depends_on_ticket_id) .. ", status: " .. tostring(dependency.depends_on_status) .. ") before continuing."
+            end
+            unmet[#unmet + 1] = {
+                dependency_id = dependency.id,
+                depends_on_ticket_id = dependency.depends_on_ticket_id,
+                depends_on_title = dependency.depends_on_title,
+                depends_on_status = dependency.depends_on_status,
+                reason = reason,
+                prompt = prompt,
+            }
+        end
+    end
+    return unmet
+end
+
+local function dependency_block(run, attrs)
+    local unmet = unmet_ticket_dependencies(run.ticket_id)
+    if #unmet == 0 then
+        return nil
+    end
+
+    local payload = {
+        step_id = attrs.step_id,
+        run_step_id = attrs.run_step_id,
+        target_step_id = attrs.target_step_id,
+        source = attrs.source,
+        reason = "ticket_dependencies",
+        unmet_dependencies = unmet,
+    }
+    repo.append_event("step.advance_blocked", {
+        run_id = run.id,
+        ticket_id = run.ticket_id,
+        payload = payload,
+    })
+    return {
+        ok = false,
+        status = "blocked",
+        reason = "ticket_dependencies",
+        step_id = attrs.step_id,
+        run_step_id = attrs.run_step_id,
+        target_step_id = attrs.target_step_id,
+        source = attrs.source,
+        unmet_dependencies = unmet,
+    }
+end
+
 local function spawn_step_agent(run, step, opts)
     opts = opts or {}
     if util.is_blank(step.agent_name) then
@@ -366,6 +427,25 @@ local function spawn_step_agent(run, step, opts)
     end
     if util.is_blank(run.target_id) then
         return nil, "target_id is required before spawning agent steps"
+    end
+
+    -- Last-line defense: refuse create_agent / re-prompt even if a caller
+    -- bypassed activation preflight. Primary gate remains activate/advance/retry.
+    local blocked = dependency_block(run, {
+        step_id = step.id,
+        run_step_id = run.current_run_step_id,
+        target_step_id = step.id,
+        source = "spawn_step_agent",
+    })
+    if blocked then
+        local names = {}
+        for _, entry in ipairs(blocked.unmet_dependencies) do
+            names[#names + 1] = (entry.depends_on_title or entry.depends_on_ticket_id)
+                .. " ("
+                .. tostring(entry.depends_on_status or entry.reason or "open")
+                .. ")"
+        end
+        return nil, "ticket dependencies must close before spawning: " .. table.concat(names, ", ")
     end
 
     local ticket = repo.get_ticket(run.ticket_id)
@@ -1468,64 +1548,6 @@ local function run_command_step(run, step)
     return result, nil
 end
 
-local function unmet_ticket_dependencies(ticket_id)
-    local unmet = {}
-    local dependencies = repo.ticket_dependencies(ticket_id)
-    for _, dependency in ipairs(dependencies) do
-        if dependency.depends_on_status ~= "closed" then
-            local unavailable = util.is_blank(dependency.depends_on_status)
-            local reason = unavailable and "unavailable_ticket" or "open_ticket"
-            local label = dependency.depends_on_title or dependency.depends_on_ticket_id
-            local prompt
-            if unavailable then
-                prompt = "Restore or remove unavailable dependency ticket " .. tostring(dependency.depends_on_ticket_id) .. " before continuing."
-            else
-                prompt = "Close dependency ticket " .. tostring(label) .. " (" .. tostring(dependency.depends_on_ticket_id) .. ", status: " .. tostring(dependency.depends_on_status) .. ") before continuing."
-            end
-            unmet[#unmet + 1] = {
-                dependency_id = dependency.id,
-                depends_on_ticket_id = dependency.depends_on_ticket_id,
-                depends_on_title = dependency.depends_on_title,
-                depends_on_status = dependency.depends_on_status,
-                reason = reason,
-                prompt = prompt,
-            }
-        end
-    end
-    return unmet
-end
-
-local function dependency_block(run, attrs)
-    local unmet = unmet_ticket_dependencies(run.ticket_id)
-    if #unmet == 0 then
-        return nil
-    end
-
-    local payload = {
-        step_id = attrs.step_id,
-        run_step_id = attrs.run_step_id,
-        target_step_id = attrs.target_step_id,
-        source = attrs.source,
-        reason = "ticket_dependencies",
-        unmet_dependencies = unmet,
-    }
-    repo.append_event("step.advance_blocked", {
-        run_id = run.id,
-        ticket_id = run.ticket_id,
-        payload = payload,
-    })
-    return {
-        ok = false,
-        status = "blocked",
-        reason = "ticket_dependencies",
-        step_id = attrs.step_id,
-        run_step_id = attrs.run_step_id,
-        target_step_id = attrs.target_step_id,
-        source = attrs.source,
-        unmet_dependencies = unmet,
-    }
-end
-
 function M.activate_step(run, step, options)
     if not step then
         repo.update_run(run.id, { status = "done", current_step_id = nil, current_run_step_id = nil })
@@ -1970,11 +1992,16 @@ function M.start_run(params)
     if util.is_blank(ticket.target_id) then
         error("ticket target_id is required before starting a run")
     end
-    local blockers = repo.blocking_ticket_dependencies(params.ticket_id)
+    -- Same authority as activate/advance/retry/spawn: unmet_ticket_dependencies
+    -- over normalized ticket_dependencies rows (not a divergent SQL filter).
+    local blockers = unmet_ticket_dependencies(params.ticket_id)
     if #blockers > 0 then
         local names = {}
         for _, blocker in ipairs(blockers) do
-            names[#names + 1] = (blocker.depends_on_title or blocker.depends_on_ticket_id) .. " (" .. tostring(blocker.depends_on_status or "open") .. ")"
+            names[#names + 1] = (blocker.depends_on_title or blocker.depends_on_ticket_id)
+                .. " ("
+                .. tostring(blocker.depends_on_status or blocker.reason or "open")
+                .. ")"
         end
         error("ticket dependencies must close before starting a run: " .. table.concat(names, ", "))
     end
@@ -2118,6 +2145,23 @@ function M.request_step_advance(params, context)
     })
     local updated = repo.get_run(run.id)
     local activation = M.activate_step(updated, next_step)
+    -- Do not report top-level success when target activation is dependency-blocked
+    -- (TOCTOU after the preflight check, or any residual fail-closed path).
+    if activation and activation.ok == false and activation.reason == "ticket_dependencies" then
+        return {
+            ok = false,
+            status = "blocked",
+            reason = "ticket_dependencies",
+            step = step,
+            completed_step = step,
+            next_step = next_step,
+            target_step = next_step,
+            source = activation.source or "activate_step",
+            unmet_dependencies = activation.unmet_dependencies,
+            activation = activation,
+            run = repo.get_run(run.id),
+        }
+    end
     return { ok = true, completed_step = step, next_step = next_step, activation = activation, run = repo.get_run(run.id) }
 end
 

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -4067,6 +4067,106 @@ fn catalog_plugin_project_pipelines_mid_run_dependency_blocks_plan_review_to_imp
             end
             assert(saw_activated == false)
             assert(saw_block == true)
+
+            -- Hostile phase flip on advance: first advance preflight closed,
+            -- activate pre-side-effect open. Source visit must stay active;
+            -- no step.completed, no target activation, no agent request.
+            phase = 0
+            events = {{}}
+            create_agent_calls = 0
+            created_visits = 0
+            notification_calls = 0
+            visit_status = "active"
+            run.current_step_id = "plan_review"
+            run.current_run_step_id = "visit-plan-review"
+            package.loaded["project_pipelines.repo"].ticket_dependencies = function(ticket_id)
+              phase = phase + 1
+              -- advance preflight closed; activate's checks open
+              local status = phase == 1 and "closed" or "open"
+              return {{
+                {{
+                  id = "dependency-kit",
+                  ticket_id = ticket_id,
+                  depends_on_ticket_id = "ticket-kit",
+                  depends_on_title = "Kit blocker",
+                  depends_on_status = status,
+                }},
+              }}
+            end
+            local advance_hostile = engine.request_step_advance({{
+              run_id = "run-live",
+              summary = "hostile phase flip during advance",
+            }}, {{}})
+            assert(advance_hostile.ok == false)
+            assert(advance_hostile.reason == "ticket_dependencies")
+            assert(advance_hostile.unmet_dependencies[1].depends_on_ticket_id == "ticket-kit")
+            assert(create_agent_calls == 0)
+            assert(created_visits == 0)
+            assert(notification_calls == 0)
+            assert(run.current_step_id == "plan_review")
+            assert(run.current_run_step_id == "visit-plan-review")
+            assert(visit_status == "active")
+            local saw_completed = false
+            saw_activated = false
+            for _, event in ipairs(events) do
+              if event.kind == "step.completed" then saw_completed = true end
+              if event.kind == "step.activated" then saw_activated = true end
+              if event.kind == "step.agent_requested" then
+                error("must not request target agent while dependency-blocked")
+              end
+            end
+            assert(saw_completed == false)
+            assert(saw_activated == false)
+
+            -- Hostile phase flip on retry: first check closed, second open.
+            -- No retry mutation, no retry event, no create_agent.
+            phase = 0
+            events = {{}}
+            create_agent_calls = 0
+            visit_status = "blocked"
+            run.status = "blocked"
+            run.current_step_id = "plan_review"
+            run.current_run_step_id = "visit-plan-review"
+            package.loaded["project_pipelines.repo"].get_run_step_visit = function(id)
+              return {{
+                id = id,
+                run_id = run.id,
+                step_id = "plan_review",
+                status = visit_status,
+                agent_session_uuid = "sess-dead",
+              }}
+            end
+            package.loaded["project_pipelines.repo"].ticket_dependencies = function(ticket_id)
+              phase = phase + 1
+              local status = phase == 1 and "closed" or "open"
+              return {{
+                {{
+                  id = "dependency-kit",
+                  ticket_id = ticket_id,
+                  depends_on_ticket_id = "ticket-kit",
+                  depends_on_title = "Kit blocker",
+                  depends_on_status = status,
+                }},
+              }}
+            end
+            local retry_hostile = engine.retry_step_agent({{
+              run_id = "run-live",
+              reason = "hostile phase flip during retry",
+            }}, {{}})
+            assert(retry_hostile.ok == false)
+            assert(retry_hostile.reason == "ticket_dependencies")
+            assert(retry_hostile.unmet_dependencies[1].depends_on_ticket_id == "ticket-kit")
+            assert(create_agent_calls == 0)
+            assert(run.status == "blocked")
+            assert(visit_status == "blocked")
+            local saw_retry_event = false
+            for _, event in ipairs(events) do
+              if event.kind == "step.agent_retry_requested" then saw_retry_event = true end
+              if event.kind == "step.agent_requested" then
+                error("must not request agent on dependency-blocked retry")
+              end
+            end
+            assert(saw_retry_event == false)
             return "ok"
             "#,
             plugin_dir = plugin_dir.display()
@@ -4112,6 +4212,9 @@ fn catalog_plugin_project_pipelines_step_advance_can_override_to_specific_step()
             }}
 
             package.loaded["project_pipelines.entities"] = {{ register = function() end, publish_snapshots = function() end }}
+            package.loaded["project_pipelines.notification_policy"] = {{
+              notify_phase_transition = function() end,
+            }}
             package.loaded["project_pipelines.repo"] = {{
               ticket_session_uuids = function() return {{}} end,
               get_run = function(run_id)
@@ -4154,6 +4257,7 @@ fn catalog_plugin_project_pipelines_step_advance_can_override_to_specific_step()
               end,
               latest_step_session = function() return nil end,
               ticket_dependencies = function() return {{}} end,
+              ticket_session_uuids = function() return {{}} end,
             }}
             package.loaded["lib.agent"] = {{ get = function() return nil end }}
             package.loaded["lib.hub"] = {{

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -3551,9 +3551,19 @@ fn catalog_plugin_project_pipelines_start_run_blocks_open_dependencies() {
                 return {{ id = id, title = "Child", target_id = "target-1" }}
               end,
               open_ticket_run = function() return nil end,
-              blocking_ticket_dependencies = function(ticket_id)
+              -- start_run uses the same unmet_ticket_dependencies authority as
+              -- activate/advance/retry/spawn (normalized ticket_dependencies rows).
+              ticket_dependencies = function(ticket_id)
                 assert(ticket_id == "ticket-child")
-                return {{ {{ ticket_id = "ticket-child", depends_on_ticket_id = "ticket-parent", depends_on_title = "Parent", depends_on_status = "open" }} }}
+                return {{
+                  {{
+                    id = "dependency-parent",
+                    ticket_id = "ticket-child",
+                    depends_on_ticket_id = "ticket-parent",
+                    depends_on_title = "Parent",
+                    depends_on_status = "open",
+                  }},
+                }}
               end,
               get_pipeline = function()
                 error("dependency gating must run before pipeline lookup")
@@ -3787,6 +3797,25 @@ fn catalog_plugin_project_pipelines_public_dependency_write_blocks_advance_befor
             assert(direct_command.ok == false and direct_command.target_step_id == "command")
             assert(mutation_calls == 0 and notification_calls == 0 and create_agent_calls == 0)
 
+            -- Mid-run dependency registration while past Plan: retry current agent also refuses.
+            reset_attempt("open")
+            local retry_blocked = handlers.project_pipelines_retry_step_agent({{
+              run_id = "run-child",
+              reason = "retry while open dependency",
+            }}, {{}}).result
+            assert(retry_blocked.ok == false)
+            assert(retry_blocked.reason == "ticket_dependencies")
+            assert(retry_blocked.source == "retry_step_agent")
+            assert(create_agent_calls == 0)
+            assert(run.current_step_id == "plan")
+            local saw_retry_block = false
+            for _, event in ipairs(events) do
+              if event.kind == "step.advance_blocked" and event.attrs.payload.source == "retry_step_agent" then
+                saw_retry_block = true
+              end
+            end
+            assert(saw_retry_block == true)
+
             reset_attempt("closed")
             local advanced = handlers.project_pipelines_request_step_advance({{ run_id = "run-child" }}, {{}}).result
             assert(advanced.ok == true)
@@ -3807,6 +3836,203 @@ fn catalog_plugin_project_pipelines_public_dependency_write_blocks_advance_befor
         ))
         .eval()
         .expect("public ticket dependency rows should gate production advance and direct activation paths");
+
+    assert_eq!(result, "ok");
+}
+
+// Rust guideline compliant 2024-12
+// Mid-run Plan Review → Implement sequence: open blocker refuses advance and spawn.
+#[test]
+fn catalog_plugin_project_pipelines_mid_run_dependency_blocks_plan_review_to_implement() {
+    let lua = Lua::new();
+    log::register(&lua).expect("register log");
+
+    let plugin_dir = project_root_dir().join("catalog/templates/plugins/project-pipelines");
+    let result: String = lua
+        .load(format!(
+            r#"
+            package.path = "{plugin_dir}/?.lua;{plugin_dir}/?/init.lua;" .. package.path
+
+            local dependency_status = "open"
+            local dependency_calls = 0
+            local create_agent_calls = 0
+            local events = {{}}
+            local visit_status = "active"
+            local run = {{
+              id = "run-live",
+              ticket_id = "ticket-consumer",
+              pipeline_id = "pipe-1",
+              target_id = "target-1",
+              status = "active",
+              current_step_id = "plan_review",
+              current_run_step_id = "visit-plan-review",
+            }}
+            local steps = {{
+              plan_review = {{
+                id = "plan_review",
+                pipeline_id = "pipe-1",
+                kind = "agent",
+                name = "Plan Review",
+                agent_name = "codex",
+              }},
+              implement = {{
+                id = "implement",
+                pipeline_id = "pipe-1",
+                kind = "agent",
+                name = "Implement",
+                agent_name = "codex",
+              }},
+            }}
+
+            package.loaded["project_pipelines.entities"] = {{ register = function() end, publish_snapshots = function() end }}
+            package.loaded["project_pipelines.notification_policy"] = {{
+              notify_phase_transition = function() end,
+            }}
+            package.loaded["project_pipelines.repo"] = {{
+              get_run = function(id) assert(id == "run-live"); return run end,
+              get_step = function(id) return steps[id] end,
+              get_ticket = function(id) return {{ id = id, title = id, target_id = "target-1" }} end,
+              step_gates = function() return {{}} end,
+              latest_review_for_run_step = function()
+                return {{ id = "review-1", verdict = "approved" }}
+              end,
+              next_step = function() return steps.implement end,
+              ticket_dependencies = function(ticket_id)
+                assert(ticket_id == "ticket-consumer")
+                dependency_calls = dependency_calls + 1
+                return {{
+                  {{
+                    id = "dependency-kit",
+                    ticket_id = ticket_id,
+                    depends_on_ticket_id = "ticket-kit",
+                    depends_on_title = "Kit blocker",
+                    depends_on_status = dependency_status,
+                  }},
+                }}
+              end,
+              append_event = function(kind, attrs)
+                events[#events + 1] = {{ kind = kind, attrs = attrs }}
+              end,
+              update_run_step_visit = function(id, attrs)
+                visit_status = attrs.status or visit_status
+                return {{ id = id, run_id = run.id, step_id = run.current_step_id, status = visit_status }}
+              end,
+              update_run_step = function() end,
+              create_run_step_visit = function(run_id, step_id, attrs)
+                run.current_step_id = step_id
+                run.current_run_step_id = "visit-implement"
+                return {{ id = "visit-implement", run_id = run_id, step_id = step_id, status = attrs.status, sequence = 2 }}
+              end,
+              update_run = function(id, attrs)
+                for key, value in pairs(attrs or {{}}) do run[key] = value end
+                return run
+              end,
+              get_run_step_visit = function(id)
+                return {{
+                  id = id,
+                  run_id = run.id,
+                  step_id = run.current_step_id,
+                  status = visit_status,
+                }}
+              end,
+              get_run_step = function(run_id, step_id)
+                return {{ id = "visit-" .. step_id, run_id = run_id, step_id = step_id, status = visit_status }}
+              end,
+              latest_step_session = function() return nil end,
+              list_pr_links = function() return {{}} end,
+              open_findings = function() return {{}} end,
+              ticket_session_uuids = function() return {{}} end,
+            }}
+            package.loaded["lib.agent"] = {{ get = function() return nil end }}
+            package.loaded["lib.hub"] = {{
+              get = function()
+                return {{
+                  create_agent = function(_, opts)
+                    create_agent_calls = create_agent_calls + 1
+                    return {{ status = "queued", request_id = opts.request_id }}
+                  end,
+                }}
+              end,
+            }}
+
+            local engine = require("project_pipelines.engine")
+
+            -- Live failure sequence: Plan Review complete, open kit dependency, advance Implement.
+            local blocked = engine.request_step_advance({{
+              run_id = "run-live",
+              summary = "Plan Review approved",
+            }}, {{}})
+            assert(blocked.ok == false)
+            assert(blocked.reason == "ticket_dependencies")
+            assert(blocked.target_step_id == "implement" or blocked.target_step.id == "implement")
+            assert(create_agent_calls == 0)
+            assert(run.current_step_id == "plan_review")
+            assert(visit_status == "active")
+            assert(events[1].kind == "step.advance_blocked")
+            assert(events[1].attrs.payload.reason == "ticket_dependencies")
+            assert(events[1].attrs.payload.unmet_dependencies[1].depends_on_ticket_id == "ticket-kit")
+
+            local retry_blocked = engine.retry_step_agent({{
+              run_id = "run-live",
+              reason = "retry while kit open",
+            }}, {{}})
+            assert(retry_blocked.ok == false)
+            assert(retry_blocked.reason == "ticket_dependencies")
+            assert(create_agent_calls == 0)
+
+            dependency_status = "closed"
+            events = {{}}
+            local advanced = engine.request_step_advance({{
+              run_id = "run-live",
+              summary = "dependency closed; advance",
+            }}, {{}})
+            assert(advanced.ok == true)
+            assert(run.current_step_id == "implement")
+            assert(create_agent_calls == 1)
+
+            -- Last-line spawn defense: dependency reopens after activation preflight cleared.
+            dependency_status = "open"
+            dependency_calls = 0
+            create_agent_calls = 0
+            events = {{}}
+            run.current_step_id = "plan_review"
+            run.current_run_step_id = "visit-plan-review"
+            visit_status = "active"
+            local call_count_before_spawn = 0
+            local original_ticket_deps
+            -- activate_step checks once; spawn_step_agent checks again (last-line).
+            -- Simulate TOCTOU by flipping open after the first check returns closed.
+            local phase = 0
+            package.loaded["project_pipelines.repo"].ticket_dependencies = function(ticket_id)
+              phase = phase + 1
+              local status = phase == 1 and "closed" or "open"
+              return {{
+                {{
+                  id = "dependency-kit",
+                  ticket_id = ticket_id,
+                  depends_on_ticket_id = "ticket-kit",
+                  depends_on_title = "Kit blocker",
+                  depends_on_status = status,
+                }},
+              }}
+            end
+            -- Force package.loaded engine to re-read is not needed; repo table is shared.
+            local toctou = engine.activate_step(run, steps.implement)
+            assert(toctou.ok == false)
+            assert(create_agent_calls == 0)
+            local saw_spawn_block = false
+            for _, event in ipairs(events) do
+              if event.kind == "step.advance_blocked" and event.attrs.payload.source == "spawn_step_agent" then
+                saw_spawn_block = true
+              end
+            end
+            assert(saw_spawn_block == true)
+            return "ok"
+            "#,
+            plugin_dir = plugin_dir.display()
+        ))
+        .eval()
+        .expect("mid-run open dependencies must block Plan Review→Implement advance and last-line spawn");
 
     assert_eq!(result, "ok");
 }

--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -3544,6 +3544,11 @@ fn catalog_plugin_project_pipelines_start_run_blocks_open_dependencies() {
             package.loaded["project_pipelines.notification_policy"] = {{}}
             package.loaded["lib.agent"] = {{ get = function() return nil end }}
             package.loaded["lib.hub"] = {{ get = function() return {{}} end }}
+            local handlers = {{}}
+            mcp = {{
+              tool = function(name, _spec, handler) handlers[name] = handler end,
+              prompt = function() end,
+            }}
             package.loaded["project_pipelines.repo"] = {{
               prune_legacy_seed_data = function() end,
               get_ticket = function(id)
@@ -3568,16 +3573,34 @@ fn catalog_plugin_project_pipelines_start_run_blocks_open_dependencies() {
               get_pipeline = function()
                 error("dependency gating must run before pipeline lookup")
               end,
+              create_run = function()
+                error("start_run must not create a run while dependencies are open")
+              end,
             }}
+            package.loaded["lib.config_resolver"] = {{ list_agents = function() return {{}} end }}
 
-            local ok, err = pcall(require("project_pipelines.engine").start_run, {{
+            local engine_result = require("project_pipelines.engine").start_run({{
               ticket_id = "ticket-child",
               pipeline_id = "pipe-1",
               base_ref = "main",
             }})
+            assert(engine_result.ok == false)
+            assert(engine_result.status == "blocked")
+            assert(engine_result.reason == "ticket_dependencies")
+            assert(engine_result.source == "start_run")
+            assert(engine_result.unmet_dependencies[1].depends_on_ticket_id == "ticket-parent")
+            assert(engine_result.unmet_dependencies[1].depends_on_title == "Parent")
+            assert(engine_result.unmet_dependencies[1].reason == "open_ticket")
 
-            assert(ok == false)
-            assert(tostring(err):find("ticket dependencies must close before starting a run: Parent (open)", 1, true))
+            require("project_pipelines.mcp").register()
+            local mcp_result = handlers.project_pipelines_start_run({{
+              ticket_id = "ticket-child",
+              pipeline_id = "pipe-1",
+              base_ref = "main",
+            }}, {{}}).result
+            assert(mcp_result.ok == false)
+            assert(mcp_result.reason == "ticket_dependencies")
+            assert(mcp_result.unmet_dependencies[1].depends_on_ticket_id == "ticket-parent")
             return "ok"
             "#,
             plugin_dir = plugin_dir.display()
@@ -3990,18 +4013,25 @@ fn catalog_plugin_project_pipelines_mid_run_dependency_blocks_plan_review_to_imp
             assert(run.current_step_id == "implement")
             assert(create_agent_calls == 1)
 
-            -- Last-line spawn defense: dependency reopens after activation preflight cleared.
+            -- Pre-side-effect recheck: first activate preflight closed, second open.
+            -- Must not create a target visit, move run pointers, emit step.activated,
+            -- notify, or queue create_agent.
             dependency_status = "open"
-            dependency_calls = 0
             create_agent_calls = 0
             events = {{}}
             run.current_step_id = "plan_review"
             run.current_run_step_id = "visit-plan-review"
             visit_status = "active"
-            local call_count_before_spawn = 0
-            local original_ticket_deps
-            -- activate_step checks once; spawn_step_agent checks again (last-line).
-            -- Simulate TOCTOU by flipping open after the first check returns closed.
+            local created_visits = 0
+            local notification_calls = 0
+            package.loaded["project_pipelines.notification_policy"].notify_phase_transition = function()
+              notification_calls = notification_calls + 1
+            end
+            local original_create = package.loaded["project_pipelines.repo"].create_run_step_visit
+            package.loaded["project_pipelines.repo"].create_run_step_visit = function(...)
+              created_visits = created_visits + 1
+              return original_create(...)
+            end
             local phase = 0
             package.loaded["project_pipelines.repo"].ticket_dependencies = function(ticket_id)
               phase = phase + 1
@@ -4016,17 +4046,27 @@ fn catalog_plugin_project_pipelines_mid_run_dependency_blocks_plan_review_to_imp
                 }},
               }}
             end
-            -- Force package.loaded engine to re-read is not needed; repo table is shared.
             local toctou = engine.activate_step(run, steps.implement)
             assert(toctou.ok == false)
+            assert(toctou.reason == "ticket_dependencies")
+            assert(toctou.unmet_dependencies[1].depends_on_ticket_id == "ticket-kit")
             assert(create_agent_calls == 0)
-            local saw_spawn_block = false
+            assert(created_visits == 0)
+            assert(notification_calls == 0)
+            assert(run.current_step_id == "plan_review")
+            assert(run.current_run_step_id == "visit-plan-review")
+            local saw_activated = false
+            local saw_block = false
             for _, event in ipairs(events) do
-              if event.kind == "step.advance_blocked" and event.attrs.payload.source == "spawn_step_agent" then
-                saw_spawn_block = true
+              if event.kind == "step.activated" then saw_activated = true end
+              if event.kind == "step.advance_blocked" then
+                saw_block = true
+                assert(event.attrs.payload.reason == "ticket_dependencies")
+                assert(event.attrs.payload.unmet_dependencies[1].depends_on_ticket_id == "ticket-kit")
               end
             end
-            assert(saw_spawn_block == true)
+            assert(saw_activated == false)
+            assert(saw_block == true)
             return "ok"
             "#,
             plugin_dir = plugin_dir.display()

--- a/docs/project-pipelines-step-activation-dependency-gate.md
+++ b/docs/project-pipelines-step-activation-dependency-gate.md
@@ -1,0 +1,348 @@
+# Plan: Enforce open blocking dependencies at step activation
+
+**Pass:** 2 (addresses Plan Review `review_1786403096_917632`)
+
+## Target
+
+| Field | Value |
+| --- | --- |
+| `target_id` | `tgt_83619444571645afa5507374e36036e2` |
+| `target_repository` | `Tonksthebear/trybotster` |
+| `target_path` | monorepo catalog: `catalog/templates/plugins/project-pipelines/` |
+| Dogfood install path | `~/.botster-dev/plugins/project-pipelines/` |
+| Runtime teardown class | Does not apply |
+
+## Repository playbook loaded
+
+- [[project-pipelines-playbook]] — ownership charter for Project Pipelines engine, schema, MCP, surfaces, and gates
+
+## Other role/surface playbooks and atomic notes loaded
+
+### Role overlays
+
+- [[planner-playbook]]
+- [[botster-planner-playbook]]
+
+### Required Botster context maps (from botster-planner-playbook)
+
+- [[botster-architecture]] — domain map; confirms Project Pipelines is a first-party plugin ownership charter and that workflow policy stays in plugins/templates, not core. **Convention conflict: none.**
+- [[cli-patterns]] — Rust CLI / Lua plugin runtime patterns; confirms plugin worker + MCP tools are the production path for engine policy. **Convention conflict: none.**
+
+### Product / architecture notes
+
+- [[project pipeline orchestration belongs in a device-level botster plugin]]
+- [[project pipelines needs an operator workbench not more primitives]]
+- [[project pipelines ui contract belongs in the plugin readme]]
+- [[plugin mcp descriptors are the downstream agent contract]]
+- [[plan steps need reviewable plan artifacts]]
+- [[plan review must verify a plan artifact exists before trusting gate summaries]]
+- [[pipeline vault checklists must cite exact resolvable note titles]]
+- [[plan agents must author vault context as wikilinks not home paths]]
+- [[vault example paths are not repository placement conventions]]
+
+### Dependency-gating notes (evidence discipline)
+
+- [[project pipeline step activation gates open ticket dependencies before side effects]] — **superseded**; do not treat as shipped
+- [[vault convention notes can document unimplemented behavior as shipped]] — why the superseded note exists
+- [[cleared project pipeline dependencies require explicit reactivation without duplicate spawn requests]] — superseded sibling
+
+### Explicitly not loaded
+
+- [[botster-web-playbook]] — ticket is monorepo catalog plugin policy, not Ionic client shell
+- [[botster runtime teardown lenses]] — not WebRTC / SessionIo / peer lifecycle
+- Repository crates (`botster-core`, `botster-hub`, TUI, kit, workspaces) — out of ownership for this ticket
+- `Projects/botster-project-pipelines` package — ticket forbids treating it as dogfood source of truth
+
+## Plan artifact placement (repository evidence)
+
+Pass 1 used `docs/plans/...`. Refreshed `origin/main` has **no** tracked `docs/plans/` directory.
+
+Repository prior art for Project Pipelines durable docs on main:
+
+- `docs/project-pipelines-verification.md` (tracked under `docs/`)
+- other tracked docs live directly under `docs/` or `docs/<area>/`, not `docs/plans/`
+
+Per [[vault example paths are not repository placement conventions]] and [[plan steps need reviewable plan artifacts]], this pass relocates the plan to:
+
+**`docs/project-pipelines-step-activation-dependency-gate.md`**
+
+This matches mainline placement for Project Pipelines documentation. Pass 1 path `docs/plans/...` is retired for this ticket.
+
+## Context loaded
+
+### Ticket intent
+
+REGRESSION / INCOMPLETE FIX relative to closed `ticket_1785989402_277498`.
+
+- `start_run` already refuses open blockers.
+- Live evidence shows **step activation inside an already-running run still activated an agent** while a blocking dependency stayed open.
+- Fix must live in monorepo built-in plugin:
+  - `catalog/templates/plugins/project-pipelines/`
+  - install/sync to `~/.botster-dev/plugins/project-pipelines/` after change
+- Do **not** paper over with playbook-only instructions.
+
+### Live regression evidence (plugin.db, dogfood)
+
+Observed on `ticket_1785970234_132113` / `run_1786070915_943794`:
+
+| Time | Fact |
+| --- | --- |
+| `1786072005` | `dependency_1786072005_676257` added: consumer → open kit ticket `ticket_1786071998_949850` |
+| `1786072144` | Plan completed; Plan Review activated while kit dependency open |
+| `1786072495` | `step.advance_blocked` for **unmet review_clear findings**, not ticket dependencies |
+| `1786072603` | Plan Review completed; **Implement activated**; agent queued |
+| `1786072603` | `step.completed` evidence itself named the still-open dependency |
+| `1786072613` | Implement agent linked |
+| `1786072691` | Run cancelled by orchestrator because engine wrongly activated Implement |
+| `1786074662` | Kit dependency ticket closed (after the failure) |
+
+Conclusion: the operator-visible failure is real. Relying on `start_run` alone is insufficient once a run is active and dependencies are registered mid-flight.
+
+### Current monorepo code (this worktree / mainline catalog)
+
+`project_pipelines/engine.lua` already contains:
+
+- `unmet_ticket_dependencies(ticket_id)` over `repo.ticket_dependencies`
+- `dependency_block(run, attrs)` → `ok=false`, `reason=ticket_dependencies`, `unmet_dependencies`, `step.advance_blocked`
+- Call sites:
+  - `M.activate_step` before visit creation / notify / spawn
+  - `M.request_step_advance` before completing source visit (when `next_step` exists)
+  - `M.retry_step_agent` before requeue/spawn
+- `M.start_run` still uses `repo.blocking_ticket_dependencies` and raises before create
+
+Unit coverage already exists in `cli/tests/project_pipelines_plugin_test.rs`:
+
+- `catalog_plugin_project_pipelines_start_run_blocks_open_dependencies`
+- `catalog_plugin_project_pipelines_public_dependency_write_blocks_advance_before_side_effects`
+- retry-path coverage inside `catalog_plugin_project_pipelines_retry_step_agent_requeues_current_visit`
+
+Plugin README already documents the intended activation preflight contract. `init.lua` clears `package.loaded` for plugin modules on load.
+
+### Tension to resolve in Implement
+
+Catalog claims and unit tests assert fail-closed activation. Live dogfood on 2026-08-07 still activated Implement with an open dependency.
+
+Likely residual causes to investigate in order:
+
+1. **Stale dogfood install** — catalog had PR #200 (`07e3230a`) while `~/.botster-dev/plugins/project-pipelines` lagged or was not reloaded for the worker that advanced the run.
+2. **Residual production-path gap** — a path still mutates run/step or spawns without going through `dependency_block` (must be proven absent, not assumed).
+3. **Source-complete / activation TOCTOU** — `request_step_advance` checks deps, then completes the source visit, then calls `activate_step` again; if the second check fails (or is skipped), the source is already `done` and the response can still look like a successful advance (`ok=true` with nested blocked activation).
+4. **Evidence-only fail-open** — unit tests mock `ticket_dependencies`; they do not prove live SQLite join rows + MCP tool path + agent queue refusal against the **same bytes the Hub loaded**.
+
+Implement must treat (1)–(4) as open until closed with proof. Do not close this ticket as “already fixed on main” without identity-pinned live dogfood proof after install/sync and reload.
+
+### Plan Review findings addressed in this pass
+
+| Finding | Class | Disposition |
+| --- | --- | --- |
+| `finding_1786403096_315985` Live proof does not pin loaded Hub and plugin artifact | product / high | Acceptance now requires source commit, Hub identity, catalog↔installed digests, reload/restart evidence, and public MCP advance/retry event+session proof with no target agent request while open |
+| `finding_1786403096_191349` Missing botster-architecture and cli-patterns | process / low | Recorded above; no convention conflict |
+| `finding_1786403096_940640` docs/plans has no mainline placement | process / low | Relocated to `docs/project-pipelines-step-activation-dependency-gate.md` with mainline prior art |
+
+## Scope
+
+### In scope
+
+1. Audit every production entry that can activate an agent step or spawn/link an agent:
+   - `start_run`
+   - `request_step_advance` (including forced `next_step_id` / `override_unmet_gates`)
+   - `activate_step` (including PR review reactivation)
+   - `retry_step_agent`
+   - command-gate auto-advance (`handle_command_gate_completed` → `request_step_advance`)
+   - MCP wrappers and web actions that call those entry points
+2. Keep one shared fail-closed helper for open ticket dependencies (prefer one authority: either `blocking_ticket_dependencies` SQL or `unmet_ticket_dependencies`, not divergent filters).
+3. Guarantee:
+   - no `step.activated` for a target step while open blockers exist
+   - no `create_agent` / agent queue / `step.agent_requested` for that target
+   - typed response: `ok=false`, `status=blocked`, `reason=ticket_dependencies`, `unmet_dependencies` naming dependency ticket ids
+   - `step.advance_blocked` event with source/current/target ids
+4. Close residual gaps found by audit (examples if still present):
+   - `request_step_advance` must not complete the source visit when target activation is dependency-blocked
+   - `request_step_advance` must not return top-level `ok=true` when activation is dependency-blocked
+   - last-line defense: refuse spawn inside `spawn_step_agent` if open blockers exist (belt-and-suspenders, still keep primary gate at activation preflight)
+5. Expand tests to cover the **live failure sequence**, not only pure unit mocks:
+   - mid-run `add_ticket_dependency` while run is past Plan
+   - clear review/findings gates
+   - advance to Implement refuses
+   - retry refuses
+   - close dependency, then advance/retry succeeds
+   - `start_run` still refuses
+6. After code change: install/sync catalog → dogfood plugin path, **reload or restart so the running Hub loads those bytes**, then prove on the live public MCP path with identity pins (see Acceptance).
+7. Update plugin README only if the runtime contract changes (keep docs equal to code).
+8. After verified ship: vault capture to replace the superseded activation-gating convention with repository-backed current behavior.
+
+### Non-scope
+
+- Playbook-only “agents must check dependencies” instructions without engine enforcement
+- Changes to `Projects/botster-project-pipelines` package as dogfood SoT
+- Rails / SPA / botster-web client work
+- Hub/core spawn primitives (plugin remains policy owner)
+- Auto-activation when a dependency closes (explicit advance/retry remains required)
+- Plan-loop hygiene / `.gitignore` restore / colon worktree cargo fixes (already merged; do not re-litigate)
+- Sibling tickets (`ticket_1786071999_889350` worktree `:`, `ticket_1786072719_543972` resolve_finding)
+- Broad pipeline redesign, new primitives, optional configurability, step-level dependency opt-outs
+
+## Repository ownership boundaries and cross-repo dependencies
+
+| Surface | Owner |
+| --- | --- |
+| Workflow policy: dependency preflight, advance/retry/activate refusal, events, MCP shapes | Project Pipelines monorepo catalog plugin |
+| Agent spawn / worktree / session primitives | Hub / core (consumed, not modified) |
+| Dogfood runtime install + reload | Operator/plugin install under dogfood plugins path; Hub loads plugin modules |
+| Repository engineering conventions for other crates | Out of scope |
+
+Cross-repo dependencies for **this** ticket: none.
+
+Do not register Hub/TUI/kit work as part of this run. Prior incomplete package ticket is historical context only.
+
+## Assumptions and unknowns
+
+### Assumptions
+
+1. Ticket-ordering dependencies in `ticket_dependencies` are the authoritative “blocking dependencies” for this gate (not findings, not questions).
+2. “Open” means referenced ticket `status ~= "closed"` (and missing/unavailable tickets fail closed).
+3. Final advance with no `next_step` (run completion / merge) is intentionally not a dependency activation gate; README already states this.
+4. Closing or removing a dependency never auto-starts work; operator must advance or retry again.
+5. Monorepo catalog is the only source of truth for dogfood Project Pipelines after install/sync **and** Hub reload of those modules.
+
+### Unknowns Implement must resolve with evidence
+
+1. Why live run_1786070915 activated Implement despite monorepo PR #200 — stale install vs residual code path.
+2. Whether any non-engine caller can create visits or queue agents without `activate_step` / `retry_step_agent`.
+3. Whether real SQLite row shapes from `repo.ticket_dependencies` ever omit or mis-alias `depends_on_status` under the live plugin worker.
+4. Exact operator step required for the running Hub to load new catalog bytes (plugin hot-reload vs hub restart). Document the step that was used in live proof.
+
+## Affected surfaces / files
+
+Primary:
+
+- `catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua`
+- `cli/tests/project_pipelines_plugin_test.rs`
+- `catalog/templates/plugins/project-pipelines/README.md` (only if contract text must match a real change)
+- Dogfood mirror: `~/.botster-dev/plugins/project-pipelines/**` (install/sync, not a second source tree)
+
+Secondary (touch only if audit finds a gap):
+
+- `catalog/templates/plugins/project-pipelines/project_pipelines/mcp.lua` (error shape / descriptors)
+- `catalog/templates/plugins/project-pipelines/project_pipelines/repo.lua` (shared query helper if unified)
+- `catalog/templates/plugins/project-pipelines/project_pipelines/web/actions.lua` (only if a UI path bypasses engine)
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Declare “already fixed” because unit tests pass while dogfood still fails | Require identity-pinned live MCP proof after install/sync + reload |
+| Live proof tests a different binary/plugin than the reviewed catalog | Pin source commit, Hub identity, catalog↔installed digests, reload evidence before MCP calls count |
+| Complete source visit then fail target activation (stranded done visit) | Dependency preflight before any source completion; do not return top-level success on blocked activation |
+| Double filters (`blocking_ticket_dependencies` vs Lua re-filter) diverge | One shared helper |
+| Spawn path bypasses activation preflight | Last-line refuse in spawn path + audit all callers |
+| Docs claim shipped behavior without runtime proof | README updates only with matching tests + live proof; vault convention only after merge evidence |
+| Broad refactor while fixing a preflight | Surgical changes only around dependency preflight and its proofs |
+
+## Acceptance checks / tests
+
+### Unit / catalog (required)
+
+From `cli` with colon-free `CARGO_TARGET_DIR` if needed:
+
+```bash
+cd cli
+./test.sh -- catalog_plugin_project_pipelines_start_run_blocks_open_dependencies
+./test.sh -- catalog_plugin_project_pipelines_public_dependency_write_blocks_advance_before_side_effects
+./test.sh -- catalog_plugin_project_pipelines_retry_step_agent_requeues_current_visit
+```
+
+Add or extend a fixture that reproduces the **mid-run dependency registration → clear gates → advance Implement** sequence and asserts:
+
+- `ok=false`, `reason=ticket_dependencies`
+- zero `create_agent` calls
+- zero source visit mutations to `done`
+- `step.advance_blocked` event present
+- after closing dependency, advance succeeds and spawn is allowed
+
+### Production-path proof (required; identity-pinned)
+
+Live MCP results **do not count** until Implement records all of the following in gate evidence for the same proof session.
+
+#### A. Source and install identity (before MCP calls)
+
+Record exact values:
+
+1. **Refreshed base and source commit**
+   - `git rev-parse HEAD` on the implement worktree
+   - `git rev-parse origin/main` after `git fetch origin main`
+   - Confirm the reviewed catalog files under test are those commits’ content (or the PR branch commit under review)
+2. **Running Hub identity**
+   - `hub_id` (from `botster context` / hub manifest)
+   - Hub process identity available on this device (at least: `pid` from hub manifest, `socket_path`, and `botster --version`)
+   - If a stronger build/revision field exists on the running hub, record it too
+3. **Catalog ↔ installed digest equality** for every file that carries the gate (minimum `engine.lua`; include `mcp.lua` / `repo.lua` if touched):
+   ```bash
+   shasum -a 256 \
+     catalog/templates/plugins/project-pipelines/project_pipelines/engine.lua \
+     "$HOME/.botster-dev/plugins/project-pipelines/project_pipelines/engine.lua"
+   ```
+   Digests must match. Mismatch means live proof is invalid for the reviewed change.
+4. **Reload / restart evidence** after install/sync and **before** the MCP proof calls:
+   - State the exact operator action used (plugin hot-reload, hub restart, or documented install path that reloads modules)
+   - Record time and any log/event that shows the plugin modules reloaded
+   - Without this, digest match alone does not prove the **running worker** loaded those bytes
+
+#### B. Behavioral checks on public MCP tools (after A)
+
+Use public Project Pipelines MCP tools (not private engine requires):
+
+1. `project_pipelines_start_run` with an open blocker still refuses (typed error naming dependency ticket ids).
+2. On an active run past Plan, with an open blocker registered mid-flight:
+   - `project_pipelines_request_step_advance` into an agent step refuses with `reason=ticket_dependencies`
+   - `project_pipelines_retry_step_agent` refuses with `reason=ticket_dependencies`
+   - **No target agent request**: no `step.agent_requested` / queued spawn / new agent session for the target step while the dependency is open
+   - Record event ids and any session list evidence that proves absence of a new target agent
+3. Close or remove the blocker; explicit advance/retry then succeeds; then a target agent may be requested.
+4. Cite MCP response bodies + event ids + (when spawn is refused) absence of target session linkage.
+
+#### C. Explicit non-proofs
+
+- README prose without runtime events
+- Unit mocks without live install/sync + identity pins
+- Live MCP responses without matching digests / Hub identity / reload evidence
+- Playbook instructions to agents
+- Package-repo changes under `Projects/botster-project-pipelines`
+
+## Implementation sequence (smallest surgical path)
+
+1. Reproduce live sequence against current catalog engine with real-shaped repo fakes, then against installed dogfood plugin.
+2. Audit entry points; list every caller of spawn/activate/advance/retry.
+3. Close residual fail-open gaps (shared helper, no source-complete-before-target-ok, optional spawn-time assert).
+4. Expand tests for mid-run dependency registration.
+5. Install/sync monorepo catalog to dogfood plugin path; **reload or restart**; record identity pins (Acceptance A).
+6. Run unit suite + identity-pinned live MCP proof (Acceptance B); attach evidence.
+7. README only if contract wording must change.
+8. Vault inbox capture for a replacement current convention after verified ship.
+
+## Vault gaps worth capturing
+
+1. **Replacement current convention** for step-activation dependency preflight (the prior note remains superseded until new merge+live proof exists).
+2. **Dogfood install/sync + Hub reload is part of Project Pipelines delivery** — monorepo catalog changes are not live until installed **and** loaded by the running Hub/worker.
+3. **`start_run` gate ≠ active-run activation gate** — both must exist; proving one does not prove the other.
+4. **Live proof without artifact identity is not live proof** — Hub id, digests, and reload evidence are required so the proof cannot silently test a different plugin.
+5. Optional: **source-complete before target activation is a fail-open footgun** if the second preflight can disagree with the first.
+
+## Product decision ledger
+
+| Item | Decision |
+| --- | --- |
+| Default | Fail closed on any open/unavailable ticket dependency before agent-step side effects |
+| Non-goals | Auto-resume on dependency close; step-level opt-out; package-repo dogfood SoT |
+| Follow-up ok | Operator workbench UI polish for blocked-on-dependency state (if not already clear) |
+| Ask-human threshold | Only if audit discovers the gate must move into Hub/core primitives rather than plugin policy |
+
+## Plan Review focus (pass 2)
+
+1. Confirm target routing: trybotster monorepo catalog, not package repo, not botster-web.
+2. Confirm acceptance A+B close `finding_1786403096_315985` (identity-pinned live proof).
+3. Confirm botster-architecture + cli-patterns are recorded with no conflict.
+4. Confirm plan placement under tracked `docs/` with mainline prior art.
+5. Require Implement to prove live dogfood path with digests and Hub identity, not only unit tests that already existed before the Aug 7 failure.
+6. Ensure no silent broadening into package repo or unrelated hygiene tickets.
+)


### PR DESCRIPTION
## Summary

- Enforce open blocking ticket dependencies at each agent-step activation path.
- Apply one shared dependency check to `start_run`, activate, advance, retry, requeue, and spawn.
- Return a typed blocked result with each open dependency ticket ID.
- Prevent source completion, target activation, notification, retry mutation, and agent queue side effects when blocked.
- Document the production contract and the final advance exception.

## Ticket

`ticket_1786072718_293091` — Project Pipelines: enforce open blocking dependencies at step activation, not only at start_run

## Runtime path

The Project Pipelines engine owns the policy in the monorepo catalog plugin.

The public MCP tools call these engine paths:

- `project_pipelines_start_run` → `M.start_run`
- `project_pipelines_request_step_advance` → `M.request_step_advance` → `M.activate_step`
- command-gate completion → `M.request_step_advance`
- `project_pipelines_retry_step_agent` → `M.retry_step_agent`
- agent creation → `spawn_step_agent`

The implementation removes the old start-only enforcement gap. It keeps a spawn check as a final defense.

## Acceptance evidence

Final head: `ff4d996ff4a4f5238597f0ccbeed5648fe84d881`

Base and merge base: `a5547e4efc6f7ee879e0ead6d57a4c7236a8309e` on `main`

The branch is zero commits behind `main`. The rebase had no conflicts.

The final engine SHA-256 is:

`4204ccbe08826c2f3b16dce4fec9146d5a0ee04c403fc86809f8fec7d542c935`

The verifier confirmed that the catalog engine equals the installed dogfood engine. The verifier also confirmed the plugin reload and public MCP proof.

The live proof showed these results:

- `start_run` returned `ok=false`, `reason=ticket_dependencies`, and the dependency ticket ID.
- Mid-run advance refused while the dependency was open.
- Retry refused while the dependency was open.
- No target agent request occurred while the dependency was open.
- Explicit advance succeeded after the dependency closed.

## Tests

These commands passed through the required `cli/test.sh` wrapper on the final head:

- `CARGO_TARGET_DIR=/tmp/botster-pp-dep-gate-target ./test.sh -- start_run_blocks_open`
- `CARGO_TARGET_DIR=/tmp/botster-pp-dep-gate-target ./test.sh -- public_dependency_write_blocks`
- `CARGO_TARGET_DIR=/tmp/botster-pp-dep-gate-target ./test.sh -- mid_run_dependency_blocks_plan_review`
- `CARGO_TARGET_DIR=/tmp/botster-pp-dep-gate-target ./test.sh -- retry_step_agent_requeues_current_visit`
- `CARGO_TARGET_DIR=/tmp/botster-pp-dep-gate-target ./test.sh -- step_advance_can_override`

`git diff --check origin/main...HEAD` passed.

## Review status

All six pipeline findings are resolved. Review and Verify approved the change.

The restack changed only mainline test baseline stubs outside the ticket assertions. The engine, README, and plan document remained byte-identical.

## Scope

The PR changes four files in the monorepo catalog, tests, and documentation. It does not change Hub primitives, botster-web, or the separate package repository.

## Remaining risk

A dependency can theoretically change after the final synchronous check. The plugin worker serializes the transition, and the accepted implementation performs the final check before durable mutation.