### PR TITLE
Fix remaining Project Pipelines plugin test baseline (db v11 + session fixtures)

### DIFF
--- a/cli/tests/project_pipelines_plugin_test.rs
+++ b/cli/tests/project_pipelines_plugin_test.rs
@@ -1371,6 +1371,7 @@ fn catalog_plugin_project_pipelines_falls_back_to_existing_implementer_when_no_m
               publish_snapshots = function() end,
             }}
             package.loaded["project_pipelines.repo"] = {{
+              ticket_session_uuids = function() return {{}} end,
               find_pr_link = function(attrs)
                 assert(attrs.provider == "github")
                 assert(attrs.repo == "owner/repo")
@@ -3197,6 +3198,7 @@ fn catalog_plugin_project_pipelines_start_run_queues_agent_and_links_later_by_re
             }}
 
             package.loaded["project_pipelines.repo"] = {{
+              ticket_session_uuids = function() return {{}} end,
               prune_legacy_seed_data = function() end,
               get_ticket = function(id)
                 assert(id == "ticket-1")
@@ -3353,6 +3355,7 @@ fn catalog_plugin_project_pipelines_start_run_threads_stacked_base_metadata() {
             }}
 
             package.loaded["project_pipelines.repo"] = {{
+              ticket_session_uuids = function() return {{}} end,
               prune_legacy_seed_data = function() end,
               get_ticket = function(id) return ticket end,
               open_ticket_run = function() return nil end,
@@ -3451,6 +3454,7 @@ fn catalog_plugin_project_pipelines_start_run_explicit_base_ref_does_not_stack_o
 
             package.loaded["project_pipelines.entities"] = {{ register = function() end, publish_snapshots = function() end }}
             package.loaded["project_pipelines.repo"] = {{
+              ticket_session_uuids = function() return {{}} end,
               prune_legacy_seed_data = function() end,
               get_ticket = function(id) return tickets[id] end,
               open_ticket_run = function() return nil end,
@@ -3843,6 +3847,7 @@ fn catalog_plugin_project_pipelines_step_advance_can_override_to_specific_step()
 
             package.loaded["project_pipelines.entities"] = {{ register = function() end, publish_snapshots = function() end }}
             package.loaded["project_pipelines.repo"] = {{
+              ticket_session_uuids = function() return {{}} end,
               get_run = function(run_id)
                 assert(run_id == "run-verify")
                 return run
@@ -4324,7 +4329,7 @@ fn catalog_plugin_project_pipelines_db_v10_migration_adds_nullable_pipeline_colu
             log = {{ warn = function() end }}
 
             require("project_pipelines.db")
-            assert(spec.version == 10)
+            assert(spec.version == 11)
             for _, column in ipairs({{ "version_label", "archived_at", "replacement_pipeline_id", "supersedes_pipeline_id" }}) do
               assert(spec.models.pipelines[column] ~= nil, "fresh model missing " .. column)
             end
@@ -4437,7 +4442,7 @@ fn catalog_plugin_project_pipelines_archive_schema_and_allowlists_are_wired() {
         std::fs::read_to_string(root.join("project_pipelines/entity_contract.lua"))
             .expect("read project pipelines entity contract");
 
-    assert!(db.contains("version = 10"));
+    assert!(db.contains("version = 11"));
     for column in [
         "version_label",
         "archived_at",


### PR DESCRIPTION
## Summary
- Assert plugin.db version 11 in schema/migration tests.
- Stub `ticket_session_uuids` on repo mocks for start_run / step_advance engine paths.

## Ticket
`ticket_1786404348_273557` — residual baseline after PR #209. Consumer: `ticket_1786072719_543972`.

## Test plan
- [x] `cargo test --test project_pipelines_plugin_test`
- [x] `cd cli && ./test.sh -- project_pipelines`